### PR TITLE
Changing Interpolators to be consistent with future Firedrake changes

### DIFF
--- a/gadopt/diagnostics.py
+++ b/gadopt/diagnostics.py
@@ -1,5 +1,6 @@
 import firedrake
 from firedrake import assemble, Constant, sqrt, dot, grad, FacetNormal
+from firedrake.ufl_expr import extract_unique_domain
 from .utility import CombinedSurfaceMeasure
 
 
@@ -10,7 +11,7 @@ def domain_volume(mesh):
 class GeodynamicalDiagnostics:
 
     def __init__(self, u, p, T, bottom_id, top_id, degree=4):
-        mesh = u.ufl_domain()
+        mesh = extract_unique_domain(u)
         self.domain_volume = domain_volume(mesh)
         self.u = u
         self.p = p

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -4,7 +4,8 @@ A module with utitity functions for gadopt
 from firedrake import outer, ds_v, ds_t, ds_b, CellDiameter, CellVolume, dot, JacobianInverse
 from firedrake import sqrt, Function, FiniteElement, TensorProductElement, FunctionSpace, VectorFunctionSpace
 from firedrake import as_vector, SpatialCoordinate, Constant, max_value, min_value, dx, assemble, tanh
-from firedrake import Interpolator, op2, interpolate, VectorElement
+from firedrake import op2, VectorElement
+from firedrake.__future__ import Interpolator
 import ufl
 import finat.ufl
 import time
@@ -341,7 +342,7 @@ class LayerAveraging:
             except AttributeError:
                 raise ValueError("For non-extruded mesh need to specify depths array r1d.")
             CG1 = FunctionSpace(mesh, "CG", 1)
-            r_func = interpolate(self.r, CG1)
+            r_func = Function(CG1).interpolate(self.r)
             self.r1d = r_func.dat.data[:nlayers]
 
         self.mass = np.zeros((2, len(self.r1d)))


### PR DESCRIPTION
This PR changes the way interpolation is used for LayerAveraging and Adaptive time-stepping to be consistent with future Firedrake changes and avoid raising long weird warnings.  