### PR TITLE
Format import style 

### DIFF
--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -1,14 +1,20 @@
 from firedrake import *
-from .time_stepper import CrankNicolsonRK, ImplicitMidpoint
-from .limiter import VertexBasedP1DGLimiter
-from .utility import log, ParameterLog, TimestepAdaptor, LayerAveraging, timer_decorator
+
+from .approximations import (
+    BoussinesqApproximation,
+    ExtendedBoussinesqApproximation,
+    AnelasticLiquidApproximation,
+    TruncatedAnelasticLiquidApproximation,
+)
 from .diagnostics import GeodynamicalDiagnostics
+from .energy_solver import EnergySolver
+from .limiter import VertexBasedP1DGLimiter
 from .momentum_equation import StokesEquations
+from .preconditioners import SPDAssembledPC, VariableMassInvPC
 from .scalar_equation import EnergyEquation
 from .stokes_integrators import StokesSolver, create_stokes_nullspace
-from .energy_solver import EnergySolver
-from .approximations import BoussinesqApproximation, ExtendedBoussinesqApproximation, AnelasticLiquidApproximation, TruncatedAnelasticLiquidApproximation
-from .preconditioners import SPDAssembledPC, VariableMassInvPC
+from .time_stepper import CrankNicolsonRK, ImplicitMidpoint
+from .utility import log, ParameterLog, TimestepAdaptor, LayerAveraging, timer_decorator
 
-from firedrake.petsc import PETSc
 PETSc.Sys.popErrorHandler()
+

--- a/gadopt/approximations.py
+++ b/gadopt/approximations.py
@@ -1,5 +1,8 @@
 import abc
-from firedrake import sym, grad, inner, div, Identity
+
+import firedrake as fd
+from firedrake import div, grad, inner, sym
+
 from .utility import ensure_constant, vertical_component
 
 
@@ -133,7 +136,7 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
     def viscous_dissipation(self, u):
         stress = 2 * self.mu * sym(grad(u))
         if self.compressible:  # (used in AnelasticLiquidApproximations below)
-            stress -= 2/3 * self.mu * div(u) * Identity(u.ufl_shape[0])
+            stress -= 2/3 * self.mu * div(u) * fd.Identity(u.ufl_shape[0])
         phi = inner(stress, grad(u))
         return phi * self.Di / self.Ra
 

--- a/gadopt/diagnostics.py
+++ b/gadopt/diagnostics.py
@@ -1,11 +1,12 @@
-import firedrake
-from firedrake import assemble, Constant, sqrt, dot, grad, FacetNormal
+import firedrake as fd
+from firedrake import assemble, dot, dx, grad, sqrt
 from firedrake.ufl_expr import extract_unique_domain
+
 from .utility import CombinedSurfaceMeasure
 
 
 def domain_volume(mesh):
-    return assemble(Constant(1)*firedrake.dx(domain=mesh))
+    return assemble(fd.Constant(1)*dx(domain=mesh))
 
 
 class GeodynamicalDiagnostics:
@@ -16,14 +17,14 @@ class GeodynamicalDiagnostics:
         self.u = u
         self.p = p
         self.T = T
-        self.dx = firedrake.dx(degree=degree)
+        self.dx = dx(degree=degree)
         if T.function_space().extruded:
             ds = CombinedSurfaceMeasure(mesh, degree)
         else:
-            ds = firedrake.ds(mesh)
+            ds = ds(mesh)
         self.ds_t = ds(top_id)
         self.ds_b = ds(bottom_id)
-        self.n = FacetNormal(mesh)
+        self.n = fd.FacetNormal(mesh)
 
     def u_rms(self):
         return sqrt(assemble(dot(self.u, self.u) * self.dx)) * sqrt(1./self.domain_volume)
@@ -32,10 +33,10 @@ class GeodynamicalDiagnostics:
         return sqrt(assemble(dot(self.u, self.u) * self.ds_t))
 
     def Nu_top(self):
-        return -1 * assemble(dot(grad(self.T), self.n) * self.ds_t) * (1./assemble(Constant(1) * self.ds_t))
+        return -1 * assemble(dot(grad(self.T), self.n) * self.ds_t) * (1./assemble(fd.Constant(1) * self.ds_t))
 
     def Nu_bottom(self):
-        return assemble(dot(grad(self.T), self.n) * self.ds_b) * (1./assemble(Constant(1) * self.ds_b))
+        return assemble(dot(grad(self.T), self.n) * self.ds_b) * (1./assemble(fd.Constant(1) * self.ds_b))
 
     def T_avg(self):
         return assemble(self.T * self.dx) / self.domain_volume

--- a/gadopt/energy_solver.py
+++ b/gadopt/energy_solver.py
@@ -1,8 +1,17 @@
-from firedrake import DirichletBC, Function, TensorFunctionSpace, Jacobian, dot
+import firedrake as fd
+from firedrake import dot
+
 from .scalar_equation import EnergyEquation
