### PR TITLE
Testing fixes (unpin pyadjoint, add timing)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
           python3 -m pip install --no-index -f /tmp/wheels pyroltrilinos
           python3 -m pip install -r requirements.txt
           python3 -m pip install .
-          python3 -m pip install git+https://github.com/angus-g/pyadjoint@angus-g/rol-dualspace
 
       - name: Run test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install prerequisites
         run: |
           sudo apt update
-          sudo apt install -y task-spooler
+          sudo apt install -y task-spooler time
           tsp -S 48
       - uses: actions/checkout@v3
 
@@ -56,10 +56,27 @@ jobs:
       - name: Run test
         run: |
           . /home/firedrake/firedrake/bin/activate
-          make -j test > test_output.log
+          make -j test
           python -m pytest
         env:
           GADOPT_LOGLEVEL: INFO
+          TS_MAXFINISHED: 100
+
+      - name: Output timing information
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          for id in $(tsp | tail +2 | awk '{print $1}'); do
+            st="$(tsp -i $id)"
+            if [[ "$st" =~ "exit code 0" ]]; then
+              echo "$st" | awk '/^(Time|Command)/'
+            else
+              echo "$st" | awk '/^Command/ {print "Failed: " $0} /^Time/'
+              echo "$st" | grep '^Command' >> test_output.log
+              tsp -t $id | tail -n 10
+              tsp -t $id >> test_output.log
+            fi
+          done
 
       - name: Upload failed run log
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,8 @@ jobs:
             else
               echo "$st" | awk '/^Command/ {print "Failed: " $0} /^Time/'
               echo "$st" | grep '^Command' >> test_output.log
-              tsp -t $id | tail -n 10
-              tsp -t $id >> test_output.log
+              tsp -c $id | tail -n 10 || true
+              tsp -c $id >> test_output.log || true
             fi
           done
 

--- a/demos/2d_compressible_ALA/Makefile
+++ b/demos/2d_compressible_ALA/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: compressible_case_ALA.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/2d_compressible_TALA/Makefile
+++ b/demos/2d_compressible_TALA/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: compressible_case_TALA.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/2d_cylindrical/Makefile
+++ b/demos/2d_cylindrical/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: 2d_cylindrical.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/3d_cartesian/Makefile
+++ b/demos/3d_cartesian/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: 3d_cartesian.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/3d_spherical/Makefile
+++ b/demos/3d_spherical/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: 3d_spherical.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/Drucker-Prager_rheology/Makefile
+++ b/demos/Drucker-Prager_rheology/Makefile
@@ -4,7 +4,7 @@ all: $(cases)
 
 $(cases): spiegelman.py
 	echo "running spiegelman $@" >&2
-	tsp -fn python3 $< $@
+	/usr/bin/time --format="spiegelman $@ finished in %E" tsp -f python3 $< $@
 
 clean:
 	rm -rf $(addprefix spiegelman_,$(cases))

--- a/demos/Drucker-Prager_rheology/Makefile
+++ b/demos/Drucker-Prager_rheology/Makefile
@@ -4,7 +4,7 @@ all: $(cases)
 
 $(cases): spiegelman.py
 	echo "running spiegelman $@" >&2
-	tsp -N 1 python3 $< $@
+	tsp -fn python3 $< $@
 
 clean:
 	rm -rf $(addprefix spiegelman_,$(cases))

--- a/demos/adjoint/Makefile
+++ b/demos/adjoint/Makefile
@@ -6,11 +6,11 @@ ncpus := 2
 
 %.conv: taylor_test.py Checkpoint_State.h5
 	echo "running $< on case $*" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $< $*
+	/usr/bin/time --format="$< on case $* took %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< $*
 
 Checkpoint_State.h5: forward.py
 	echo "running forward adjoint case" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="forward adjoint case took %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.h5 *.conv *.dat

--- a/demos/analytical_comparisons/Makefile
+++ b/demos/analytical_comparisons/Makefile
@@ -6,4 +6,4 @@ all: $(cases)
 
 $(cases): analytical.py
 	echo "running analytical $@" >&2
-	python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $@
+	/usr/bin/time --format="analytical $@ finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $@

--- a/demos/base_case/Makefile
+++ b/demos/base_case/Makefile
@@ -2,7 +2,7 @@ all: params.log
 
 params.log: base_case.py
 	echo "running $<" >&2
-	tsp -fn python3 $<
+	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/optimisation_checkpointing/Makefile
+++ b/demos/optimisation_checkpointing/Makefile
@@ -2,7 +2,7 @@ all: checkpointing
 
 checkpointing: helmholtz.py
 	echo "running helmholtz checkpointing" >&2
-	tsp -N 1 -nf python3 $<
+	/usr/bin/time --format="helmholtz checkpointing took %E" tsp -f python3 $<
 
 clean:
 	rm -rf optimisation_checkpoint

--- a/demos/viscoplastic_case/Makefile
+++ b/demos/viscoplastic_case/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: viscoplastic_case.py
 	echo "running $<" >&2
-	tsp -N $(ncpus) -nf mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log


### PR DESCRIPTION
The dualspace-aware fixes for pyadjoint have been merged, so we can already unpin pyadjoint for our testing container. As another line of defense in diagnosis, the testing makefiles print out how long each of the runs took.