### PR TITLE
Make `cartesian` a mesh attribute

### DIFF
--- a/demos/2d_compressible_ALA/2d_compressible_ALA.py
+++ b/demos/2d_compressible_ALA/2d_compressible_ALA.py
@@ -101,6 +101,7 @@ from gadopt import *
 # +
 nx, ny = 40, 40  # Number of cells in x and y directions.
 mesh = UnitSquareMesh(nx, ny, quadrilateral=True)  # Square mesh generated via firedrake
+mesh.cartesian = True
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -202,7 +203,7 @@ energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
                              transpose_nullspace=Z_nullspace,
-                             cartesian=True, constant_jacobian=True)
+                             constant_jacobian=True)
 # -
 
 # Next initiate the time loop, which runs until a steady-state solution has been attained:

--- a/demos/2d_compressible_TALA/2d_compressible_TALA.py
+++ b/demos/2d_compressible_TALA/2d_compressible_TALA.py
@@ -27,6 +27,7 @@ from gadopt import *
 # +
 nx, ny = 40, 40  # Number of cells in x and y directions.
 mesh = UnitSquareMesh(nx, ny, quadrilateral=True)  # Square mesh generated via firedrake
+mesh.cartesian = True
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -128,7 +129,7 @@ energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             cartesian=True, constant_jacobian=True)
+                             constant_jacobian=True)
 # -
 
 # Next initiate the time loop, which runs until a steady-state solution has been attained:

--- a/demos/2d_cylindrical/2d_cylindrical.py
+++ b/demos/2d_cylindrical/2d_cylindrical.py
@@ -33,11 +33,14 @@ from gadopt import *
 # using the optional keyword argument `extrusion_type`, forming 32 layers. To better represent the
 # curvature of the domain and ensure accuracy of our quadratic representation of velocity, we
 # approximate the curved cylindrical shell domain quadratically, using the optional keyword argument `degree`$=2$.
+# Because this problem is not formulated in a Cartesian geometry, we set the `mesh.cartesian`
+# attribute to False. This ensures the correct configuration of a radially inward vertical direction.
 
 # +
 rmin, rmax, ncells, nlayers = 1.22, 2.22, 128, 32
 mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)  # construct a circle mesh
 mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type='radial')  # extrude into a cylinder
+mesh.cartesian = False
 bottom_id, top_id = "bottom", "top"
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -153,15 +156,13 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id, degree=6)
 # -
 
 # We can now setup and solve the variational problem, for both the energy and Stokes equations,
-# passing in the approximation, nullspace and near-nullspace information configured above. We also
-# set the optional `cartesian` keyword argument to False, which ensures that the unit vector points radially,
-# in the direction opposite to gravity.
+# passing in the approximation, nullspace and near-nullspace information configured above.
 
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, constant_jacobian=True,
+                             constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 # -

--- a/demos/3d_cartesian/3d_cartesian.py
+++ b/demos/3d_cartesian/3d_cartesian.py
@@ -42,6 +42,7 @@ a, b, c = 1.0079, 0.6283, 1.0
 nx, ny, nz = 10, int(b/c * 10), 10
 mesh2d = RectangleMesh(nx, ny, a, b, quadrilateral=True)  # Rectangular 2D mesh
 mesh = ExtrudedMesh(mesh2d, nz)
+mesh.cartesian = True
 bottom_id, top_id, left_id, right_id, front_id, back_id = "bottom", "top", 1, 2, 3, 4
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -156,7 +157,7 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=True, constant_jacobian=True,
+                             constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 # -

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -23,12 +23,15 @@ import math
 # as with our previous tutorials. For the mesh, we use Firedrake's built-in *CubedSphereMesh* and extrude it radially through
 # 8 layers, forming hexahedral elements. As with our cylindrical shell example, we approximate the curved spherical domain quadratically,
 # using the optional keyword argument *degree$=2$*.
