### PR TITLE
Cancel in-progress CI runs on PR update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
       image: firedrakeproject/firedrake:latest
       options: --shm-size 2g
 
+    concurrency:
+      group: testing-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     env:
       OMP_NUM_THREADS: 1
 


### PR DESCRIPTION
If the testing workflow has already been triggered on a pull request, updates to that pull request should now cause the existing test to be cancelled. This means we don't have to wait or manually cancel outdated runs.