### PR TITLE
Install updated CMake image when building pyrol wheel for Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Build pyrol wheel
         if: steps.cache-pyrol.outputs.cache-hit != 'true'
         run: |
+          curl -OL https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz
+          sudo tar --strip-components=1 -C /usr/local -xf cmake-3.28.1-linux-x86_64.tar.gz
           /home/firedrake/firedrake/bin/pip wheel -r requirements-git.txt -w /tmp/wheels
 
       - name: Save pyrol to cache

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,1 +1,1 @@
-git+https://github.com/angus-g/pyrol@rol-2.0-checkpointing
+git+https://github.com/angus-g/pyrol


### PR DESCRIPTION
With some recent changes (including moving our working branch of pyrol to master), the Ubuntu-provided CMake isn't sufficiently new enough (even though none of the new features are actually used :roll_eyes:). This change only affects the case when the pyrol wheel is rebuilt, i.e. when it isn't cached, so it shouldn't hit every invocation of the workflow.