### PR TITLE
Fix adoint cylindrical

### DIFF
--- a/demos/adjoint_2d_cylindrical/forward.py
+++ b/demos/adjoint_2d_cylindrical/forward.py
@@ -43,7 +43,6 @@ def run_forward():
     # Set up function spaces for the Q2Q1 pair
     V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
     W = FunctionSpace(mesh, "CG", 1)  # Pressure function space (scalar)
-    Q = FunctionSpace(mesh, "CG", 2)  # Temperature function space (scalar)
     Q1 = FunctionSpace(mesh, "CG", 1)  # Average temperature function space (scalar, P1)
     Z = MixedFunctionSpace([V, W])
 


### PR DESCRIPTION
This PR fixes an inconsistency in defining the strain-rate for non-linear cases. The definition of `forward.py` currently uses an additional factor of $\sqrt{1/2}$, that should actually appear in the definition for `epsii`. 

To make the two scripts consistent, and also the same as the original scripts for running the adoints we are now using a higher `sigma_y`.