### PR TITLE
Require `cartesian` argument when instantiating approximation

### DIFF
--- a/demos/2d_compressible_ALA/compressible_case_ALA.py
+++ b/demos/2d_compressible_ALA/compressible_case_ALA.py
@@ -44,7 +44,9 @@ alphabar = Function(Q, name="IsobaricThermalExpansivity").assign(1.0)
 cpbar = Function(Q, name="IsobaricSpecificHeatCapacity").assign(1.0)
 chibar = Function(Q, name="IsothermalBulkModulus").assign(1.0)
 
-approximation = AnelasticLiquidApproximation(Ra, Di, rho=rhobar, Tbar=Tbar, alpha=alphabar, chi=chibar, cp=cpbar)
+approximation = AnelasticLiquidApproximation(
+    Ra, Di, cartesian=True, rho=rhobar, Tbar=Tbar, alpha=alphabar, chi=chibar, cp=cpbar
+)
 
 time = 0.0
 steady_state_tolerance = 1e-9
@@ -92,9 +94,14 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, constant_jacobian=True,
-                             transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    transpose_nullspace=Z_nullspace,
+)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/2d_compressible_TALA/compressible_case_TALA.py
+++ b/demos/2d_compressible_TALA/compressible_case_TALA.py
@@ -41,7 +41,9 @@ alphabar = Function(Q, name="IsobaricThermalExpansivity").assign(1.0)
 cpbar = Function(Q, name="IsobaricSpecificHeatCapacity").assign(1.0)
 chibar = Function(Q, name="IsothermalBulkModulus").assign(1.0)
 
-approximation = TruncatedAnelasticLiquidApproximation(Ra, Di, rho=rhobar, Tbar=Tbar, alpha=alphabar, cp=cpbar)
+approximation = TruncatedAnelasticLiquidApproximation(
+    Ra, Di, cartesian=True, rho=rhobar, Tbar=Tbar, alpha=alphabar, cp=cpbar
+)
 
 time = 0.0
 steady_state_tolerance = 1e-9
@@ -93,9 +95,14 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, constant_jacobian=True,
-                             transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    transpose_nullspace=Z_nullspace,
+)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/2d_cylindrical/2d_cylindrical.py
+++ b/demos/2d_cylindrical/2d_cylindrical.py
@@ -37,7 +37,7 @@ r = sqrt(X[0]**2 + X[1]**2)
 T.interpolate(rmax - r + 0.02*cos(4*atan2(X[1], X[0])) * sin((r - rmin) * pi))
 
 Ra = Constant(1e5)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=False)
 
 delta_t = Constant(1e-7)  # Initial time-step
 
@@ -74,10 +74,16 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace=Z_nullspace,
+    transpose_nullspace=Z_nullspace,
+    near_nullspace=Z_near_nullspace,
+)
 
 t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_tolerance=1.5)
 

--- a/demos/3d_cartesian/3d_cartesian.py
+++ b/demos/3d_cartesian/3d_cartesian.py
@@ -34,7 +34,7 @@ t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_toleranc
 
 # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
 Ra = Constant(3e4)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=True)
 
 time = 0.0
 steady_state_tolerance = 1e-7  # Set to 1e-9 for simulations in GMD paper.
@@ -77,10 +77,16 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace=Z_nullspace,
+    transpose_nullspace=Z_nullspace,
+    near_nullspace=Z_near_nullspace,
+)
 
 # Change solver tolerances for CI - note not done for models shown in paper.
 stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-4

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -54,7 +54,7 @@ T.interpolate(conductive_term +
               (eps_c*cos(m*theta) + eps_s*sin(m*theta)) * Plm * sin(pi*(r - rmin)/(rmax-rmin)))
 
 Ra = Constant(7e3)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=False)
 
 delta_t = Constant(1e-6)  # Initial time-step
 
@@ -102,10 +102,16 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace=Z_nullspace,
+    transpose_nullspace=Z_nullspace,
+    near_nullspace=Z_near_nullspace,
+)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/Drucker-Prager_rheology/spiegelman.py
+++ b/demos/Drucker-Prager_rheology/spiegelman.py
@@ -200,7 +200,7 @@ def spiegelman(U0, mu1, nx, ny, picard_iterations, stabilisation=False):
 
     # SCK:
     T = 0
