### PR TITLE
Lower tolerances, to avoid the occasional inner solve failure.

### DIFF
--- a/demos/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/demos/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -77,8 +77,8 @@ def model(level, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # add delta forcing as ad-hoc aditional term
     # forcing is applied as "internal" boundary integral over facets

--- a/demos/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/demos/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -77,8 +77,8 @@ def model(level, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # add delta forcing as ad-hoc aditional term
     # forcing is applied as "internal" boundary integral over facets

--- a/demos/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/demos/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -77,8 +77,8 @@ def model(level, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # add delta forcing as ad-hoc aditional term
     # forcing is applied as "internal" boundary integral over facets

--- a/demos/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/demos/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -77,8 +77,8 @@ def model(level, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # add delta forcing as ad-hoc aditional term
     # forcing is applied as "internal" boundary integral over facets

--- a/demos/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/demos/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -76,8 +76,8 @@ def model(level, k, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # Solve system - configured for solving non-linear systems, where everything is on the LHS (as above)
     # and the RHS == 0.

--- a/demos/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/demos/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -76,8 +76,8 @@ def model(level, k, nn, do_write=False):
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:
-    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-14
-    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-12
+    stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
+    stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11
 
     # Solve system - configured for solving non-linear systems, where everything is on the LHS (as above)
     # and the RHS == 0.


### PR DESCRIPTION
Slacken solver tolerances marginally for analytical cases. This (for my testing at least!) seems to reduce the number of inner solve failures, and in the long-term should improve stability of the tests. I wonder if some of this has contributed to the timing issues @stephankramer has been seeing. I'll dig deeper tomorrow. 