### PR TITLE
Informing `StokesSolver` when our LHS is not changing in time. 

### DIFF
--- a/demos/2d_compressible_ALA/compressible_case_ALA.py
+++ b/demos/2d_compressible_ALA/compressible_case_ALA.py
@@ -34,7 +34,6 @@ t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_toleranc
 
 # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
 Ra = Constant(1e5)  # Rayleigh number
-mu = Constant(1.0)  # Viscosity
 
 # Compressible reference state:
 gruneisen = 1.0
@@ -94,8 +93,9 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True,
-                             transpose_nullspace=Z_nullspace)
+                             cartesian=True, J="constant",
+                             transpose_nullspace=Z_nullspace,
+                             )
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/2d_compressible_ALA/compressible_case_ALA.py
+++ b/demos/2d_compressible_ALA/compressible_case_ALA.py
@@ -93,7 +93,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, J="constant",
+                             cartesian=True, constant_jacobian=True,
                              transpose_nullspace=Z_nullspace,
                              )
 

--- a/demos/2d_compressible_ALA/compressible_case_ALA.py
+++ b/demos/2d_compressible_ALA/compressible_case_ALA.py
@@ -94,8 +94,7 @@ stokes_bcs = {
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
                              cartesian=True, constant_jacobian=True,
-                             transpose_nullspace=Z_nullspace,
-                             )
+                             transpose_nullspace=Z_nullspace)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/2d_compressible_TALA/compressible_case_TALA.py
+++ b/demos/2d_compressible_TALA/compressible_case_TALA.py
@@ -94,7 +94,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, J="constant",
+                             cartesian=True, constant_jacobian=True,
                              transpose_nullspace=Z_nullspace)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")

--- a/demos/2d_compressible_TALA/compressible_case_TALA.py
+++ b/demos/2d_compressible_TALA/compressible_case_TALA.py
@@ -31,7 +31,6 @@ T.interpolate((1.0 - (T0*exp(Di) - T0)) * ((1.0-X[1]) + (0.05*cos(pi*X[0])*sin(p
 
 # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
 Ra = Constant(1e5)  # Rayleigh number
-mu = Constant(1.0)  # Viscosity
 
 # Compressible reference state:
 gruneisen = 1.0
@@ -95,7 +94,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True,
+                             cartesian=True, J="constant",
                              transpose_nullspace=Z_nullspace)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")

--- a/demos/2d_cylindrical/2d_cylindrical.py
+++ b/demos/2d_cylindrical/2d_cylindrical.py
@@ -75,7 +75,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False,
+                             cartesian=False, J="constant",
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/2d_cylindrical/2d_cylindrical.py
+++ b/demos/2d_cylindrical/2d_cylindrical.py
@@ -75,7 +75,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, J="constant",
+                             cartesian=False, constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/3d_cartesian/3d_cartesian.py
+++ b/demos/3d_cartesian/3d_cartesian.py
@@ -78,7 +78,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True,
+                             cartesian=True, J="constant",
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/3d_cartesian/3d_cartesian.py
+++ b/demos/3d_cartesian/3d_cartesian.py
@@ -78,7 +78,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, J="constant",
+                             cartesian=True, constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -103,7 +103,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, J="constant",
+                             cartesian=False, constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -103,7 +103,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False,
+                             cartesian=False, J="constant",
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 

--- a/demos/adjoint/forward.py
+++ b/demos/adjoint/forward.py
@@ -88,6 +88,7 @@ stokes_solver = StokesSolver(
     bcs=stokes_bcs,
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,
+    constant_jacobian=True,
 )
 
 # Create output file and select output_frequency

--- a/demos/adjoint/inverse.py
+++ b/demos/adjoint/inverse.py
@@ -115,6 +115,7 @@ def inverse(alpha_u, alpha_d, alpha_s):
         bcs=stokes_bcs,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
+        constant_jacobian=True,
     )
 
     # Control variable for optimisation

--- a/demos/adjoint/taylor_test.py
+++ b/demos/adjoint/taylor_test.py
@@ -100,6 +100,7 @@ def rectangle_taylor_test(case):
         bcs=stokes_bcs,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
+        constant_jacobian=True,
     )
 
     # Control variable for optimisation

--- a/demos/base_case/base_case.py
+++ b/demos/base_case/base_case.py
@@ -74,7 +74,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True,
+                             cartesian=True, J="constant",
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")

--- a/demos/base_case/base_case.py
+++ b/demos/base_case/base_case.py
@@ -74,7 +74,7 @@ stokes_bcs = {
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, J="constant",
+                             cartesian=True, constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -113,21 +113,20 @@ class StokesSolver:
         self.mu = ensure_constant(mu)
         self.solver_parameters = solver_parameters
 
-        # By default we assume the Jacobian to be varying in time
+        # Assume Jacobian varies in time unless specified otherwise
         self.constant_jacobian = False
+        self.J = None  # Default value for Jacobian
 
-        # In case J is provide, making sure is valid and see if it needs to be constant
+        # Validate and set the Jacobian if provided
         if J is not None:
-            # in cases where J is provided
             if isinstance(J, (ufl.BaseForm, slate.TensorBase)):
                 self.J = J
-            # for constant viscosity
-            elif isinstance(J, str) and J == "constant":
-                self.J = None
+            elif isinstance(J, str) and J.lower() == "constant":
+                # Handling constant Jacobian
                 self.constant_jacobian = True
             else:
-                raise TypeError(
-                    "Provided Jacobian is a '%s', and is not valid" % type(J).__name__)
+                # Raising error for invalid Jacobian type
+                raise TypeError(f"Invalid Jacobian type: {repr(J)}")
 
         self.linear = not depends_on(self.mu, self.solution)
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -2,8 +2,6 @@ from .momentum_equation import StokesEquations
 from .utility import upward_normal, ensure_constant
 from .utility import log_level, INFO, DEBUG, depends_on
 import firedrake as fd
-import ufl
-from firedrake import slate
 
 iterative_stokes_solver_parameters = {
     "mat_type": "matfree",
@@ -112,23 +110,8 @@ class StokesSolver:
         self.approximation = approximation
         self.mu = ensure_constant(mu)
         self.solver_parameters = solver_parameters
-
-        # Assume Jacobian varies in time unless specified otherwise
-        self.constant_jacobian = False
         self.J = J
         self.constant_jacobian = constant_jacobian
-
-        # Validate and set the Jacobian if provided
-        if J is not None:
-            if isinstance(J, (ufl.BaseForm, slate.TensorBase)):
-                self.J = J
-            elif isinstance(J, str) and J.lower() == "constant":
-                # Handling constant Jacobian
-                self.constant_jacobian = True
-            else:
-                # Raising error for invalid Jacobian type
-                raise TypeError(f"Invalid Jacobian type: {repr(J)}")
-
         self.linear = not depends_on(self.mu, self.solution)
 
         self.solver_kwargs = kwargs
@@ -193,7 +176,7 @@ class StokesSolver:
             a, L = fd.lhs(F_stokes_lin), fd.rhs(F_stokes_lin)
             self.problem = fd.LinearVariationalProblem(a, L, self.solution,
                                                        bcs=self.strong_bcs,
-                                                       constant_jacobian=True,)
+                                                       constant_jacobian=True)
             self.solver = fd.LinearVariationalSolver(self.problem,
                                                      solver_parameters=self.solver_parameters,
                                                      options_prefix=self.name,

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -113,11 +113,15 @@ class StokesSolver:
         self.mu = ensure_constant(mu)
         self.solver_parameters = solver_parameters
 
-        # In case J is provide, making sure is valid
+        # By default we assume the Jacobian to be varying in time
+        self.constant_jacobian = False
+
+        # In case J is provide, making sure is valid and see if it needs to be constant
         if J is not None:
+            # in cases where J is provided
             if isinstance(J, (ufl.BaseForm, slate.TensorBase)):
                 self.J = J
-                self.constant_jacobian = False
+            # for constant viscosity
             elif isinstance(J, str) and J == "constant":
                 self.J = None
                 self.constant_jacobian = True

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -142,14 +142,14 @@ class StokesSolver:
         self.strong_bcs = []
         for id, bc in bcs.items():
             weak_bc = {}
-            for type, value in bc.items():
-                if type == 'u':
+            for bc_type, value in bc.items():
+                if bc_type == 'u':
                     self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0), value, id))