-    approximation = BoussinesqApproximation(0)
+    approximation = BoussinesqApproximation(0, cartesian=True)
     bcs = {left_id: {'ux': 1}, right_id: {'ux': -1}, bottom_id: {'uy': 0}}
     picard_solver = StokesSolver(z, T, approximation, mu=mu_nl,
                                  bcs=bcs, solver_parameters=initial_picard_solver_parameters)

--- a/demos/adjoint/forward.py
+++ b/demos/adjoint/forward.py
@@ -58,7 +58,7 @@ checkpoint_file.save_function(Taverage, name="Average Temperature", idx=0)
 checkpoint_file.save_function(T, name="Temperature", idx=0)
 
 Ra = Constant(1e6)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=True)
 
 delta_t = Constant(4e-6)  # Constant time step
 max_timesteps = 80

--- a/demos/adjoint/inverse.py
+++ b/demos/adjoint/inverse.py
@@ -65,7 +65,7 @@ def inverse(alpha_u, alpha_d, alpha_s):
     p.rename("Pressure")
 
     Ra = Constant(1e6)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=True)
 
     # Define time stepping parameters:
     max_timesteps = 80

--- a/demos/adjoint/taylor_test.py
+++ b/demos/adjoint/taylor_test.py
@@ -50,7 +50,7 @@ def rectangle_taylor_test(case):
     p.rename("Pressure")
 
     Ra = Constant(1e6)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=True)
 
     # Define time stepping parameters:
     max_timesteps = 80

--- a/demos/adjoint_2d_cylindrical/forward.py
+++ b/demos/adjoint_2d_cylindrical/forward.py
@@ -53,7 +53,7 @@ def run_forward():
     X = SpatialCoordinate(mesh)
     r = sqrt(X[0] ** 2 + X[1] ** 2)
     Ra = Constant(1e7)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=False)
 
     # Define time stepping parameters:
     max_timesteps = 200
@@ -137,7 +137,6 @@ def run_forward():
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/adjoint_2d_cylindrical/inverse.py
+++ b/demos/adjoint_2d_cylindrical/inverse.py
@@ -78,7 +78,7 @@ def inverse(alpha_u, alpha_d, alpha_s):
     X = SpatialCoordinate(mesh)
     r = sqrt(X[0] ** 2 + X[1] ** 2)
     Ra = Constant(1e7)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=False)
 
     # Define time stepping parameters:
     max_timesteps = 200
@@ -160,7 +160,6 @@ def inverse(alpha_u, alpha_d, alpha_s):
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/adjoint_2d_cylindrical/taylor_test.py
+++ b/demos/adjoint_2d_cylindrical/taylor_test.py
@@ -78,7 +78,7 @@ def annulus_taylor_test(case):
     X = SpatialCoordinate(mesh)
     r = sqrt(X[0] ** 2 + X[1] ** 2)
     Ra = Constant(1e7)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=False)
 
     # Define time stepping parameters:
     max_timesteps = 200
@@ -162,7 +162,6 @@ def annulus_taylor_test(case):
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/demos/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -62,7 +62,7 @@ def model(level, nn, do_write=False):
     g = Constant(1.0)  # Overall scaling of delta forcing
     T = Constant(0.0)
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'un': 0},
         top_id: {'un': 0},
@@ -72,10 +72,15 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/demos/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -62,7 +62,7 @@ def model(level, nn, do_write=False):
     g = Constant(1.0)  # Overall scaling of delta forcing
     T = Constant(0.0)
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'un': 0},
         top_id: {'un': 0},
@@ -72,10 +72,15 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/demos/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -62,7 +62,7 @@ def model(level, nn, do_write=False):
     g = Constant(1.0)  # Overall scaling of delta forcing
     T = Constant(0.0)
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'u': 0},
         top_id: {'u': 0},
@@ -72,10 +72,15 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/demos/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -62,7 +62,7 @@ def model(level, nn, do_write=False):
     g = Constant(1.0)  # Overall scaling of delta forcing
     T = Constant(0.0)
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'u': 0},
         top_id: {'u': 0},
@@ -72,10 +72,15 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/demos/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -61,7 +61,7 @@ def model(level, k, nn, do_write=False):
 
     T = -r**k/rmax**k*cos(nn*phi)  # RHS
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'un': 0},
         top_id: {'un': 0},
