### PR TITLE
Create workflow summaries for test status and timings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,13 +76,28 @@ jobs:
           python3 -m pip install .
 
       - name: Run test
+        id: run_tests
         run: |
           . /home/firedrake/firedrake/bin/activate
           make -j test
-          python -m pytest -m 'not longtest'
         env:
           GADOPT_LOGLEVEL: INFO
           TS_MAXFINISHED: 100
+
+      - name: Pytest
+        id: run_pytest
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          python -m pytest -m 'not longtest' --junit-xml=test_results.xml
+
+      - name: Pytest report
+        uses: mikepenz/action-junit-report@v4
+        if: ${{ !cancelled() && steps.run_pytest.conclusion != 'skipped' }}
+        with:
+          check_name: Test suite report
+          report_paths: test_results.xml
+          include_passed: true
+          annotate_only: true
 
       - name: Output timing information
         if: ${{ !cancelled() }}
@@ -101,7 +116,7 @@ jobs:
           done
 
       - name: Upload failed run log
-        if: failure()
+        if: steps.run_tests.conclusion == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: run-log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,16 +103,35 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          for id in $(tsp | tail +2 | awk '{print $1}'); do
+          declare -A timings
+          declare -A success
+
+          # extract info
+          for id in $(tsp | awk 'NR>1 { print $1 }'); do
             st="$(tsp -i $id)"
-            if [[ "$st" =~ "exit code 0" ]]; then
-              echo "$st" | awk '/^(Time|Command)/'
+            command=$(sed -En 's/^Command.*python3? //p' <<< "$st")
+            timings["$command"]=$(sed -n 's/^Time run: //p' <<< "$st")
+
+            if grep -q "exit code 0" <<< "$st"; then
+              success["$command"]=Yes
             else
-              echo "$st" | awk '/^Command/ {print "Failed: " $0} /^Time/'
-              echo "$st" | grep '^Command' >> test_output.log
+              success["$command"]=No
+              echo "$command failed:"
               tsp -c $id | tail -n 10 || true
+              echo $command >> test_output.log
               tsp -c $id >> test_output.log || true
             fi
+          done
+
+          # sort by case name
+          declare -a cases
+          while IFS= read -r -d '' entry; do
+            cases+=("$entry")
+          done < <(printf "%s\0" "${!timings[@]}" | sort -z)
+
+          printf "## Case timings\nCase | Time | Success?\n---- | ---- | ----\n" >> "$GITHUB_STEP_SUMMARY"
+          for case in "${cases[@]}"; do
+            printf "%s | %s | %s\n" "$case" ${timings["$case"]} ${success["$case"]} >> "$GITHUB_STEP_SUMMARY"
           done
 
       - name: Upload failed run log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,18 @@ jobs:
     outputs:
       skip: ${{ steps.check_commit.outputs.skip }}
     steps:
+      - name: Always run tests on workflow dispatch
+        id: early_exit
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run:
+          echo skip=true >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
+        if: ${{ steps.early_exit.outputs.skip != 'true' }}
         with:
           ref: ${{ github.event.push.after || github.event.pull_request.head.sha || github.event.workflow_dispatch.ref }}
       - name: Check if message contains skip keyword
         id: check_commit
+        if: ${{ steps.early_exit.outputs.skip != 'true' }}
         run: |
           message=$(git log -1 --pretty=format:'%B')
           regex="\[skip tests\]"


### PR DESCRIPTION
These now show up on the workflow summary page, rather than needing to go into the run log itself.