### PR TITLE
Defer to PyPI for pyroltrilinos package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,33 +56,10 @@ jobs:
           tsp -S 48
       - uses: actions/checkout@v4
 
-      - name: Load pyrol wheel from cache
-        uses: actions/cache/restore@v3
-        id: cache-pyrol
-        with:
-          path: /tmp/wheels
-          key: pyrol
-
-      - name: Build pyrol wheel
-        if: steps.cache-pyrol.outputs.cache-hit != 'true'
-        run: |
-          curl -OL https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz
-          sudo tar --strip-components=1 -C /usr/local -xf cmake-3.28.1-linux-x86_64.tar.gz
-          /home/firedrake/firedrake/bin/pip wheel -r requirements-git.txt -w /tmp/wheels
-
-      - name: Save pyrol to cache
-        if: steps.cache-pyrol.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: /tmp/wheels
-          key: pyrol
-
       - name: Install Python dependencies
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python3 -m pip install --no-index -f /tmp/wheels pyroltrilinos
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install .
+          python3 -m pip install .[testing,optimisation]
 
       - name: Run test
         id: run_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,9 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 
+[project.optional-dependencies]
+testing = ["assess", "pandas"]
+optimisation = ["pyroltrilinos"]
+
 [tool.setuptools]
 packages = ["gadopt"]


### PR DESCRIPTION
Now that this is being built for most platforms, we should use the packaged wheel to make sure that's working, and remove the need for a fairly lengthy build in the testing workflow. This should also make things simpler for upstream installs (i.e. `pip install gadopt[optimisation]` should do what you want).

I've also split the gadopt specification: installing bare gadopt **won't** include pyrol, or assess/pandas. These packages are pulled in by the *optimisation* and *testing* variants, respectively. So in the installation for testing, we now install `gadopt[testing,optimisation]`. Is this a sensible way to split things up?