@@ -71,10 +71,15 @@ def model(level, k, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/demos/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -61,7 +61,7 @@ def model(level, k, nn, do_write=False):
 
     T = -r**k/rmax**k*cos(nn*phi)  # RHS
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'u': 0},
         top_id: {'u': 0},
@@ -71,10 +71,15 @@ def model(level, k, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/demos/analytical_comparisons/smooth_spherical_freeslip.py
+++ b/demos/analytical_comparisons/smooth_spherical_freeslip.py
@@ -67,7 +67,7 @@ def model(level, l, mm, k, do_write=False):
 
     T = -rhop  # RHS
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'un': 0},
         top_id: {'un': 0},
@@ -77,10 +77,15 @@ def model(level, l, mm, k, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9

--- a/demos/analytical_comparisons/smooth_spherical_zeroslip.py
+++ b/demos/analytical_comparisons/smooth_spherical_zeroslip.py
@@ -67,7 +67,7 @@ def model(level, l, mm, k, do_write=False):
 
     T = -rhop  # RHS
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=False)
     stokes_bcs = {
         bottom_id: {'u': 0},
         top_id: {'u': 0},
@@ -77,10 +77,15 @@ def model(level, l, mm, k, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9

--- a/demos/base_case/base_case.py
+++ b/demos/base_case/base_case.py
@@ -31,7 +31,7 @@ delta_t = Constant(1e-6)  # Initial time-step
 
 # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
 Ra = Constant(1e4)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=True)
 
 time = 0.0
 steady_state_tolerance = 1e-9
@@ -73,9 +73,15 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace=Z_nullspace,
+    transpose_nullspace=Z_nullspace,
+)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/demos/parallel_scaling/stokes_cubed_sphere.py
+++ b/demos/parallel_scaling/stokes_cubed_sphere.py
@@ -55,7 +55,7 @@ def model(ref_level, nlayers, delta_t, steps=None):
                   (eps_c*cos(m*theta) + eps_s*sin(m*theta)) * Plm * sin(pi*(r - rmin)/(rmax-rmin)))
 
     Ra = Constant(7e3)  # Rayleigh number
-    approximation = BoussinesqApproximation(Ra)
+    approximation = BoussinesqApproximation(Ra, cartesian=False)
     mu = exp(4.605170185988092 * (0.5 - T))
 
     delta_t = Constant(delta_t)  # Initial time-step
@@ -81,10 +81,16 @@ def model(ref_level, nlayers, delta_t, steps=None):
     energy_solver.solver_parameters['ksp_view'] = None
     energy_solver.solver_parameters['ksp_rtol'] = 1e-7
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs, mu=mu,
-                                 cartesian=False,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        mu=mu,
+        nullspace=Z_nullspace,
+        transpose_nullspace=Z_nullspace,
+        near_nullspace=Z_near_nullspace,
+    )
 
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_converged_reason'] = None
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_monitor_true_residual'] = None

--- a/demos/scalar_advection/scalar_advection.py
+++ b/demos/scalar_advection/scalar_advection.py
@@ -74,7 +74,7 @@ q_in = Constant(1.0)
 # Use G-ADOPT's Energy Solver to advect the tracer. By setting the Rayleigh number to 1
 # the choice of units is up to the user. We set the diffusiviy to zero for pure advection.
 # We also apply weak boundary conditions on inflow regions.
-approximation = BoussinesqApproximation(Ra=1, kappa=Constant(0))
+approximation = BoussinesqApproximation(Ra=1, cartesian=True, kappa=Constant(0))
 bc_in = {'q': q_in}
 bcs = {1: bc_in, 2: bc_in, 3: bc_in, 4: bc_in}
 energy_solver = EnergySolver(q, u, approximation, dt, DIRK33, bcs=bcs, su_advection=True)

--- a/demos/scalar_advection_diffusion/scalar_advection_diffusion.py
+++ b/demos/scalar_advection_diffusion/scalar_advection_diffusion.py
@@ -61,7 +61,7 @@ dt = T/600.0
 # the choice of units is up to the user. We use the diagonaly implicit DIRK33 Runge-Kutta
 # method for timestepping. 'T' means that the boundary conditions will be applied strongly
 # by the energy solver.
