### PR TITLE
Add spherical analytical with long test framework

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: "Run linter"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Test SSH
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && ls"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && cd demos/analytical_comparisons && make spherical_cases gadopt_checkout=${{secrets.GADI_REPO_PATH}}"
 
 # make sure PETSc build is up to date
 # maybe build on jobfs, then tarball (like fem-on-colab)? could get around transient gdata issues

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -32,9 +32,16 @@ jobs:
           EOF
 
       - name: Run test cases
+        id: run_tests
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && make longtest gadopt_checkout=${{secrets.GADI_REPO_PATH}} gadopt_prefix_image=${{secrets.GADI_PREFIX_IMAGE}} project=${{secrets.GADI_PROJECT}}"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && make -j longtest gadopt_checkout=${{secrets.GADI_REPO_PATH}} gadopt_prefix_image=${{secrets.GADI_PREFIX_IMAGE}} project=${{secrets.GADI_PROJECT}}"
 
-# copy test results back
+      - name: Test results
+        if: ${{ success() }}
+        run: |
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && python3 -m pytest -m longtest"
 
-# check tests
+      - name: Get error output
+        if: ${{ failure() }}
+        run: |
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && make longtest_output"

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -1,0 +1,45 @@
+name: Run long regression tests
+
+on:
+  workflow_dispatch:
+
+concurrency: longtest_environment
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Sync repository to Gadi
+        uses: up9cloud/action-rsync@v1.4
+        env:
+          HOST: gadi.nci.org.au
+          TARGET: ${{secrets.GADI_REPO_PATH}}
+          KEY: ${{secrets.GADI_TESTING_KEY}}
+          USER: ${{secrets.GADI_USER}}
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "${{secrets.GADI_TESTING_KEY}}" > ~/.ssh/gadi.key
+          chmod 600 ~/.ssh/gadi.key
+          echo "${{secrets.GADI_HOST_KEY}}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          cat >>~/.ssh/config <<EOF
+          Host gadi
+            Hostname gadi.nci.org.au
+            User ${{secrets.GADI_USER}}
+            IdentityFile ~/.ssh/gadi.key
+          EOF
+
+      - name: Test SSH
+        run: |
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && ls"
+
+# make sure PETSc build is up to date
+# maybe build on jobfs, then tarball (like fem-on-colab)? could get around transient gdata issues
+
+# make sure Firedrake build is up to date
+
+# run tests (copy .dat files back to runner?)
+
+# check tests

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Sync repository to Gadi
         uses: up9cloud/action-rsync@v1.4
         env:

--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -31,15 +31,10 @@ jobs:
             IdentityFile ~/.ssh/gadi.key
           EOF
 
-      - name: Test SSH
+      - name: Run test cases
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && cd demos/analytical_comparisons && make spherical_cases gadopt_checkout=${{secrets.GADI_REPO_PATH}}"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && make longtest gadopt_checkout=${{secrets.GADI_REPO_PATH}} gadopt_prefix_image=${{secrets.GADI_PREFIX_IMAGE}} project=${{secrets.GADI_PROJECT}}"
 
-# make sure PETSc build is up to date
-# maybe build on jobfs, then tarball (like fem-on-colab)? could get around transient gdata issues
-
-# make sure Firedrake build is up to date
-
-# run tests (copy .dat files back to runner?)
+# copy test results back
 
 # check tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  check_commit:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_commit.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.push.after || github.event.pull_request.head.sha || github.event.workflow_dispatch.ref }}
+      - name: Check if message contains skip keyword
+        id: check_commit
+        run: |
+          message=$(git log -1 --pretty=format:'%B')
+          regex="\[skip tests\]"
+          if [[ "$message" =~ $regex ]]; then
+            echo skip=true >> "$GITHUB_OUTPUT"
+          fi
   build:
     name: Benchmark regression test
     runs-on: self-hosted
@@ -19,6 +35,9 @@ jobs:
       group: testing-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
+    needs: check_commit
+    if: ${{ needs.check_commit.outputs.skip != 'true' }}
+
     env:
       OMP_NUM_THREADS: 1
 
@@ -28,7 +47,7 @@ jobs:
           sudo apt update
           sudo apt install -y task-spooler time
           tsp -S 48
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load pyrol wheel from cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           make -j test
-          python -m pytest
+          python -m pytest -m 'not longtest'
         env:
           GADOPT_LOGLEVEL: INFO
           TS_MAXFINISHED: 100

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test
+.PHONY: lint test longtest
 
 lint:
 	@echo "Linting module code"
@@ -8,3 +8,6 @@ lint:
 
 test:
 	$(MAKE) -C demos
+
+longtest:
+	$(MAKE) -C demos longtest

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test:
 
 longtest:
 	$(MAKE) -C demos longtest
