### PR TITLE
Fix the iteration counter for restored optimiser

### DIFF
--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -215,6 +215,11 @@ class LinMoreOptimiser:
         self.rol_solver.rolvector.checkpoint_path = self.checkpoint_dir / "solution_checkpoint.h5"
         self.rol_solver.rolvector.load(self._mesh)
 
+        # ROL algorithms run in a loop like `while (statusTest()) { ... }`
+        # so we will double up on saving the restored iteration
+        # by rolling back the iteration counter, we make sure we overwrite the checkpoint
+        # we just restored, to keep the ROL iteration count, and our checkpoint iteration
+        # count in sync
         self.iteration -= 1
 
         # The various ROLVector objects can load all their metadata, but can't actually

--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -215,6 +215,8 @@ class LinMoreOptimiser:
         self.rol_solver.rolvector.checkpoint_path = self.checkpoint_dir / "solution_checkpoint.h5"
         self.rol_solver.rolvector.load(self._mesh)
 
+        self.iteration -= 1
+
         # The various ROLVector objects can load all their metadata, but can't actually
         # restore from the Firedrake checkpoint. They register themselves, so we can access
         # them through a flat list.


### PR DESCRIPTION
This fixes the checkpointing iteration counter for restored optimisations.

Currently, the restored iteration gets saved again in the checkpointing directory as the next iteration. So after restoring from say iteration 10, this gets checkpointed as iteration 11 but is still iteration 10 as far as ROL is concerned. This means that with each restored run of the optimisation the directory names in the checkpoint directory and the actual ROL iteration values get more and more out of sync.

Please let me know if this was intended behaviour, but doesn't seem very user-friendly to me!