-approximation = BoussinesqApproximation(Ra=1, kappa=kappa)
+approximation = BoussinesqApproximation(Ra=1, cartesian=True, kappa=kappa)
 q_top = 1.0
 q_bottom = 0.0
 bcs = {3: {'T': q_bottom}, 4: {'T': q_top}}

--- a/demos/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
+++ b/demos/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
@@ -47,7 +47,7 @@ dt = 0.01
 # the choice of units is up to the user. We use the diagonaly implicit DIRK33 Runge-Kutta
 # method for timestepping. 'T' means that the boundary conditions will be applied strongly
 # by the energy solver.
-approximation = BoussinesqApproximation(Ra=1, kappa=kappa)
+approximation = BoussinesqApproximation(Ra=1, cartesian=True, kappa=kappa)
 # strongly applied dirichlet bcs on top and bottom
 q_left = conditional(y < 0.2, 0.0, 1.0)
 q_bottom = 0

--- a/demos/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
+++ b/demos/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
@@ -65,7 +65,7 @@ def model(n, Pe=0.25, su_advection=True, do_write=False):
 
     # Use G-ADOPT's Energy Solver to advect the tracer. By setting the Rayleigh number to 1
     # the choice of units is up to the user.
-    approximation = BoussinesqApproximation(Ra=1, kappa=kappa)
+    approximation = BoussinesqApproximation(Ra=1, cartesian=True, kappa=kappa)
     approximation.energy_source = Constant(1)  # Provide a source term to force the equations.
 
     energy_solver = EnergySolver(q, u, approximation, dt, DIRK33, bcs=bcs, su_advection=su_advection)

--- a/demos/viscoplastic_case/viscoplastic_case.py
+++ b/demos/viscoplastic_case/viscoplastic_case.py
@@ -32,7 +32,7 @@ t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_toleranc
 
 # Stokes related constants (note that since these are included in UFL, they are wrapped inside Constant):
 Ra = Constant(100)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = BoussinesqApproximation(Ra, cartesian=True)
 # Rheology:
 gamma_T, gamma_Z = Constant(ln(10**5)), Constant(ln(10))
 mu_star, sigma_y = Constant(0.001), Constant(1.0)
@@ -81,9 +81,15 @@ stokes_bcs = {
 }
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs, mu=mu,
-                             cartesian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    mu=mu,
+    nullspace=Z_nullspace,
+    transpose_nullspace=Z_nullspace,
+)
 
 checkpoint_file = CheckpointFile("Checkpoint_State.h5", "w")
 checkpoint_file.save_mesh(mesh)

--- a/gadopt/approximations.py
+++ b/gadopt/approximations.py
@@ -128,6 +128,9 @@ class BoussinesqApproximation(BaseApproximation):
 
     Arguments:
       Ra:    Rayleigh number
+      cartesian:
+        - True: gravity is assumed to point in the negative z-direction
+        - False: gravity is assumed to point radially inward
       kappa: thermal diffusivity
       g:     gravitational acceleration
       rho:   reference density
@@ -145,12 +148,15 @@ class BoussinesqApproximation(BaseApproximation):
     def __init__(
         self,
         Ra: Function | Number,
+        *,
+        cartesian: bool,
         kappa: Function | Number = 1,
         g: Function | Number = 1,
         rho: Function | Number = 1,
-        alpha: Function | Number = 1
+        alpha: Function | Number = 1,
     ):
         self.Ra = ensure_constant(Ra)
+        self.cartesian = cartesian
         self.thermal_diffusivity = ensure_constant(kappa)
         self.g = ensure_constant(g)
         self.rho = ensure_constant(rho)
@@ -186,9 +192,6 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
       Di: Dissipation number
       mu: dynamic viscosity
       H:  volumetric heat production
-      cartesian:
-        - True: gravity is assumed to point in the negative z-direction
-        - False: gravity is assumed to point radially inward
 
     Keyword Arguments:
       kappa (Number): thermal diffusivity
@@ -204,12 +207,19 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
     """
     compressible = False
 
-    def __init__(self, Ra: Number, Di: Number, mu: Number = 1, H: Optional[Number] = None, cartesian: bool = True, **kwargs):
+    def __init__(
+        self,
+        Ra: Number,
+        Di: Number,
+        *,
+        mu: Number = 1,
+        H: Optional[Number] = None,
+        **kwargs,
+    ):
         super().__init__(Ra, **kwargs)
         self.Di = Di
         self.mu = mu
         self.H = H
-        self.cartesian = cartesian
 
     def viscous_dissipation(self, u):
         stress = 2 * self.mu * sym(grad(u))
@@ -264,16 +274,19 @@ class TruncatedAnelasticLiquidApproximation(ExtendedBoussinesqApproximation):
     """
     compressible = True
 