+
+longtest_output:
+	$(MAKE) -C demos longtest_output

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,11 +1,13 @@
 cases := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_case 2d_cylindrical analytical_comparisons Drucker-Prager_rheology 3d_spherical 3d_cartesian adjoint optimisation_checkpointing
 long_cases := analytical_comparisons
 
-.PHONY: all longtest $(cases) $(long_cases) clean generate
+.PHONY: all longtest longtest_output $(cases) $(long_cases) clean generate
 
 all: $(cases)
 
 longtest: $(long_cases)
+
+longtest_output: $(long_cases)
 
 # sort to remove duplicates which define both short and long tests
 $(sort $(cases) $(long_cases)):

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,10 +1,14 @@
 cases := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_case 2d_cylindrical analytical_comparisons Drucker-Prager_rheology 3d_spherical 3d_cartesian adjoint optimisation_checkpointing
+long_cases := analytical_comparisons
 
-.PHONY: all $(cases) clean generate
+.PHONY: all longtest $(cases) $(long_cases) clean generate
 
 all: $(cases)
 
-$(cases):
+longtest: $(long_cases)
+
+# sort to remove duplicates which define both short and long tests
+$(sort $(cases) $(long_cases)):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
 generate:

--- a/demos/adjoint/cases.py
+++ b/demos/adjoint/cases.py
@@ -1,0 +1,1 @@
+cases = ["damping", "smoothing", "Tobs", "uobs"]

--- a/demos/adjoint/taylor_test.py
+++ b/demos/adjoint/taylor_test.py
@@ -9,10 +9,10 @@ from mpi4py import MPI
 import numpy as np
 import sys
 
+from cases import cases
+
 ds_t = ds_t(degree=6)
 dx = dx(degree=6)
-
-cases = ["damping", "smoothing", "Tobs", "uobs"]
 
 
 def rectangle_taylor_test(case):

--- a/demos/adjoint/test_adjoint.py
+++ b/demos/adjoint/test_adjoint.py
@@ -1,9 +1,9 @@
 import pytest
 from pathlib import Path
-import taylor_test
+from cases import cases
 
 
-@pytest.mark.parametrize("case_name", taylor_test.cases)
+@pytest.mark.parametrize("case_name", cases)
 def test_rectangular_taylor_test(case_name):
     with open(Path(__file__).parent.resolve() / f"{case_name}.conv", "r") as f:
         minconv = float(f.read())

--- a/demos/adjoint_2d_cylindrical/cases.py
+++ b/demos/adjoint_2d_cylindrical/cases.py
@@ -1,0 +1,1 @@
+cases = ["damping", "smoothing", "Tobs", "uobs"]

--- a/demos/adjoint_2d_cylindrical/taylor_test.py
+++ b/demos/adjoint_2d_cylindrical/taylor_test.py
@@ -9,10 +9,10 @@ from mpi4py import MPI
 import numpy as np
 import sys
 
+from cases import cases
+
 ds_t = ds_t(degree=6)
 dx = dx(degree=6)
