### PR TITLE
Force SuperLU_DIST on compressible demos

### DIFF
--- a/demos/2d_compressible_ALA/Makefile
+++ b/demos/2d_compressible_ALA/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: 2d_compressible_ALA.py
 	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< -Stokes_pc_factor_mat_solver_type superlu_dist
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/2d_compressible_TALA/Makefile
+++ b/demos/2d_compressible_TALA/Makefile
@@ -4,7 +4,7 @@ ncpus := 4
 
 params.log: 2d_compressible_TALA.py
 	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< -Stokes_pc_factor_mat_solver_type superlu_dist
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log


### PR DESCRIPTION
There's some kind of parallel ordering bug with the MUMPS+METIS combo for direct solves that seems to pop up in particular on these test cases. Using a different solver (e.g. SuperLU_DIST) avoids this issue. The other option would be PaStiX, but it segfaults on the compressible demos. We can't enable superlu globally, because that affects convergence on one of our tests, causing the CI to time out (see https://github.com/g-adopt/g-adopt/actions/runs/9900787219/job/27352140174). To avoid modifying the demo directly, we perform the solver override only when running the demo in its test configuration.