### PR TITLE
A fix for vertical_component and upward_normal in 3d extruded meshes.

### DIFF
--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -91,7 +91,7 @@ def upward_normal(mesh, cartesian):
         return as_vector([0]*(n-1) + [1])
     else:
         X = SpatialCoordinate(mesh)
-        r = sqrt(dot(X, X))
+        r = sqrt(sum([x ** 2 for x in X]))
         return X/r
 
 
@@ -100,7 +100,7 @@ def vertical_component(u, cartesian):
         return u[u.ufl_shape[0]-1]
     else:
         n = upward_normal(extract_unique_domain(u), cartesian)
-        return dot(n, u)
+        return sum([n_i * u_i for n_i, u_i in zip(n, u)])
 
 
 def ensure_constant(f):


### PR DESCRIPTION
Currently the following code fails because of [this issue](https://github.com/firedrakeproject/firedrake/issues/3652) from tsfc: 

```python3
from gadopt.utility import vertical_component
from gadopt import *

mesh2d = CubedSphereMesh(1, refinement_level=1, degree=2)
mesh = ExtrudedMesh(mesh2d, layers=2, extrusion_type='radial')

Q = FunctionSpace(mesh, "CG", 1)  # Temperature function space (scalar)
upward_component = vertical_component(SpatialCoordinate(mesh), cartesian=False)
q = Function(Q, name="r")
q.interpolate(upward_component)
```

The change just rewrites the UFL for the two inner products.