### PR TITLE
Don't remove nullspace inside massinvpc solve.

### DIFF
--- a/demos/2d_cylindrical/2d_cylindrical.py
+++ b/demos/2d_cylindrical/2d_cylindrical.py
@@ -57,7 +57,7 @@ u.rename("Velocity")
 p.rename("Pressure")
 # Create output file and select output_frequency:
 output_file = File("output.pvd")
-dump_period = 1
+dump_period = 50
 # Frequency of checkpoint files:
 checkpoint_period = dump_period * 4
 # Open file for logging diagnostic output:

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -53,10 +53,6 @@ class VariableMassInvPC(fd.PCBase):
                              mat_type=mat_type, options_prefix=self.options_prefix)
 
         Pmat = self.A.petscmat
-        Pmat.setNullSpace(P.getNullSpace())
-        tnullsp = P.getTransposeNullSpace()
-        if tnullsp.handle != 0:
-            Pmat.setTransposeNullSpace(tnullsp)
 
         ksp = PETSc.KSP().create(comm=pc.comm)
         ksp.incrementTabLevel(1, parent=pc)


### PR DESCRIPTION
The mass matrix we use as an approximation of the Schur complement does not actually have a nullspace, so when we use cg to invert it in order to apply it as a preconditioner, we should not be removing the nullspace inside the cg iteration. This in fact led to frequent (silently failing) solves - add ['fieldsplit_1']['Mp_ksp_converged_reason'] = None to see - either failing with definite pc, or (worse) failing to converge within 10000 iterations. The latter is of course a bit of time waste (the pressure mass cg iteration is rel. fairly cheap, so not as bad as you might think). The fact that this solve (silently) fails also didn't seem to impact the overall convergence of the Schur complement (outer iteration).

Note that this only leaves out the nullspace in the pressure mass solve (fieldsplit_1_ksp_Mp); the nullspace is still being removed in the outer Schur iteration (fieldsplit_1_ksp)

Also reduce excessive vtu output in 2d_cylindrical.