### PR TITLE
Change default restored checkpoint in optimisation to the last saved

### DIFF
--- a/demos/optimisation_checkpointing/helmholtz.py
+++ b/demos/optimisation_checkpointing/helmholtz.py
@@ -61,7 +61,7 @@ optimiser = LinMoreOptimiser(
 )
 run(optimiser, rf, mesh.comm.rank, "full_optimisation.dat")
 
-# re-initialise optimiser, and restore from checkpoint
+# re-initialise optimiser, and restore from checkpoint 5
 optimiser = LinMoreOptimiser(
     minimisation_problem,
     minimisation_parameters,
@@ -69,4 +69,16 @@ optimiser = LinMoreOptimiser(
     auto_checkpoint=False,
 )
 optimiser.restore(5)
-run(optimiser, rf, mesh.comm.rank, "restored_optimisation.dat")
+run(optimiser, rf, mesh.comm.rank, "restored_optimisation_from_it_5.dat")
+
+# re-initialise optimiser, and restore from last stored checkpoint
+
+minimisation_parameters["Status Test"]["Iteration Limit"] = 15
+optimiser = LinMoreOptimiser(
+    minimisation_problem,
+    minimisation_parameters,
+    checkpoint_dir="optimisation_checkpoint",
+    auto_checkpoint=False,
+)
+optimiser.restore()
+run(optimiser, rf, mesh.comm.rank, "restored_optimisation_from_last_it.dat")

--- a/demos/optimisation_checkpointing/test_checkpointing.py
+++ b/demos/optimisation_checkpointing/test_checkpointing.py
@@ -13,6 +13,5 @@ def test_checkpointing():
     assert np.allclose(full_optimisation[-restored_steps:], restored_optimisation)
 
     restored_optimisation_last_it = np.loadtxt(base / "restored_optimisation_from_last_it.dat")
-    restored_steps_last_it = restored_optimisation_last_it.size
 
-    assert np.allclose(full_optimisation[-restored_steps_last_it:], restored_optimisation)
+    assert full_optimisation[-1] > restored_optimisation_last_it[0]

--- a/demos/optimisation_checkpointing/test_checkpointing.py
+++ b/demos/optimisation_checkpointing/test_checkpointing.py
@@ -6,8 +6,13 @@ def test_checkpointing():
     base = Path(__file__).parent.resolve()
 
     full_optimisation = np.loadtxt(base / "full_optimisation.dat")
-    restored_optimisation = np.loadtxt(base / "restored_optimisation.dat")
+    restored_optimisation = np.loadtxt(base / "restored_optimisation_from_it_5.dat")
 
     restored_steps = restored_optimisation.size
 
     assert np.allclose(full_optimisation[-restored_steps:], restored_optimisation)
+
+    restored_optimisation_last_it = np.loadtxt(base / "restored_optimisation_from_last_it.dat")
+    restored_steps_last_it = restored_optimisation_last_it.size
+
+    assert np.allclose(full_optimisation[-restored_steps_last_it:], restored_optimisation)

--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -201,8 +201,8 @@ class LinMoreOptimiser:
     def restore(self, iteration=None):
         """Restore the ROL state from disk.
 
-	The last stored iteration in `checkpoint_dir` is used unless a given iteration is specifed.
-	"""
+        The last stored iteration in `checkpoint_dir` is used unless a given iteration is specifed.
+        """
         if iteration is not None:
             self.iteration = iteration
         else:

--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -198,10 +198,17 @@ class LinMoreOptimiser:
             for i, func in enumerate(self.rol_solver.rolvector.dat):
                 f.save_function(func, name=f"dat_{i}")
 
-    def restore(self, iteration):
-        """Restore the ROL state from a given iteration from disk."""
+    def restore(self, iteration=None):
+        """Restore the ROL state from disk.
 
-        self.iteration = iteration
+	The last stored iteration in `checkpoint_dir` is used unless a given iteration is specifed.
+	"""
+        if iteration is not None:
+            self.iteration = iteration
+        else:
+            stored_iterations = [int(path.parts[-1]) for path in self._base_checkpoint_dir.glob('*[0-9]/')]
+            self.iteration = sorted(stored_iterations)[-1]
+
         self.rol_algorithm = ROL.load_algorithm(MPI.COMM_WORLD.rank, str(self.checkpoint_dir))
         self._add_statustest()
 


### PR DESCRIPTION
This PR changes the default iteration for the restored checkpoint to be the last stored checkpoint instead of requiring a given iteration number to restore from.

Note that if a user adds other subdirectories to `checkpoint_dir` then this might/will break as it assumes the only things in there are the subdirectories for the iterations' checkpoints. I think this is a non-issue as we probably don't need to allow for that?