### PR TITLE
Use string to request default solver parameters

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -138,14 +138,14 @@ class StokesSolver:
         z: fd.Function,
         T: fd.Function,
         approximation: BaseApproximation,
-        bcs: Optional[dict[int, dict[str, int | float]]] = None,
+        bcs: dict[int, dict[str, int | float]] = {},
         mu: fd.Function | int | float = 1,
         quad_degree: int = 6,
         cartesian: bool = True,
         solver_parameters: Optional[dict[str, str | Number] | str] = None,
         J: Optional[fd.Function] = None,
         constant_jacobian: bool = False,
-        **kwargs
+        **kwargs,
     ):
         self.Z = z.function_space()
         self.mesh = self.Z.mesh()
@@ -155,7 +155,6 @@ class StokesSolver:
         self.solution = z
         self.approximation = approximation
         self.mu = ensure_constant(mu)
-        self.solver_parameters = solver_parameters
         self.J = J
         self.constant_jacobian = constant_jacobian
         self.linear = not depends_on(self.mu, self.solution)
@@ -194,7 +193,9 @@ class StokesSolver:
         for test, eq, u in zip(self.test, self.equations, fd.split(self.solution)):
             self.F -= eq.residual(test, u, u, self.fields, bcs=self.weak_bcs)
 
-        if not isinstance(self.solver_parameters, dict):
+        if isinstance(solver_parameters, dict):
+            self.solver_parameters = solver_parameters
+        else:
             if self.linear:
                 self.solver_parameters = {"snes_type": "ksponly"}
             else:
@@ -203,17 +204,17 @@ class StokesSolver:
             if INFO >= log_level:
                 self.solver_parameters["snes_monitor"] = None
 
-            if isinstance(self.solver_parameters, str):
-                match self.solver_parameters:
+            if isinstance(solver_parameters, str):
+                match solver_parameters:
+                    case "direct":
+                        self.solver_parameters.update(direct_stokes_solver_parameters)
                     case "iterative":
                         self.solver_parameters.update(
                             iterative_stokes_solver_parameters
                         )
-                    case "direct":
-                        self.solver_parameters.update(direct_stokes_solver_parameters)
                     case _:
                         raise ValueError(
-                            f"Solver type '{self.solver_parameters}' not implemented."
+                            f"Solver type '{solver_parameters}' not implemented."
                         )
             elif self.mesh.topological_dimension() == 2 and cartesian:
                 self.solver_parameters.update(direct_stokes_solver_parameters)

--- a/tests/test_stokes_solver_configuration.py
+++ b/tests/test_stokes_solver_configuration.py
@@ -1,5 +1,5 @@
 import firedrake as fd
-import numpy as np
+import pytest
 
 from gadopt.approximations import BoussinesqApproximation
 from gadopt.stokes_integrators import (
@@ -81,13 +81,7 @@ def test_solver_parameters_argument():
             solver_parameters=solver_parameters,
         )
 
-        np.testing.assert_equal(stokes_solver.solver_parameters, expected_value)
+        assert stokes_solver.solver_parameters == expected_value
 
-    np.testing.assert_raises(
-        ValueError,
-        StokesSolver,
-        stokes_function,
-        temperature,
-        approximation,
-        solver_parameters="",
-    )
+    with pytest.raises(ValueError):
+        StokesSolver(stokes_function, temperature, approximation, solver_parameters="")

--- a/tests/test_stokes_solver_configuration.py
+++ b/tests/test_stokes_solver_configuration.py
@@ -1,0 +1,93 @@
+import firedrake as fd
+import numpy as np
+
+from gadopt.approximations import BoussinesqApproximation
+from gadopt.stokes_integrators import (
+    StokesSolver,
+    direct_stokes_solver_parameters,
+    iterative_stokes_solver_parameters,
+    newton_stokes_solver_parameters,
+)
+
+
+def test_solver_parameters_argument():
+    mesh = fd.UnitSquareMesh(10, 10)
+
+    func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
+    func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
+    func_space_stokes = fd.MixedFunctionSpace([func_space_vel, func_space_pres])
+    stokes_function = fd.Function(func_space_stokes)
+
+    func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
+    temperature = fd.Function(func_space_temp, name="Temperature")
+
+    approximation = BoussinesqApproximation(1)
+
+    base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
+    example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
+
+    for test_case in [
+        "unspecified",
+        "direct",
+        "iterative",
+        "dictionary",
+        "cartesian_false",
+        "linear_false",
+    ]:
+        mu = 1
+        cartesian = True
+
+        match test_case:
+            case "unspecified":
+                solver_parameters = None
+                expected_value = (
+                    base_linear_params_with_log | direct_stokes_solver_parameters
+                )
+            case "direct":
+                solver_parameters = "direct"
+                expected_value = (
+                    base_linear_params_with_log | direct_stokes_solver_parameters
+                )
+            case "iterative":
+                solver_parameters = "iterative"
+                expected_value = (
+                    base_linear_params_with_log | iterative_stokes_solver_parameters
+                )
+            case "dictionary":
+                solver_parameters = example_solver_params
+                expected_value = example_solver_params
+            case "cartesian_false":
+                cartesian = False
+                solver_parameters = None
+                expected_value = (
+                    base_linear_params_with_log | iterative_stokes_solver_parameters
+                )
+                expected_value["fieldsplit_1"] |= {"ksp_converged_reason": None}
+            case "linear_false":
+                mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
+                solver_parameters = "direct"
+                expected_value = (
+                    {"snes_monitor": None}
+                    | newton_stokes_solver_parameters
+                    | direct_stokes_solver_parameters
+                )
+
+        stokes_solver = StokesSolver(
+            stokes_function,
+            temperature,
+            approximation,
+            mu=mu,
+            cartesian=cartesian,
+            solver_parameters=solver_parameters,
+        )
+
+        np.testing.assert_equal(stokes_solver.solver_parameters, expected_value)
+
+    np.testing.assert_raises(
+        ValueError,
+        StokesSolver,
+        stokes_function,
+        temperature,
+        approximation,
+        solver_parameters="",
+    )


### PR DESCRIPTION
Default iterative and direct Stokes solver parameters can now be specified using eponymous strings.