+# Because this problem is not formulated in a Cartesian geometry, we set the `mesh.cartesian`
+# attribute to False. This ensures the correct configuration of a radially inward vertical direction.
 
 # +
 rmin, rmax, ref_level, nlayers = 1.208, 2.208, 4, 8
 
 mesh2d = CubedSphereMesh(rmin, refinement_level=ref_level, degree=2)
 mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type='radial')
+mesh.cartesian = False
 bottom_id, top_id = "bottom", "top"
 domain_volume = assemble(1*dx(domain=mesh))  # Required for a diagnostic calculation.
 
@@ -88,7 +91,7 @@ T.interpolate(conductive_term +
 
 # Compute layer average for initial temperature field, using the LayerAveraging functionality provided by G-ADOPT.
 
-averager = LayerAveraging(mesh, cartesian=False, quad_degree=6)
+averager = LayerAveraging(mesh, quad_degree=6)
 averager.extrapolate_layer_average(T_avg, averager.get_layer_average(T))
 
 # Nullspaces and near-nullspace objects are next set up,
@@ -124,15 +127,13 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id, degree=6)
 # -
 
 # We can now setup and solve the variational problem, for both the energy and Stokes equations,
-# passing in the approximation, nullspace and near-nullspace information configured above. We also
-# set the optional `cartesian` keyword argument to False, which ensures that the unit vector points radially,
-# in the direction opposite to gravity.
+# passing in the approximation, nullspace and near-nullspace information configured above.
 
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             cartesian=False, constant_jacobian=True,
+                             constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 # -

--- a/demos/adjoint/forward.py
+++ b/demos/adjoint/forward.py
@@ -18,6 +18,7 @@ mesh1d = IntervalMesh(disc_n, length_or_left=0.0, right=x_max)
 mesh = ExtrudedMesh(
     mesh1d, layers=disc_n, layer_height=y_max / disc_n, extrusion_type="uniform"
 )
+mesh.cartesian = True
 
 # write out the mesh
 with CheckpointFile("mesh.h5", mode="w") as fi:
@@ -48,7 +49,7 @@ Taverage = Function(Q1, name="Average Temperature")
 
 # Calculate the layer average of the initial state
 averager = LayerAveraging(
-    mesh, np.linspace(0, 1.0, 150 * 2), cartesian=True, quad_degree=6
+    mesh, np.linspace(0, 1.0, 150 * 2), quad_degree=6
 )
 averager.extrapolate_layer_average(Taverage, averager.get_layer_average(T))
 

--- a/demos/adjoint/inverse.py
+++ b/demos/adjoint/inverse.py
@@ -45,6 +45,7 @@ def inverse(alpha_u, alpha_d, alpha_s):
 
     with CheckpointFile("mesh.h5", "r") as f:
         mesh = f.load_mesh("firedrake_default_extruded")
+        mesh.cartesian = True
 
     bottom_id, top_id, left_id, right_id = "bottom", "top", 1, 2
     X = SpatialCoordinate(mesh)

--- a/demos/adjoint/taylor_test.py
+++ b/demos/adjoint/taylor_test.py
@@ -33,6 +33,7 @@ def rectangle_taylor_test(case):
 
     with CheckpointFile("mesh.h5", "r") as f:
         mesh = f.load_mesh("firedrake_default_extruded")
+        mesh.cartesian = True
 
     bottom_id, top_id, left_id, right_id = "bottom", "top", 1, 2
 

--- a/demos/adjoint_2d_cylindrical/forward.py
+++ b/demos/adjoint_2d_cylindrical/forward.py
@@ -39,6 +39,7 @@ def run_forward():
     # Start with a previously-initialised temperature field
     with CheckpointFile("Checkpoint230.h5", mode="r") as f:
         mesh = f.load_mesh("firedrake_default_extruded")
+        mesh.cartesian = False
 
     # Set up function spaces for the Q2Q1 pair
     V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -103,7 +104,7 @@ def run_forward():
 
     # Calculate the layer average of the initial state
     averager = LayerAveraging(
-        mesh, np.linspace(rmin, rmax, nlayers * 2), cartesian=False, quad_degree=6
+        mesh, np.linspace(rmin, rmax, nlayers * 2), quad_degree=6
     )
     averager.extrapolate_layer_average(Taverage, averager.get_layer_average(T))
 
