### PR TITLE
Add render workflow

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,0 +1,48 @@
+name: Render demo notebooks
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  render:
+    runs-on: self-hosted
+    container:
+      image: firedrakeproject/firedrake:latest
+      options: --shm-size 2g
+
+    env:
+      OMP_NUM_THREADS: 1
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y xvfb gmsh
+          . /home/firedrake/firedrake/bin/activate
+          python3 -m pip install nbval nbconvert jupytext
+          python3 -m pip install .[demos]
+          python3 -m ipykernel install --name firedrake --user
+      - name: Convert notebooks
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          export DISPLAY=:99
+          export PYVISTA_OFF_SCREEN=true
+          export LIBGL_ALWAYS_SOFTWARE=true
+          Xvfb $DISPLAY -screen 0 1024x768x24 > /dev/null 2>&1 &
+          sleep 3
+          make -j convert_demos
+          rm -rf rendered && mkdir rendered
+          find demos -name '*.ipynb' -exec cp "{}" rendered \;
+          cp demos/.pages rendered
+          cp demos/.diagram.mermaid rendered
+        env:
+          GADOPT_LOGLEVEL: WARN
+      - uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: notebooks
+          path: rendered


### PR DESCRIPTION
Instead of rendering the demo notebooks as part of the website build, it makes more sense to render them in this repository, and provide the rendered results as artifacts.

As a first stage, this just adds the workflow to master so it can trigger. Then we can enable the dispatch on the website side, and then finally we can turn on the automatic dispatch here!