-    def __init__(self,
-                 Ra: Number,
-                 Di: Number,
-                 Tbar: Function | Number = 0,
-                 chi: Function | Number = 1,
-                 cp: Function | Number = 1,
-                 gamma0: Function | Number = 1,
-                 cp0: Function | Number = 1,
-                 cv0: Function | Number = 1,
-                 **kwargs):
+    def __init__(
+        self,
+        Ra: Number,
+        Di: Number,
+        *,
+        Tbar: Function | Number = 0,
+        chi: Function | Number = 1,
+        cp: Function | Number = 1,
+        gamma0: Function | Number = 1,
+        cp0: Function | Number = 1,
+        cv0: Function | Number = 1,
+        **kwargs,
+    ):
         super().__init__(Ra, Di, **kwargs)
         self.Tbar = Tbar
         # Equation of State:

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -138,10 +138,10 @@ class StokesSolver:
         z: fd.Function,
         T: fd.Function,
         approximation: BaseApproximation,
+        *,
         bcs: dict[int, dict[str, int | float]] = {},
         mu: fd.Function | int | float = 1,
         quad_degree: int = 6,
-        cartesian: bool = True,
         solver_parameters: Optional[dict[str, str | Number] | str] = None,
         J: Optional[fd.Function] = None,
         constant_jacobian: bool = False,
@@ -161,7 +161,7 @@ class StokesSolver:
 
         self.solver_kwargs = kwargs
         u, p = fd.split(self.solution)
-        self.k = upward_normal(self.Z.mesh(), cartesian)
+        self.k = upward_normal(self.Z.mesh(), approximation.cartesian)
         self.fields = {
             'velocity': u,
             'pressure': p,
@@ -216,7 +216,7 @@ class StokesSolver:
                         raise ValueError(
                             f"Solver type '{solver_parameters}' not implemented."
                         )
-            elif self.mesh.topological_dimension() == 2 and cartesian:
+            elif self.mesh.topological_dimension() == 2 and approximation.cartesian:
                 self.solver_parameters.update(direct_stokes_solver_parameters)
             else:
                 self.solver_parameters.update(iterative_stokes_solver_parameters)

--- a/tests/test_stokes_solver_configuration.py
+++ b/tests/test_stokes_solver_configuration.py
@@ -21,7 +21,7 @@ def test_solver_parameters_argument():
     func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
     temperature = fd.Function(func_space_temp, name="Temperature")
 
-    approximation = BoussinesqApproximation(1)
+    approximation = BoussinesqApproximation(1, cartesian=True)
 
     base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
     example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
@@ -35,7 +35,6 @@ def test_solver_parameters_argument():
         "linear_false",
     ]:
         mu = 1
-        cartesian = True
 
         match test_case:
             case "unspecified":
@@ -57,7 +56,7 @@ def test_solver_parameters_argument():
                 solver_parameters = example_solver_params
                 expected_value = example_solver_params
             case "cartesian_false":
-                cartesian = False
+                approximation.cartesian = False
                 solver_parameters = None
                 expected_value = (
                     base_linear_params_with_log | iterative_stokes_solver_parameters
@@ -77,7 +76,6 @@ def test_solver_parameters_argument():
             temperature,
             approximation,
             mu=mu,
-            cartesian=cartesian,
             solver_parameters=solver_parameters,
         )
 


### PR DESCRIPTION
`cartesian` is currently supplied to `StokesSolver` and any approximation inheriting from `ExtendedBoussinesqApproximation`. In both cases, it is an optional argument that defaults to `True`. The current situation may lead to confusion. When setting up a non-Cartesian simulation, one may well omit to supply `cartesian=False` to either of the approximation and Stokes solver without any complaint from G-ADOPT. Moreover, one could assume that `cartesian` does not apply to `BoussinesqApproximation` when, in fact, it indirectly does through `StokesSolver`.

The present PR enforces `cartesian` as a required argument for all approximations and removes it from `StokesSolver`'s argument list.

@drhodrid and @sghelichkhani, please feel free to add more information.