@@ -137,7 +138,6 @@ def run_forward():
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/adjoint_2d_cylindrical/inverse.py
+++ b/demos/adjoint_2d_cylindrical/inverse.py
@@ -61,6 +61,7 @@ def inverse(alpha_u, alpha_d, alpha_s):
 
     with CheckpointFile("Checkpoint_State.h5", "r") as f:
         mesh = f.load_mesh("firedrake_default_extruded")
+        mesh.cartesian = False
 
     enable_disk_checkpointing()
 
@@ -160,7 +161,6 @@ def inverse(alpha_u, alpha_d, alpha_s):
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/adjoint_2d_cylindrical/taylor_test.py
+++ b/demos/adjoint_2d_cylindrical/taylor_test.py
@@ -61,6 +61,7 @@ def annulus_taylor_test(case):
 
     with CheckpointFile("Checkpoint230.h5", "r") as f:
         mesh = f.load_mesh("firedrake_default_extruded")
+        mesh.cartesian = False
 
     enable_disk_checkpointing()
 
@@ -162,7 +163,6 @@ def annulus_taylor_test(case):
         approximation,
         mu=mu,
         bcs=stokes_bcs,
-        cartesian=False,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/demos/base_case/base_case.py
+++ b/demos/base_case/base_case.py
@@ -162,9 +162,15 @@ from gadopt import *
 # corresponds to the plane $x=0$; 2 to the $x=1$ plane; 3 to the $y=0$ plane;
 # and 4 to the $y=1$ plane. We name these `left`, `right`, `bottom` and `top`,
 # respectively.
+#
+# On the mesh, we also denote that our geometry is Cartesian, i.e. gravity points
+# in the negative z-direction. This attribute is used by gadopt specifically, not
+# Firedrake. By contrast, a non-Cartesian geometry is assumed to have gravity
+# pointing in the radially inward direction.
 
 nx, ny = 40, 40  # Number of cells in x and y directions.
 mesh = UnitSquareMesh(nx, ny, quadrilateral=True)  # Square mesh generated via firedrake
+mesh.cartesian = True
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 
 # We also need function spaces, which is achieved by associating the
@@ -326,7 +332,7 @@ energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             cartesian=True, constant_jacobian=True)
+                             constant_jacobian=True)
 # -
 
 # We can now initiate the time-loop, with the Stokes and energy

--- a/demos/gplates_global/gplates_global.py
+++ b/demos/gplates_global/gplates_global.py
@@ -38,6 +38,7 @@ rmin, rmax, ref_level, nlayers = 1.208, 2.208, 4, 8
 
 mesh2d = CubedSphereMesh(rmin, refinement_level=ref_level, degree=2)
 mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type="radial")
+mesh.cartesian = False
 bottom_id, top_id = "bottom", "top"
 domain_volume = assemble(1*dx(domain=mesh))  # Required for a diagnostic calculation.
 
@@ -79,7 +80,7 @@ if m == 0:
 T.interpolate(conductive_term +
               (eps_c*cos(m*theta) + eps_s*sin(m*theta)) * Plm * sin(pi*(r - rmin)/(rmax-rmin)))
 
-averager = LayerAveraging(mesh, cartesian=False, quad_degree=6)
+averager = LayerAveraging(mesh, quad_degree=6)
 averager.extrapolate_layer_average(T_avg, averager.get_layer_average(T))
 # -
 
@@ -96,7 +97,7 @@ averager.extrapolate_layer_average(T_avg, averager.get_layer_average(T))
 # provided by G-ADOPT to populate the viscosity field.
 
 mu = Function(Q, name="Viscosity")
-interpolate_1d_profile(function=mu, one_d_filename="mu2_radial.rad", cartesian=False)
+interpolate_1d_profile(function=mu, one_d_filename="mu2_radial.rad")
 
 # ## Nullspaces:
 #