-                elif type == 'ux':
+                elif bc_type == 'ux':
                     self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(0), value, id))
-                elif type == 'uy':
+                elif bc_type == 'uy':
                     self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(1), value, id))
-                elif type == 'uz':
+                elif bc_type == 'uz':
                     self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(2), value, id))
                 else:
                     weak_bc[type] = value

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -113,15 +113,17 @@ class StokesSolver:
         self.mu = ensure_constant(mu)
         self.solver_parameters = solver_parameters
 
-        if isinstance(J, (ufl.BaseForm, slate.TensorBase)):
-            self.J = J
-            self.constant_jacobian = False
-        elif isinstance(J, str) and J == "constant":
-            self.J = None
-            self.constant_jacobian = True
-        else:
-            raise TypeError(
-                "Provided Jacobian is a '%s', and is not valid" % type(J).__name__)
+        # In case J is provide, making sure is valid
+        if J is not None:
+            if isinstance(J, (ufl.BaseForm, slate.TensorBase)):
+                self.J = J
+                self.constant_jacobian = False
+            elif isinstance(J, str) and J == "constant":
+                self.J = None
+                self.constant_jacobian = True
+            else:
+                raise TypeError(
+                    "Provided Jacobian is a '%s', and is not valid" % type(J).__name__)
 
         self.linear = not depends_on(self.mu, self.solution)
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -101,7 +101,7 @@ class StokesSolver:
 
     def __init__(self, z, T, approximation, bcs=None, mu=1,
                  quad_degree=6, cartesian=True, solver_parameters=None,
-                 closed=True, rotational=False, J=None,
+                 closed=True, rotational=False, J=None, constant_jacobian=False,
                  **kwargs):
         self.Z = z.function_space()
         self.mesh = self.Z.mesh()
@@ -115,7 +115,8 @@ class StokesSolver:
 
         # Assume Jacobian varies in time unless specified otherwise
         self.constant_jacobian = False
-        self.J = None  # Default value for Jacobian
+        self.J = J
+        self.constant_jacobian = constant_jacobian
 
         # Validate and set the Jacobian if provided
         if J is not None:
@@ -157,7 +158,7 @@ class StokesSolver:
                 elif bc_type == 'uz':
                     self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(2), value, id))
                 else:
-                    weak_bc[type] = value
+                    weak_bc[bc_type] = value
             self.weak_bcs[id] = weak_bc
 
         self.F = 0


### PR DESCRIPTION
## Issue
In many of demos, as well as some simplified Earth-like problems, we do  not have time-varying viscosity. For example for our adjoint optimisations, we might do many iterations with only a depth dependent viscosity to obtain a better "initial guess", before considering temperature-(or other temporally changing) dependencies. Currently we do assume the LHS of the stokes problem needs to be updated every timestep, whereas in the aforementioned cases this is not the case, as the Jacobian needs to be assembled once. 

## Change
With this PR, if `constant_jacobian=True` is provided to `StokesSolver` we setup a `LinearVariationalProblem` with `constant_jacobian=True`, which should result in considerable speed up in run-time for cases with temporally constant viscosities.