-
-cases = ["damping", "smoothing", "Tobs", "uobs"]
 
 newton_stokes_solver_parameters = {
     "snes_type": "newtonls",

--- a/demos/adjoint_2d_cylindrical/test_cylindrical_adjoint.py
+++ b/demos/adjoint_2d_cylindrical/test_cylindrical_adjoint.py
@@ -1,9 +1,9 @@
 import pytest
 from pathlib import Path
-import taylor_test
+from cases import cases
 
 
-@pytest.mark.parametrize("case_name", taylor_test.cases)
+@pytest.mark.parametrize("case_name", cases)
 @pytest.mark.skip(reason="currently untested")
 def test_annulus_taylor_test(case_name):
     with open(Path(__file__).parent.resolve() / f"{case_name}.conv", "r") as f:

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -1,7 +1,7 @@
 cases := smooth/cylindrical/free_slip smooth/cylindrical/zero_slip delta/cylindrical/free_slip delta/cylindrical/zero_slip delta/cylindrical/free_slip_dpc delta/cylindrical/zero_slip_dpc
 spherical_cases := smooth/spherical/free_slip smooth/spherical/zero_slip
 
-.PHONY: all longtest $(cases) $(spherical_cases) clean
+.PHONY: all longtest longtest_output $(cases) $(spherical_cases) clean
 
 all: $(cases)
 
@@ -13,14 +13,17 @@ $(cases): analytical.py
 
 .ONESHELL:
 SHELL = /bin/bash
-$(spherical_cases): analytical.py
+$(spherical_cases): analytical.py clean
 	exec {out}<> <(:) # create new named FD
 	qsub -W depend=on:$$(python3 analytical.py count $@) -N sentinel -W block=true -l ncpus=1,walltime=00:00:30,wd -q normal -P $(project) -- /bin/true >&"$$out" &
 	read -u "$$out" sjob
 	echo "running spherical $@, waiting on $$sjob" >&2
 	mkdir -p pbs_output
-	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_PREFIX_IMAGE=$(gadopt_prefix_image) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/l{level}_{params}.out -e pbs_output/l{level}_{params}.err -- ./run_gadi.sh" $@
+	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_PREFIX_IMAGE=$(gadopt_prefix_image) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/$(subst /,-,$@)_l{level}_{params}.out -e pbs_output/$(subst /,-,$@)_l{level}_{params}.err -- ./run_gadi.sh" $@
 	wait
 
 clean:
 	rm -rf pbs_output *.dat sentinel.*
+
+longtest_output:
+	[[ -d pbs_output ]] && tail -n +1 pbs_output/*

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -18,5 +18,5 @@ $(spherical_cases): analytical.py
 	qsub -W depend=on:$$(python3 analytical.py count $@) -N sentinel -W block=true -l ncpus=1,walltime=00:00:30,wd -q normal -P $(project) -- /bin/true >&"$$out" &
 	read -u "$$out" sjob
 	echo "running spherical $@, waiting on $$sjob" >&2
-	python3 analytical.py submit -t "qsub -v PATH,LD_LIBRARY_PATH,PYTHONPATH,PETSC_DIR,OMP_NUM_THREADS=1 -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output -e pbs_output -- mpiexec" $@
+	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/l{level}_{params}.out -e pbs_output/l{level}_{params}.err -- ./run_gadi.sh" $@
 	wait

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -1,15 +1,15 @@
 cases := smooth/cylindrical/free_slip smooth/cylindrical/zero_slip delta/cylindrical/free_slip delta/cylindrical/zero_slip delta/cylindrical/free_slip_dpc delta/cylindrical/zero_slip_dpc
 spherical_cases := smooth/spherical/free_slip smooth/spherical/zero_slip
 
-.PHONY: all $(cases) $(spherical_cases)
+.PHONY: all longtest $(cases) $(spherical_cases) clean
 
 all: $(cases)
+
+longtest: $(spherical_cases)
 
 $(cases): analytical.py
 	echo "running analytical $@" >&2
 	/usr/bin/time --format="analytical $@ finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $@
-
-project := xd2
 
 .ONESHELL:
 SHELL = /bin/bash
@@ -18,5 +18,9 @@ $(spherical_cases): analytical.py
 	qsub -W depend=on:$$(python3 analytical.py count $@) -N sentinel -W block=true -l ncpus=1,walltime=00:00:30,wd -q normal -P $(project) -- /bin/true >&"$$out" &
 	read -u "$$out" sjob
 	echo "running spherical $@, waiting on $$sjob" >&2
-	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/l{level}_{params}.out -e pbs_output/l{level}_{params}.err -- ./run_gadi.sh" $@
+	mkdir -p pbs_output
+	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_PREFIX_IMAGE=$(gadopt_prefix_image) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/l{level}_{params}.out -e pbs_output/l{level}_{params}.err -- ./run_gadi.sh" $@
 	wait
+
+clean:
+	rm -rf pbs_output *.dat sentinel.*

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -1,6 +1,7 @@
 cases := smooth/cylindrical/free_slip smooth/cylindrical/zero_slip delta/cylindrical/free_slip delta/cylindrical/zero_slip delta/cylindrical/free_slip_dpc delta/cylindrical/zero_slip_dpc
+spherical_cases := smooth/spherical/free_slip smooth/spherical/zero_slip
 
-.PHONY: all $(cases) smooth/spherical/free_slip
+.PHONY: all $(cases) $(spherical_cases)
 
 all: $(cases)
 
@@ -12,7 +13,7 @@ project := xd2
 
 .ONESHELL:
 SHELL = /bin/bash
-smooth/spherical/free_slip: analytical.py
+$(spherical_cases): analytical.py
 	exec {out}<> <(:) # create new named FD
 	qsub -W depend=on:$$(python3 analytical.py count $@) -N sentinel -W block=true -l ncpus=1,walltime=00:00:30,wd -q normal -P $(project) -- /bin/true >&"$$out" &
 	read -u "$$out" sjob

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -1,9 +1,21 @@
 cases := smooth/cylindrical/free_slip smooth/cylindrical/zero_slip delta/cylindrical/free_slip delta/cylindrical/zero_slip delta/cylindrical/free_slip_dpc delta/cylindrical/zero_slip_dpc
 
-.PHONY: all $(cases)
+.PHONY: all $(cases) smooth/spherical/free_slip
 
 all: $(cases)
 
 $(cases): analytical.py
 	echo "running analytical $@" >&2
 	/usr/bin/time --format="analytical $@ finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $@
+
+project := xd2
+
+.ONESHELL:
+SHELL = /bin/bash
+smooth/spherical/free_slip: analytical.py
+	exec {out}<> <(:) # create new named FD
+	qsub -W depend=on:$$(python3 analytical.py count $@) -N sentinel -W block=true -l ncpus=1,walltime=00:00:30,wd -q normal -P $(project) -- /bin/true >&"$$out" &
+	read -u "$$out" sjob
+	echo "running spherical $@, waiting on $$sjob" >&2
+	python3 analytical.py submit -t "qsub -v PATH,LD_LIBRARY_PATH,PYTHONPATH,PETSC_DIR,OMP_NUM_THREADS=1 -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output -e pbs_output -- mpiexec" $@
+	wait

--- a/demos/analytical_comparisons/analytical.py
+++ b/demos/analytical_comparisons/analytical.py
@@ -21,16 +21,18 @@ cases = {
         },
         "spherical": {
             "free_slip": {
-                "l": [2, 4, 8],
-                "k": [3, 5, 9],
-                "levels": [3, 4, 5, 6],
-                "layers": [8, 16, 32, 64],
+                "cores": [24, 48, 192],
+                "levels": [3, 4, 5],
+                "l": [2, 8],
+                "m": [2, 1],
+                "k": [3, 9],
             },
             "zero_slip": {
-                "l": [2, 4, 8],
-                "k": [3, 5, 9],
-                "levels": [3, 4, 5, 6],
-                "layers": [8, 16, 32, 64],
+                "cores": [24, 48, 192],
+                "levels": [3, 4, 5],
+                "l": [2, 8],
+                "m": [2, 1],
+                "k": [3, 9],
             },
         },
     },
@@ -84,6 +86,10 @@ def run_subcommand(args):
         from delta_cylindrical_freeslip_dpc import model
     elif args.case == "delta/cylindrical/zero_slip_dpc":
         from delta_cylindrical_zeroslip_dpc import model
+    elif args.case == "smooth/spherical/free_slip":
+        from smooth_spherical_freeslip import model
+    elif args.case == "smooth/spherical/zero_slip":
+        from smooth_spherical_zeroslip import model
     else:
         raise ValueError(f"unknown case {args.case}")
 

--- a/demos/analytical_comparisons/analytical.py
+++ b/demos/analytical_comparisons/analytical.py
@@ -73,6 +73,13 @@ def get_case(cases, config):
     return cases
 
 
+def param_sets(config, permutate=False):
+    if permutate:
+        return itertools.product(*config.values())
+
+    return zip(*config.values())
+
+
 def run_subcommand(args):
     from mpi4py import MPI
 
@@ -115,12 +122,7 @@ def submit_subcommand(args):
     permutate = config.pop("permutate", True)
 
     for level, cores in zip(config.pop("levels"), config.pop("cores")):
-        if permutate:
-            param_gen = itertools.product(*config.values())
-        else:
-            param_gen = zip(*config.values())
-
-        for params in param_gen:
+        for params in param_sets(config, permutate):
             paramstr = "-".join([str(v) for v in params])
             command = args.template.format(cores=cores, mem=4*cores, params=paramstr)
 
@@ -146,10 +148,7 @@ def count_subcommand(args):
     config = get_case(cases, args.case)
     permutate = config.pop("permutate", True)
     levels = zip(config.pop("levels"), config.pop("cores"))
-    if permutate:
-        params = itertools.product(*config.values())
-    else:
-        params = zip(*config.values())
+    params = param_sets(config, permutate)
 
     print(len(list(levels)) * len(list(params)))
 

--- a/demos/analytical_comparisons/analytical.py
+++ b/demos/analytical_comparisons/analytical.py
@@ -133,6 +133,18 @@ def submit_subcommand(args):
         sys.exit(1)
 
 
+def count_subcommand(args):
+    config = get_case(cases, args.case)
+    permutate = config.pop("permutate", True)
+    levels = zip(config.pop("levels"), config.pop("cores"))
+    if permutate:
+        params = itertools.product(*config.values())
+    else:
+        params = zip(*config.values())
+
+    print(len(list(levels)) * len(list(params)))
+
+
 # two modes, submit and run
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -149,6 +161,9 @@ if __name__ == "__main__":
     parser_submit.add_argument("-t", "--template", default="mpiexec -np {cores}", help="template command for running commands under MPI")
     parser_submit.add_argument("case")
     parser_submit.set_defaults(func=submit_subcommand)
+    parser_count = subparsers.add_parser("count", help="return the number of jobs to run for a specific case")
+    parser_count.add_argument("case")
+    parser_count.set_defaults(func=count_subcommand)
 
     args = parser.parse_args()
     args.func(args)

--- a/demos/analytical_comparisons/analytical.py
+++ b/demos/analytical_comparisons/analytical.py
@@ -124,7 +124,7 @@ def submit_subcommand(args):
     for level, cores in zip(config.pop("levels"), config.pop("cores")):
         for params in param_sets(config, permutate):
             paramstr = "-".join([str(v) for v in params])
-            command = args.template.format(cores=cores, mem=4*cores, params=paramstr)
+            command = args.template.format(cores=cores, mem=4*cores, params=paramstr, level=level)
 
             procs[paramstr] = subprocess.Popen(
                 [

--- a/demos/analytical_comparisons/run_gadi.sh
+++ b/demos/analytical_comparisons/run_gadi.sh
@@ -2,18 +2,19 @@
 
 module load python3/3.10.4 openmpi/4.0.7
 
-tar -C $PBS_JOBFS -xf /g/data/xd2/ahg157/firedrake-prefixes/firedrake-prefix-current.tar.gz
-
-cat > $PBS_JOBFS/firedrake-prefix/lib/python3.10/site-packages/petsc4py/lib/petsc.cfg <<EOF
-PETSC_DIR = $PBS_JOBFS/firedrake-prefix
-PETSC_ARCH =
-EOF
-
 export PETSC_DIR=$PBS_JOBFS/firedrake-prefix
 export OMP_NUM_THREADS=1
 export PYTHONUSERBASE=$PBS_JOBFS/firedrake-prefix
 export XDG_CACHE_HOME=$PBS_JOBFS/xdg
 
-python3 -m pip install --user --no-build-isolation $GADOPT_CHECKOUT
+mpiexec --map-by ppr:1:node --np $PBS_NNODES bash -c "tar -C $PBS_JOBFS -xf $GADOPT_PREFIX_IMAGE && \
+cat > $PBS_JOBFS/firedrake-prefix/lib/python3.10/site-packages/petsc4py/lib/petsc.cfg <<EOF && \
+cp -r $GADOPT_CHECKOUT $PBS_JOBFS && \
+python3 -m pip install --user --no-build-isolation $PBS_JOBFS/g-adopt
+PETSC_DIR = $PBS_JOBFS/firedrake-prefix
+PETSC_ARCH =
+EOF"
+
+export LD_LIBRARY_PATH=$PBS_JOBFS/firedrake-prefix/lib:$LD_LIBRARY_PATH
 
 mpiexec $@

--- a/demos/analytical_comparisons/run_gadi.sh
+++ b/demos/analytical_comparisons/run_gadi.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -i
+
+module load python3/3.10.4 openmpi/4.0.7
+
+tar -C $PBS_JOBFS -xf /g/data/xd2/ahg157/firedrake-prefixes/firedrake-prefix-current.tar.gz
+
+cat > $PBS_JOBFS/firedrake-prefix/lib/python3.10/site-packages/petsc4py/lib/petsc.cfg <<EOF
+PETSC_DIR = $PBS_JOBFS/firedrake-prefix
+PETSC_ARCH =
+EOF
+
+export PETSC_DIR=$PBS_JOBFS/firedrake-prefix
+export OMP_NUM_THREADS=1
+export PYTHONUSERBASE=$PBS_JOBFS/firedrake-prefix
+export XDG_CACHE_HOME=$PBS_JOBFS/xdg
+
+python3 -m pip install --user --no-build-isolation $GADOPT_CHECKOUT
+
+mpiexec $@

--- a/demos/analytical_comparisons/smooth_spherical_freeslip.py
+++ b/demos/analytical_comparisons/smooth_spherical_freeslip.py
@@ -1,0 +1,136 @@
+from gadopt import *
+import numpy
+import assess
+
+# Quadrature degree:
+_dx = dx(degree=6)
+
+# Projection solver parameters for nullspaces:
+_project_solver_parameters = {
+    "snes_type": "ksponly",
+    "ksp_type": "gmres",
+    "pc_type": "sor",
+    "mat_type": "aij",
+    "ksp_rtol": 1e-12,
+}
+
+
+def model(level, l, mm, k, do_write=False):
+    """The smooth initial condition, spherical domain, free-slip boundary condition model.
+
+    Args:
+        level: refinement level
+        l: spherical harmonic degree
+        mm: ratio of spherical harmonic degree to spherical harmonic order
+        k: radial component of forcing term
+        do_write: whether to output the velocity/pressure fields
+    """
+
+    rmin, rmax = 1.22, 2.22
+    m = l // mm
+
+    l = Constant(l)
+    m = Constant(m)
+    k = Constant(k)
+
+    nlayers = 2 ** level
+
+    # Construct a cubed sphere mesh and then extrude into a sphere:
+    mesh2d = CubedSphereMesh(radius=rmin, refinement_level=level, degree=2)
+    mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type="radial")
+    bottom_id, top_id = "bottom", "top"
+
+    # Define geometric quantities
+    X = SpatialCoordinate(mesh)
+
+    # Set up function spaces - currently using the P2P1 element pair :
+    V = VectorFunctionSpace(mesh, "CG", 2)  # velocity function space (vector)
+    Vscl = FunctionSpace(mesh, "CG", 2)  # scalar version of V, used for rho'
+    W = FunctionSpace(mesh, "CG", 1)  # pressure function space (scalar)
+    Wvec = VectorFunctionSpace(mesh, "CG", 1)  # vector version of W, used for coordinates in anal. pressure solution
+    Z = MixedFunctionSpace([V, W])
+    v, w = TestFunctions(Z)
+
+    # Set up fields on these function spaces - split into each component so that they are easily accessible:
+    z = Function(Z)  # a field over the mixed function space Z.
+    u, p = split(z)
+    u_, p_ = z.subfunctions
+
+    # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
+    mu = Constant(1.0)  # Constant viscosity
+
+    # RHS provided by assess solution: rho'=r**k Y_lm
+    solution = assess.SphericalStokesSolutionSmoothFreeSlip(float(l), float(m), float(k), nu=float(mu), Rp=rmax, Rm=rmin, g=1.0)
+    u_xyz = interpolate(X, V)
+    rhop = Function(Vscl)
+    rhop.dat.data[:] = [solution.delta_rho_cartesian(xyzi) for xyzi in u_xyz.dat.data]
+
+    T = -rhop  # RHS
+
+    approximation = BoussinesqApproximation(1)
+    stokes_bcs = {
+        bottom_id: {'un': 0},
+        top_id: {'un': 0},
+    }
+
+    # Nullspaces and near-nullspaces:
+    Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
+    Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
+
+    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
+                                 cartesian=False,
+                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
+                                 near_nullspace=Z_near_nullspace)
+    # use tighter tolerances than default to ensure convergence:
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9
+
+    # Solve system - configured for solving non-linear systems, where everything is on the LHS (as above)
+    # and the RHS == 0.
+    stokes_solver.solve()
+
+    # take out null modes through L2 projection from velocity and pressure
+    # removing rotation from velocity:
+    rot = as_vector((0, X[2], -X[1]))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+    rot = as_vector((-X[2], 0, X[0]))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+    rot = as_vector((-X[1], X[0], 0))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+
+    # removing constant nullspace from pressure
+    coef = assemble(p_ * _dx)/assemble(Constant(1.0)*_dx(domain=mesh))
+    p_.project(p_ - coef, solver_parameters=_project_solver_parameters)
+
+    # compute u analytical and error
+    uxzy = interpolate(as_vector((X[0], X[1], X[2])), V)
+    u_anal = Function(V, name="AnalyticalVelocity")
+    u_anal.dat.data[:] = [solution.velocity_cartesian(xyzi) for xyzi in uxzy.dat.data]
+    u_error = Function(V, name="VelocityError").assign(u_-u_anal)
+
+    # compute p analytical and error
+    pxyz = interpolate(as_vector((X[0], X[1], X[2])), Wvec)
+    p_anal = Function(W, name="AnalyticalPressure")
+    p_anal.dat.data[:] = [solution.pressure_cartesian(xyzi) for xyzi in pxyz.dat.data]
+    p_error = Function(W, name="PressureError").assign(p_-p_anal)
+
+    if do_write:
+        # Write output files in VTK format:
+        u_.rename("Velocity")
+        p_.rename("Pressure")
+        u_file = File("fs_velocity_{}.pvd".format(level))
+        p_file = File("fs_pressure_{}.pvd".format(level))
+
+        # Write output:
+        u_file.write(u_, u_anal, u_error)
+        p_file.write(p_, p_anal, p_error)
+
+    l2anal_u = numpy.sqrt(assemble(dot(u_anal, u_anal)*_dx))
+    l2anal_p = numpy.sqrt(assemble(dot(p_anal, p_anal)*_dx))
+    l2error_u = numpy.sqrt(assemble(dot(u_error, u_error)*_dx))
+    l2error_p = numpy.sqrt(assemble(dot(p_error, p_error)*_dx))
+
+    return l2error_u, l2error_p, l2anal_u, l2anal_p

--- a/demos/analytical_comparisons/smooth_spherical_zeroslip.py
+++ b/demos/analytical_comparisons/smooth_spherical_zeroslip.py
@@ -1,0 +1,136 @@
+from gadopt import *
+import numpy
+import assess
+
+# Quadrature degree:
+_dx = dx(degree=6)
+
+# Projection solver parameters for nullspaces:
+_project_solver_parameters = {
+    "snes_type": "ksponly",
+    "ksp_type": "gmres",
+    "pc_type": "sor",
+    "mat_type": "aij",
+    "ksp_rtol": 1e-12,
+}
+
+
+def model(level, l, mm, k, do_write=False):
+    """The smooth initial condition, spherical domain, zero-slip boundary condition model.
+
+    Args:
+        level: refinement level
+        l: spherical harmonic degree
+        mm: ratio of spherical harmonic degree to spherical harmonic order
+        k: radial component of forcing term
+        do_write: whether to output the velocity/pressure fields
+    """
+
+    rmin, rmax = 1.22, 2.22
+    m = l // mm
+
+    l = Constant(l)
+    m = Constant(m)
+    k = Constant(k)
+
+    nlayers = 2 ** level
+
+    # Construct a cubed sphere mesh and then extrude into a sphere:
+    mesh2d = CubedSphereMesh(radius=rmin, refinement_level=level, degree=2)
+    mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type="radial")
+    bottom_id, top_id = "bottom", "top"
+
+    # Define geometric quantities
+    X = SpatialCoordinate(mesh)
+
+    # Set up function spaces - currently using the P2P1 element pair :
+    V = VectorFunctionSpace(mesh, "CG", 2)  # velocity function space (vector)
+    Vscl = FunctionSpace(mesh, "CG", 2)  # scalar version of V, used for rho'
+    W = FunctionSpace(mesh, "CG", 1)  # pressure function space (scalar)
+    Wvec = VectorFunctionSpace(mesh, "CG", 1)  # vector version of W, used for coordinates in anal. pressure solution
+    Z = MixedFunctionSpace([V, W])
+    v, w = TestFunctions(Z)
+
+    # Set up fields on these function spaces - split into each component so that they are easily accessible:
+    z = Function(Z)  # a field over the mixed function space Z.
+    u, p = split(z)
+    u_, p_ = z.subfunctions
+
+    # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
+    mu = Constant(1.0)  # Constant viscosity
+
+    # RHS provided by assess solution: rho'=r**k Y_lm
+    solution = assess.SphericalStokesSolutionSmoothZeroSlip(float(l), float(m), float(k), nu=float(mu), Rp=rmax, Rm=rmin, g=1.0)
+    u_xyz = interpolate(X, V)
+    rhop = Function(Vscl)
+    rhop.dat.data[:] = [solution.delta_rho_cartesian(xyzi) for xyzi in u_xyz.dat.data]
+
+    T = -rhop  # RHS
+
+    approximation = BoussinesqApproximation(1)
+    stokes_bcs = {
+        bottom_id: {'u': 0},
+        top_id: {'u': 0},
+    }
+
+    # Nullspaces and near-nullspaces:
+    Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
+    Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
+
+    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
+                                 cartesian=False,
+                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
+                                 near_nullspace=Z_near_nullspace)
+    # use tighter tolerances than default to ensure convergence:
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9
+
+    # Solve system - configured for solving non-linear systems, where everything is on the LHS (as above)
+    # and the RHS == 0.
+    stokes_solver.solve()
+
+    # take out null modes through L2 projection from velocity and pressure
+    # removing rotation from velocity:
+    rot = as_vector((0, X[2], -X[1]))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+    rot = as_vector((-X[2], 0, X[0]))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+    rot = as_vector((-X[1], X[0], 0))
+    coef = assemble(dot(rot, u_)*_dx) / assemble(dot(rot, rot)*_dx)
+    u_.project(u_ - rot*coef, solver_parameters=_project_solver_parameters)
+
+    # removing constant nullspace from pressure
+    coef = assemble(p_ * _dx)/assemble(Constant(1.0)*_dx(domain=mesh))
+    p_.project(p_ - coef, solver_parameters=_project_solver_parameters)
+
+    # compute u analytical and error
+    uxzy = interpolate(as_vector((X[0], X[1], X[2])), V)
+    u_anal = Function(V, name="AnalyticalVelocity")
+    u_anal.dat.data[:] = [solution.velocity_cartesian(xyzi) for xyzi in uxzy.dat.data]
+    u_error = Function(V, name="VelocityError").assign(u_-u_anal)
+
+    # compute p analytical and error
+    pxyz = interpolate(as_vector((X[0], X[1], X[2])), Wvec)
+    p_anal = Function(W, name="AnalyticalPressure")
+    p_anal.dat.data[:] = [solution.pressure_cartesian(xyzi) for xyzi in pxyz.dat.data]
+    p_error = Function(W, name="PressureError").assign(p_-p_anal)
+
+    if do_write:
+        # Write output files in VTK format:
+        u_.rename("Velocity")
+        p_.rename("Pressure")
+        u_file = File("zs_velocity_{}.pvd".format(level))
+        p_file = File("zs_pressure_{}.pvd".format(level))
+
+        # Write output:
+        u_file.write(u_, u_anal, u_error)
+        p_file.write(p_, p_anal, p_error)
+
+    l2anal_u = numpy.sqrt(assemble(dot(u_anal, u_anal)*_dx))
+    l2anal_p = numpy.sqrt(assemble(dot(p_anal, p_anal)*_dx))
+    l2error_u = numpy.sqrt(assemble(dot(u_error, u_error)*_dx))
+    l2error_p = numpy.sqrt(assemble(dot(p_error, p_error)*_dx))
+
+    return l2error_u, l2error_p, l2anal_u, l2anal_p

--- a/demos/analytical_comparisons/test_analytical.py
+++ b/demos/analytical_comparisons/test_analytical.py
@@ -15,6 +15,11 @@ enabled_cases = {
     "smooth/spherical/zero_slip": {"convergence": (4.0, 2.0)},
 }
 
+longtest_cases = [
+    "smooth/spherical/free_slip",
+    "smooth/spherical/zero_slip",
+]
+
 params = {
     f"{l1}/{l2}/{l3}": v3 for l1, v1 in analytical.cases.items()
     for l2, v2 in v1.items()
@@ -31,7 +36,11 @@ for name, conf in params.items():
     permutate = conf.pop("permutate", True)
 
     for combination in analytical.param_sets(conf, permutate):
-        configs.append((name, enabled_cases[name], dict(zip(conf.keys(), combination))))
+        conf_tuple = (name, enabled_cases[name], dict(zip(conf.keys(), combination)))
+        if name in longtest_cases:
+            configs.append(pytest.param(*conf_tuple, marks=pytest.mark.longtest))
+        else:
+            configs.append(conf_tuple)
 
 
 def idfn(val):

--- a/demos/analytical_comparisons/test_analytical.py
+++ b/demos/analytical_comparisons/test_analytical.py
@@ -1,6 +1,5 @@
 import pytest
 import analytical
-import itertools
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -29,14 +28,9 @@ for name, conf in params.items():
     conf = conf.copy()
     conf.pop("cores")
     conf.pop("levels")
-
     permutate = conf.pop("permutate", True)
-    if permutate:
-        param_gen = itertools.product(*conf.values())
-    else:
-        param_gen = zip(*conf.values())
 
-    for combination in param_gen:
+    for combination in analytical.param_sets(conf, permutate):
         configs.append((name, enabled_cases[name], dict(zip(conf.keys(), combination))))
 
 

--- a/demos/analytical_comparisons/test_analytical.py
+++ b/demos/analytical_comparisons/test_analytical.py
@@ -30,7 +30,13 @@ for name, conf in params.items():
     conf.pop("cores")
     conf.pop("levels")
 
-    for combination in itertools.product(*conf.values()):
+    permutate = conf.pop("permutate", True)
+    if permutate:
+        param_gen = itertools.product(*conf.values())
+    else:
+        param_gen = zip(*conf.values())
+
+    for combination in param_gen:
         configs.append((name, enabled_cases[name], dict(zip(conf.keys(), combination))))
 
 

--- a/demos/analytical_comparisons/test_analytical.py
+++ b/demos/analytical_comparisons/test_analytical.py
@@ -11,8 +11,8 @@ enabled_cases = {
     "delta/cylindrical/zero_slip": {"convergence": (1.5, 0.5)},
     "delta/cylindrical/free_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 1e-1},
     "delta/cylindrical/zero_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 2e-1},
-    "smooth/spherical/free_slip": {"convergence": (4.0, 2.0)},
-    "smooth/spherical/zero_slip": {"convergence": (4.0, 2.0)},
+    "smooth/spherical/free_slip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
+    "smooth/spherical/zero_slip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
 }
 
 longtest_cases = [

--- a/demos/analytical_comparisons/test_analytical.py
+++ b/demos/analytical_comparisons/test_analytical.py
@@ -12,6 +12,8 @@ enabled_cases = {
     "delta/cylindrical/zero_slip": {"convergence": (1.5, 0.5)},
     "delta/cylindrical/free_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 1e-1},
     "delta/cylindrical/zero_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 2e-1},
+    "smooth/spherical/free_slip": {"convergence": (4.0, 2.0)},
+    "smooth/spherical/zero_slip": {"convergence": (4.0, 2.0)},
 }
 
 params = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 python_files = test_*.py
+markers =
+  longtest


### PR DESCRIPTION
This finally adds the more expensive spherical analytical cases, as well as the testing framework that will let us fire off automated tests on HPC (just Gadi for the moment).

- [x] check out and copy repository to Gadi
- [x] set up SSH access to run tests
- [x] run tests using existing `make` framework
- [x] execute tests in parallel
- [x] retrieve failed runs
- [x] test results
  - maybe do this on the remote machine too, by adding a pytest tag for longtest results? the SSH command will error if pytest fails
- [x] clean up test artefacts