@@ -258,7 +259,7 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id, degree=6)
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             mu=mu, cartesian=False, constant_jacobian=True,
+                             mu=mu, constant_jacobian=True,
                              nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                              near_nullspace=Z_near_nullspace)
 # -

--- a/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
+++ b/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
@@ -66,6 +66,7 @@ nx, ny = 40, 40  # Number of cells in x and y directions
 lx, ly = 0.9142, 1  # Domain dimensions in x and y directions
 # Rectangle mesh generated via Firedrake
 mesh = RectangleMesh(nx, ny, lx, ly, quadrilateral=True)
+mesh.cartesian = True
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)

--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -81,6 +81,7 @@ gmsh.finalize()
 
 # +
 mesh = Mesh(mesh_file)  # Load the GMSH mesh using Firedrake
+mesh.cartesian = True
 
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 

--- a/demos/scalar_advection/scalar_advection.py
+++ b/demos/scalar_advection/scalar_advection.py
@@ -7,6 +7,7 @@ from gadopt.time_stepper import DIRK33
 
 # We use a 40-by-40 mesh of squares.
 mesh = UnitSquareMesh(40, 40, quadrilateral=True)
+mesh.cartesian = True
 
 # We set up a function space of bilinear elements for :math:`q`, and
 # a vector-valued continuous function space for our velocity field. ::

--- a/demos/viscoplastic_case/viscoplastic_case.py
+++ b/demos/viscoplastic_case/viscoplastic_case.py
@@ -48,6 +48,7 @@ from gadopt import *
 # +
 nx, ny = 40, 40  # Number of cells in x and y directions.
 mesh = UnitSquareMesh(nx, ny, quadrilateral=True)  # Square mesh generated via firedrake
+mesh.cartesian = True
 left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
@@ -143,8 +144,7 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
 stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs, mu=mu,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             cartesian=True)
+                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
 # -
 
 # Next, we initiate the time loop, which runs until a steady-state solution has been attained.

--- a/gadopt/approximations.py
+++ b/gadopt/approximations.py
@@ -202,9 +202,6 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
       Di: Dissipation number
       mu: dynamic viscosity
       H:  volumetric heat production
-      cartesian:
-        - True: gravity is assumed to point in the negative z-direction
-        - False: gravity is assumed to point radially inward
 
     Keyword Arguments:
       kappa (Number): thermal diffusivity
