### PR TITLE
Change GAMG default to use mis_k_minimum_degree_ordering

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -21,6 +21,7 @@ iterative_stokes_solver_parameters = {
         "assembled_pc_gamg_threshold": 0.01,
         "assembled_pc_gamg_square_graph": 100,
         "assembled_pc_gamg_coarse_eq_limit": 1000,
+        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
     },
     "fieldsplit_1": {
         "ksp_type": "fgmres",


### PR DESCRIPTION
Do as the title says! I have found with a number of test cases that this improves solver behaviour at all levels (reduces the number of inner solve iterations). Would like to run through test suite as an independent change, to ensure I didn't miss anything, prior to merging. 