-from .utility import is_continuous, ensure_constant
-from .utility import log_level, INFO, DEBUG, log
-from .utility import absv, su_nubar
+from .utility import (
+    DEBUG,
+    INFO,
+    absv,
+    ensure_constant,
+    is_continuous,
+    log,
+    log_level,
+    su_nubar,
+)
 
 iterative_energy_solver_parameters = {
     "mat_type": "aij",
@@ -51,7 +60,7 @@ class EnergySolver:
             # beta(Pe) is the xibar vector in (2.44a)
             # then we get artifical viscosity nubar from (2.49)
 
-            J = Function(TensorFunctionSpace(self.mesh, 'DQ', 1), name='Jacobian').interpolate(Jacobian(self.mesh))
+            J = fd.Function(fd.TensorFunctionSpace(self.mesh, 'DQ', 1), name='Jacobian').interpolate(fd.Jacobian(self.mesh))
             kappa = self.fields['diffusivity'] + 1e-12  # Set lower bound for diffusivity in case zero diffusivity specified for pure advection.
             vel = self.fields['velocity']
             Pe = absv(dot(vel, J)) / (2*kappa)  # Calculate grid peclet number
@@ -82,7 +91,7 @@ class EnergySolver:
             for type, value in bc.items():
                 if type == 'T':
                     if apply_strongly:
-                        self.strong_bcs.append(DirichletBC(self.Q, value, id))
+                        self.strong_bcs.append(fd.DirichletBC(self.Q, value, id))
                     else:
                         weak_bc['q'] = value
                 else:
@@ -90,7 +99,7 @@ class EnergySolver:
             self.weak_bcs[id] = weak_bc
 
         self.timestepper = timestepper
-        self.T_old = Function(self.Q)
+        self.T_old = fd.Function(self.Q)
         # solver is setup only last minute
         # so people can overwrite parameters we've setup here
         self._solver_setup = False

--- a/gadopt/equations.py
+++ b/gadopt/equations.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
-import firedrake
+
+import firedrake as fd
+from firedrake import dS, ds, dS_h, dS_v, dx, inner
+
 from .utility import CombinedSurfaceMeasure
 
 
@@ -38,12 +41,12 @@ class BaseEquation(ABC):
             # so that ds or dS integrates over both horizontal and vertical boundaries
             # and we can also use "bottom" and "top" as surface ids, e.g. ds("top")
             self.ds = CombinedSurfaceMeasure(self.mesh, quad_degree)
-            self.dS = firedrake.dS_v(domain=self.mesh, degree=quad_degree) + firedrake.dS_h(domain=self.mesh, degree=quad_degree)
+            self.dS = dS_v(domain=self.mesh, degree=quad_degree) + dS_h(domain=self.mesh, degree=quad_degree)
         else:
-            self.ds = firedrake.ds(domain=self.mesh, degree=quad_degree)
-            self.dS = firedrake.dS(domain=self.mesh, degree=quad_degree)
+            self.ds = ds(domain=self.mesh, degree=quad_degree)
+            self.dS = dS(domain=self.mesh, degree=quad_degree)
 
-        self.dx = firedrake.dx(domain=self.mesh, degree=quad_degree)
+        self.dx = dx(domain=self.mesh, degree=quad_degree)
 
         # self._terms stores the actual instances of the BaseTerm-classes in self.terms
         self._terms = []
@@ -52,7 +55,7 @@ class BaseEquation(ABC):
 
     def mass_term(self, test, trial):
         r"""Return the UFL for the mass term \int test * trial * dx typically used in the time term."""
-        return firedrake.inner(test, trial) * self.dx
+        return inner(test, trial) * self.dx
 
     def residual(self, test, trial, trial_lagged=None, fields=None, bcs=None):
         """Return the UFL for all terms (except the time derivative)."""
@@ -79,7 +82,7 @@ class BaseTerm(ABC):
         self.dS = dS
         self.mesh = test_space.mesh()
         self.dim = self.mesh.geometric_dimension()
-        self.n = firedrake.FacetNormal(self.mesh)
+        self.n = fd.FacetNormal(self.mesh)
         self.term_kwargs = kwargs
 
     @abstractmethod


### PR DESCRIPTION
I am trying to see if there is some merit to defining a consistent way in which packages are imported in G-ADOPT.

The current situation is quite heterogeneous, and there are some intricate relationships. For example,  `demos/optimisation_checkpointing/helmholtz.py` calls `Control`, which is imported using `from gadopt.inverse import *`, in which one can find `from firedrake.adjoint import *`. This is obscure at best.

The way Firedrake classes and functions are imported into G-ADOPT seems to vary from module to module. Having a defined style would help to tidy the code. I can see some constraints to reorganising imports:
- `from module import *` is not considered good practice in Python, given potential namespace clashes and the ambiguous origin of objects used in the code
- `from module import Class, function, object` is fine, but it forces the programmer to always scroll up and insert the new object they need
- the beauty of UFL lies in the fact that Python code can be read as if it were mathematics; using `fd.grad(fd.dot(a, b))` loses this magic, and I can already hear people complaining about it

With this in mind, I have tried the following approach:
- `import firedrake as fd` and use `fd.` to refer to Classes
- `from firedrake import functions` to refer to any object using lowercase naming

What are your thoughts on this matter?