@@ -220,12 +217,11 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
     """
     compressible = False
 
-    def __init__(self, Ra: Number, Di: Number, mu: Number = 1, H: Optional[Number] = None, cartesian: bool = True, **kwargs):
+    def __init__(self, Ra: Number, Di: Number, mu: Number = 1, H: Optional[Number] = None, **kwargs):
         super().__init__(Ra, **kwargs)
         self.Di = Di
         self.mu = mu
         self.H = H
-        self.cartesian = cartesian
 
     def viscous_dissipation(self, u):
         stress = 2 * self.mu * sym(grad(u))
@@ -235,7 +231,7 @@ class ExtendedBoussinesqApproximation(BoussinesqApproximation):
         return phi * self.Di / self.Ra
 
     def work_against_gravity(self, u, T):
-        w = vertical_component(u, self.cartesian)
+        w = vertical_component(u)
         return self.Di * self.alpha * self.rho * self.g * w * T
 
     def linearized_energy_sink(self, u):
@@ -268,9 +264,6 @@ class TruncatedAnelasticLiquidApproximation(ExtendedBoussinesqApproximation):
       alpha (Number): reference thermal expansion coefficient
       mu (Number):    viscosity used in viscous dissipation
       H (Number):     volumetric heat production - default 0
-      cartesian (bool):
-        - True: gravity points in negative z-direction
-        - False: gravity points radially inward
       kappa (Number):  diffusivity
       g (Number):      gravitational acceleration
 
@@ -305,7 +298,7 @@ class TruncatedAnelasticLiquidApproximation(ExtendedBoussinesqApproximation):
         return self.rho * self.cp
 
     def linearized_energy_sink(self, u):
-        w = vertical_component(u, self.cartesian)
+        w = vertical_component(u)
         return self.Di * self.rho * self.alpha * w
 
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -125,7 +125,6 @@ class StokesSolver:
       mu: Firedrake function representing dynamic viscosity
       quad_degree: Quadrature degree. Default value is `2p + 1`, where
                    p is the polynomial degree of the trial space
-      cartesian: Whether to use Cartesian coordinates
       solver_parameters: Either a dictionary of PETSc solver parameters or a string
                          specifying a default set of parameters defined in G-ADOPT
       J: Firedrake function representing the Jacobian of the system
@@ -143,7 +142,6 @@ class StokesSolver:
         bcs: dict[int, dict[str, Number]] = {},
         mu: fd.Function | Number = 1,
         quad_degree: int = 6,
-        cartesian: bool = True,
         solver_parameters: Optional[dict[str, str | Number] | str] = None,
         J: Optional[fd.Function] = None,
         constant_jacobian: bool = False,
@@ -164,7 +162,7 @@ class StokesSolver:
 
         self.solver_kwargs = kwargs
         u, p = fd.split(self.solution)
-        self.k = upward_normal(self.Z.mesh(), cartesian)
+        self.k = upward_normal(self.Z.mesh())
         self.fields = {
             'velocity': u,
             'pressure': p,
@@ -219,7 +217,7 @@ class StokesSolver:
                         raise ValueError(
                             f"Solver type '{solver_parameters}' not implemented."
                         )
-            elif self.mesh.topological_dimension() == 2 and cartesian:
+            elif self.mesh.topological_dimension() == 2 and self.mesh.cartesian:
                 self.solver_parameters.update(direct_stokes_solver_parameters)
             else:
                 self.solver_parameters.update(iterative_stokes_solver_parameters)

--- a/tests/Drucker-Prager_rheology/spiegelman.py
+++ b/tests/Drucker-Prager_rheology/spiegelman.py
@@ -32,6 +32,7 @@ def spiegelman(U0, mu1, nx, ny, picard_iterations, stabilisation=False):
     log('\n')
     log('WRITING TO:', output_dir)
     mesh = RectangleMesh(nx, ny, 4, 1, quadrilateral=True)  # Square mesh generated via firedrake
+    mesh.cartesian = True
     left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # noqa: F841 Boundary IDs
 
     # Set up function spaces - currently using the bilinear Q2Q1 element pair:

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -31,6 +31,7 @@ def model(level, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -70,7 +71,6 @@ def model(level, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -31,6 +31,7 @@ def model(level, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -70,7 +71,6 @@ def model(level, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -31,6 +31,7 @@ def model(level, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -70,7 +71,6 @@ def model(level, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -31,6 +31,7 @@ def model(level, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -70,7 +71,6 @@ def model(level, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -34,6 +34,7 @@ def model(level, k, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -69,7 +70,6 @@ def model(level, k, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -34,6 +34,7 @@ def model(level, k, nn, do_write=False):
     # Construct a circle mesh and then extrude into a cylinder:
     mesh1d = CircleManifoldMesh(ncells, radius=rmin, degree=2)
     mesh = ExtrudedMesh(mesh1d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -69,7 +70,6 @@ def model(level, k, nn, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/smooth_spherical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_freeslip.py
@@ -35,6 +35,7 @@ def model(level, l, mm, k, do_write=False):
     # Construct a cubed sphere mesh and then extrude into a sphere:
     mesh2d = CubedSphereMesh(radius=rmin, refinement_level=level, degree=2)
     mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -75,7 +76,6 @@ def model(level, l, mm, k, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/analytical_comparisons/smooth_spherical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_zeroslip.py
@@ -35,6 +35,7 @@ def model(level, l, mm, k, do_write=False):
     # Construct a cubed sphere mesh and then extrude into a sphere:
     mesh2d = CubedSphereMesh(radius=rmin, refinement_level=level, degree=2)
     mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type="radial")
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Define geometric quantities
@@ -75,7 +76,6 @@ def model(level, l, mm, k, do_write=False):
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
     # use tighter tolerances than default to ensure convergence:

--- a/tests/multi_material/run_benchmark.py
+++ b/tests/multi_material/run_benchmark.py
@@ -144,6 +144,9 @@ else:  # Initialise mesh and key functions
     time_now = 0
     dump_counter = 0
 
+# Whether we start from checkpoint or not, we annotate our mesh as cartesian
+mesh.cartesian = True
+
 # Extract velocity and pressure from the Stokes function
 velocity, pressure = fd.split(stokes_function)  # UFL expressions
 # Associated Firedrake functions

--- a/tests/parallel_scaling/stokes_cubed_sphere.py
+++ b/tests/parallel_scaling/stokes_cubed_sphere.py
@@ -10,6 +10,7 @@ def model(ref_level, nlayers, delta_t, steps=None):
     # Construct a CubedSphere mesh and then extrude into a sphere:
     mesh2d = CubedSphereMesh(rmin, refinement_level=ref_level, degree=2)
     mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type='radial')
+    mesh.cartesian = False
     bottom_id, top_id = "bottom", "top"
 
     # Set up function spaces - currently using the bilinear Q2Q1 element pair:
@@ -79,7 +80,6 @@ def model(ref_level, nlayers, delta_t, steps=None):
     energy_solver.solver_parameters['ksp_rtol'] = 1e-7
 
     stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs, mu=mu,
-                                 cartesian=False,
                                  nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
                                  near_nullspace=Z_near_nullspace)
 

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion.py
@@ -7,6 +7,7 @@ from gadopt.time_stepper import DIRK33
 
 # We use a 40-by-40 mesh of squares.
 mesh = UnitSquareMesh(40, 40, quadrilateral=True)
+mesh.cartesian = True
 
 # We set up a function space of bilinear elements for :math:`q`, and
 # a vector-valued continuous function space for our velocity field. ::

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
@@ -10,6 +10,7 @@ from gadopt.time_stepper import DIRK33
 
 nx, ny = 10, 10
 mesh = UnitSquareMesh(nx, ny, quadrilateral=True)
+mesh.cartesian = True
 
 # We set up a function space of discontinous bilinear elements for :math:`q`, and
 # a vector-valued continuous function space for our velocity field. ::

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
@@ -23,6 +23,7 @@ def model(n, Pe=0.25, su_advection=True, do_write=False):
         do_write: whether to output the scalar/velocity field
     """
     mesh = UnitSquareMesh(n, n, quadrilateral=True)
