### PR TITLE
Add diagram showing relationship of demos

### DIFF
--- a/demos/.diagram.mermaid
+++ b/demos/.diagram.mermaid
@@ -1,0 +1,38 @@
+graph TD
+  base[Base]
+
+  subgraph physical[Physical]
+  ala[ALA] --> tala[TALA]
+  viscoplastic[Viscoplastic]
+  end
+
+  subgraph dimension[Dimension]
+  cartesian_3d[3D Cartesian]
+  end
+
+  subgraph geometry[Geometry]
+  cylindrical_2d[2D Cylindrical] --> spherical_3d[3D Spherical]
+  end
+
+  subgraph multimaterial[Multi-material]
+  isothermal["2-Material (isothermal)"] --> thermochemical["2-Material (thermochemical)"]
+  end
+
+  subgraph adjoint[Adjoint]
+  inverse[Inverse]
+  end
+
+  base --> physical
+  base --> dimension
+  base --> geometry
+  base --> multimaterial
+  base ~~~ adjoint
+
+  click base "base_case"
+  click ala "2d_compressible_ALA"
+  click tala "2d_compressible_TALA"
+  click viscoplastic "viscoplastic_case"
+  click cartesian_3d "3d_cartesian"
+  click cylindrical_2d "2d_cylindrical"
+  click isothermal "compositional_buoyancy"
+  click thermochemical "thermochemical_buoyancy"


### PR DESCRIPTION
I've already put a `.pages` file in the demos directory that is used for the table of contents that shows up on the documentation site. I think that, and this diagram make more sense here because they can be updated alongside the demos.

Diagram is rendered here: https://10f9be33.g-adopt.pages.dev/tutorials/

Also has links to the tutorials that show up in the hierarchy, plus adjoint on the side (without a link until #80 goes in).