### PR TITLE
Convert GeodynamicalDiagnostics to accept a mixed function

### DIFF
--- a/demos/2d_compressible_ALA/compressible_case_ALA.py
+++ b/demos/2d_compressible_ALA/compressible_case_ALA.py
@@ -1,5 +1,4 @@
 from gadopt import *
-from mpi4py import MPI
 
 # Set up geometry:
 nx, ny = 40, 40
@@ -76,7 +75,7 @@ plog.log_str(
     "nu_top energy avg_t rate_work_g rate_viscous energy_2"
 )
 
-gd = GeodynamicalDiagnostics(u, p, FullT, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, FullT, bottom_id, top_id)
 
 
 temp_bcs = {
@@ -119,9 +118,7 @@ for timestep in range(0, max_timesteps):
     # Compute diagnostics:
     u_rms = gd.u_rms()
     u_rms_surf = gd.u_rms_top()
-    bcu = DirichletBC(u.function_space(), 0, top_id)
-    ux_max = u.dat.data_ro_with_halos[bcu.nodes, 0].max(initial=0)
-    ux_max = u.comm.allreduce(ux_max, MPI.MAX)  # Maximum Vx at surface
+    ux_max = gd.ux_max(top_id)
     nusselt_number_top = gd.Nu_top()
     nusselt_number_base = gd.Nu_bottom()
     energy_conservation = abs(abs(nusselt_number_top) - abs(nusselt_number_base))

--- a/demos/2d_compressible_TALA/compressible_case_TALA.py
+++ b/demos/2d_compressible_TALA/compressible_case_TALA.py
@@ -1,5 +1,4 @@
 from gadopt import *
-from mpi4py import MPI
 
 # Set up geometry:
 nx, ny = 40, 40
@@ -77,7 +76,7 @@ plog.log_str(
     "nu_top energy avg_t rate_work_g rate_viscous energy_2"
 )
 
-gd = GeodynamicalDiagnostics(u, p, FullT, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, FullT, bottom_id, top_id)
 
 
 temp_bcs = {
@@ -120,9 +119,7 @@ for timestep in range(0, max_timesteps):
     # Compute diagnostics:
     u_rms = gd.u_rms()
     u_rms_surf = gd.u_rms_top()
-    bcu = DirichletBC(u.function_space(), 0, top_id)
-    ux_max = u.dat.data_ro_with_halos[bcu.nodes, 0].max(initial=0)
-    ux_max = u.comm.allreduce(ux_max, MPI.MAX)  # Maximum Vx at surface
+    ux_max = gd.ux_max(top_id)
     nusselt_number_top = gd.Nu_top()
     nusselt_number_base = gd.Nu_bottom()
     energy_conservation = abs(abs(nusselt_number_top) - abs(nusselt_number_base))

--- a/demos/3d_cartesian/3d_cartesian.py
+++ b/demos/3d_cartesian/3d_cartesian.py
@@ -1,5 +1,4 @@
 from gadopt import *
-from mpi4py import MPI
 
 # Set up geometry:
 a, b, c = 1.0079, 0.6283, 1.0
@@ -60,7 +59,7 @@ checkpoint_period = dump_period * 4
 plog = ParameterLog('params.log', mesh)
 plog.log_str("timestep time dt maxchange u_rms u_rms_top ux_max nu_top nu_base energy avg_t")
 
-gd = GeodynamicalDiagnostics(u, p, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 
 temp_bcs = {
     bottom_id: {'T': 1.0},
@@ -106,9 +105,7 @@ for timestep in range(0, max_timesteps):
     energy_solver.solve()
 
     # Compute diagnostics:
-    bcu = DirichletBC(u.function_space(), 0, top_id)
-    ux_max = u.dat.data_ro_with_halos[bcu.nodes, 0].max(initial=0)
-    ux_max = u.comm.allreduce(ux_max, MPI.MAX)  # Maximum Vx at surface
+    ux_max = gd.ux_max(top_id)
     nusselt_number_top = gd.Nu_top()
     nusselt_number_base = gd.Nu_bottom()
     energy_conservation = abs(abs(nusselt_number_top) - abs(nusselt_number_base))

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -89,7 +89,7 @@ checkpoint_period = dump_period * 4
 plog = ParameterLog('params.log', mesh)
 plog.log_str("timestep time dt maxchange u_rms nu_top nu_base energy avg_t t_dev_avg")
 
-gd = GeodynamicalDiagnostics(u, p, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_tolerance=1.5)
 
 temp_bcs = {

--- a/demos/base_case/base_case.py
+++ b/demos/base_case/base_case.py
@@ -1,5 +1,4 @@
 from gadopt import *
-from mpi4py import MPI
 
 # Set up geometry:
 nx, ny = 40, 40
@@ -56,7 +55,7 @@ checkpoint_period = dump_period * 4
 plog = ParameterLog('params.log', mesh)
 plog.log_str("timestep time dt maxchange u_rms u_rms_surf ux_max nu_top nu_base energy avg_t")
 
-gd = GeodynamicalDiagnostics(u, p, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 t_adapt = TimestepAdaptor(delta_t, u, V, maximum_timestep=0.1, increase_tolerance=1.5)
 
 
@@ -97,9 +96,7 @@ for timestep in range(0, max_timesteps):
     energy_solver.solve()
 
     # Compute diagnostics:
-    bcu = DirichletBC(u.function_space(), 0, top_id)
-    ux_max = u.dat.data_ro_with_halos[bcu.nodes, 0].max(initial=0)
-    ux_max = u.comm.allreduce(ux_max, MPI.MAX)  # Maximum Vx at surface
+    ux_max = gd.ux_max(top_id)
     nusselt_number_top = gd.Nu_top()
     nusselt_number_base = gd.Nu_bottom()
     energy_conservation = abs(abs(nusselt_number_top) - abs(nusselt_number_base))

--- a/demos/viscoplastic_case/viscoplastic_case.py
+++ b/demos/viscoplastic_case/viscoplastic_case.py
@@ -1,5 +1,4 @@
 from gadopt import *
-from mpi4py import MPI
 
 # Set up geometry:
 nx, ny = 40, 40
@@ -65,7 +64,7 @@ checkpoint_period = dump_period * 4
 plog = ParameterLog('params.log', mesh)
 plog.log_str("timestep time dt maxchange u_rms u_rms_surf ux_max nu_top nu_base energy avg_t")
 
-gd = GeodynamicalDiagnostics(u, p, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 
 
 temp_bcs = {
@@ -105,9 +104,7 @@ for timestep in range(0, max_timesteps):
     energy_solver.solve()
 
     # Compute diagnostics:
-    bcu = DirichletBC(u.function_space(), 0, top_id)
-    ux_max = u.dat.data_ro_with_halos[bcu.nodes, 0].max(initial=0)
-    ux_max = u.comm.allreduce(ux_max, MPI.MAX)  # Maximum Vx at surface
+    ux_max = gd.ux_max(top_id)
     nusselt_number_top = gd.Nu_top()
     nusselt_number_base = gd.Nu_bottom()
     energy_conservation = abs(abs(nusselt_number_top) - abs(nusselt_number_base))

--- a/gadopt/diagnostics.py
+++ b/gadopt/diagnostics.py
@@ -8,8 +8,7 @@ class GeodynamicalDiagnostics:
     """Typical simulation diagnostics used in geodynamical simulations.
 
     Arguments:
-      u:         Firedrake function for the velocity
-      p:         Firedrake function for the pressure
+      z:         Firedrake function for the mixed Stokes function space
       T:         Firedrake function for the temperature
       bottom_id: bottom boundary identifier.
       top_id:    top boundary identifier.
@@ -30,16 +29,14 @@ class GeodynamicalDiagnostics:
 
     def __init__(
         self,
-        u: Function,
-        p: Function,
+        z: Function,
         T: Function,
         bottom_id: int,
         top_id: int,
         degree: int = 4
     ):
-        self.mesh = extract_unique_domain(u)
-        self.u = u
-        self.p = p
+        self.mesh = extract_unique_domain(z)
+        self.u, self.p, *_ = z.subfunctions
         self.T = T
 
         self.dx = firedrake.dx(degree=degree)


### PR DESCRIPTION
Instead of splitting our mixed function `z` and then passing `u` and `p` around (e.g. to `GeodynamicalDiagnostics`), it seems to make more sense to provide it with `z` directly. We have precedent for this already in `StokesSolver`, especially with the free surface fields coming in #51.

Additionally, instead of exposing some of the gory MPI internals in our demos, I've pushed that into a `ux_max` diagnostic, which can be given a surface ID. I think related to the discussion in #74, this would be better off knowing what the "lateral" direction is, as it just makes the cartesian assumption at the moment.