+    mesh.cartesian = True
 
     # We set up a function space of bilinear elements for :math:`q`, and
     # a vector-valued continuous function space for our velocity field. ::

--- a/tests/unit/test_interpolate_1d_profile.py
+++ b/tests/unit/test_interpolate_1d_profile.py
@@ -15,12 +15,13 @@ def test_oned_average_assignment_spherical(tmp_path):
 
     mesh2d = CubedSphereMesh(rmin, refinement_level=ref_level, degree=2)
     mesh = ExtrudedMesh(mesh2d, layers=nlayers, extrusion_type='radial')
+    mesh.cartesian = False
 
     X = SpatialCoordinate(mesh)
     Q = FunctionSpace(mesh, "CG", 1)
-    q = Function(Q).interpolate(vertical_component(X, cartesian=False))
+    q = Function(Q).interpolate(vertical_component(X))
 
-    averager = LayerAveraging(mesh, None, cartesian=False)
+    averager = LayerAveraging(mesh, None)
     q_profile = averager.get_layer_average(q)
 
     output_fi = ParameterLog(tmp_path / "one_d_test_spherical.output", mesh)
@@ -28,7 +29,7 @@ def test_oned_average_assignment_spherical(tmp_path):
     output_fi.close()
 
     p = Function(Q)
-    interpolate_1d_profile(p, tmp_path / "one_d_test_spherical.output", cartesian=False)
+    interpolate_1d_profile(p, tmp_path / "one_d_test_spherical.output")
     log(assemble((p-q) ** 2 * dx))
     assert assemble((p-q) ** 2 * dx) < 1e-10
 
@@ -41,6 +42,7 @@ def test_oned_average_assignment_cartesian(tmp_path):
     """
     n = 10
     mesh = UnitSquareMesh(n, n)
+    mesh.cartesian = True
 
     # because this is not an extruded mesh we have to provide r1d for layer averaging
     y_disc = np.linspace(0.0, 1.0, n+1)
@@ -49,7 +51,7 @@ def test_oned_average_assignment_cartesian(tmp_path):
     Q = FunctionSpace(mesh, "CG", 1)
     q = Function(Q).interpolate(X[1])
 
-    averager = LayerAveraging(mesh, y_disc if mesh.layers is None else None, cartesian=True)
+    averager = LayerAveraging(mesh, y_disc if mesh.layers is None else None)
     q_profile = averager.get_layer_average(q)
 
     output_fi = ParameterLog(tmp_path / "one_d_test.output", mesh)
@@ -57,6 +59,6 @@ def test_oned_average_assignment_cartesian(tmp_path):
     output_fi.close()
 
     p = Function(Q)
-    interpolate_1d_profile(p, tmp_path / "one_d_test.output", cartesian=True)
+    interpolate_1d_profile(p, tmp_path / "one_d_test.output")
 
     assert assemble((p-q) ** 2 * dx) < 1e-10

--- a/tests/unit/test_layer_averaging.py
+++ b/tests/unit/test_layer_averaging.py
@@ -4,6 +4,7 @@ from gadopt import *
 def test_layer_averaging():
     n = 10
     mesh = UnitSquareMesh(n, n)
+    mesh.cartesian = True
 
     # because this is not an extruded mesh we have to provide r1d for layer averaging
     y_disc = np.linspace(0.0, 1.0, n+1)
@@ -12,7 +13,7 @@ def test_layer_averaging():
     Q = FunctionSpace(mesh, "CG", 2)
     q = Function(Q).interpolate(X[1])
 
-    averager = LayerAveraging(mesh, y_disc if mesh.layers is None else None, cartesian=True)
+    averager = LayerAveraging(mesh, y_disc if mesh.layers is None else None)
     q_profile = averager.get_layer_average(q)
 
     assert np.allclose(q_profile, y_disc, atol=1e-10)

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -35,7 +35,7 @@ def test_solver_parameters_argument():
         "linear_false",
     ]:
         mu = 1
-        cartesian = True
+        mesh.cartesian = True
 
         match test_case:
             case "unspecified":
@@ -57,7 +57,7 @@ def test_solver_parameters_argument():
                 solver_parameters = example_solver_params
                 expected_value = example_solver_params
             case "cartesian_false":
-                cartesian = False
+                mesh.cartesian = False
                 solver_parameters = None
                 expected_value = (
                     base_linear_params_with_log | iterative_stokes_solver_parameters
@@ -77,7 +77,6 @@ def test_solver_parameters_argument():
             temperature,
             approximation,
             mu=mu,
-            cartesian=cartesian,
             solver_parameters=solver_parameters,
         )
 


### PR DESCRIPTION
There are several places where we would like to know whether the domain is Cartesian or not, and forgetting to specify this can cause silently confusing behaviour. It seems to make sense that the mesh itself should know whether it represents a Cartesian domain, and indeed a mesh is present in all places where previously a `cartesian` kwarg would have been required.

The usage of this approach is fairly simple:
```python
mesh = SomeMeshFunction(...)
mesh.cartesian = True # or False
```
From here on, the `vertical_component` or `upward_normal` functions can query the mesh directly, and it doesn't have to be passed around as a flag. In the case when the `cartesian` attribute is *not* present on the mesh, I think this will fail with an `AttributeError`. Perhaps this is better than silently making an assumption about the domain, but it could certainly do with a more informative error message in this case.

Supersedes #74.