### PR TITLE
Change format of demo table of contents

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -54,7 +54,7 @@ jobs:
           make -j convert_demos
           rm -rf rendered && mkdir rendered
           find demos -name '*.ipynb' -exec cp "{}" rendered \;
-          cp demos/.pages rendered
+          cp demos/.pages rendered/CONTENTS.md
           cp demos/.diagram.mermaid rendered
         env:
           GADOPT_LOGLEVEL: WARN

--- a/demos/.pages
+++ b/demos/.pages
@@ -1,17 +1,16 @@
-nav:
-  - index.md
-  - Base case:
-    - base_case.ipynb
-  - Physical approximation:
-    - 2d_compressible_ALA.ipynb
-    - 2d_compressible_TALA.ipynb
-    - viscoplastic_case.ipynb
-  - Dimension:
-    - 3d_cartesian.ipynb
-  - Geometry & Boundary Conditions:
-    - 2d_cylindrical.ipynb
-    - 3d_spherical.ipynb
-    - gplates_global.ipynb
-  - Multi-material:
-    - compositional_buoyancy.ipynb
-    - thermochemical_buoyancy.ipynb
+- [Tutorials](index.md)
+- Base case
+    - [base_case](base_case.ipynb)
+- Physical approximation
+    - [2d_compressible_ALA](2d_compressible_ALA.ipynb)
+    - [visualise_ALA_p_nullspace](visualise_ALA_p_nullspace.ipynb)
+    - [2d_compressible_TALA](2d_compressible_TALA.ipynb)
+    - [viscoplastic_case](viscoplastic_case.ipynb)
+- Dimension
+    - [3d_cartesian](3d_cartesian.ipynb)
+- Geometry & Boundary Conditions
+    - [2d_cylindrical](2d_cylindrical.ipynb)
+    - [3d_spherical](3d_spherical.ipynb)
+- Multi-material
+    - [compositional_buoyancy](compositional_buoyancy.ipynb)
+    - [thermochemical_buoyancy](thermochemical_buoyancy.ipynb)

--- a/demos/.pages
+++ b/demos/.pages
@@ -3,7 +3,6 @@
     - [base_case](base_case.ipynb)
 - Physical approximation
     - [2d_compressible_ALA](2d_compressible_ALA.ipynb)
-    - [visualise_ALA_p_nullspace](visualise_ALA_p_nullspace.ipynb)
     - [2d_compressible_TALA](2d_compressible_TALA.ipynb)
     - [viscoplastic_case](viscoplastic_case.ipynb)
 - Dimension
@@ -11,6 +10,7 @@
 - Geometry & Boundary Conditions
     - [2d_cylindrical](2d_cylindrical.ipynb)
     - [3d_spherical](3d_spherical.ipynb)
+    - [gplates_global](gplates_global.ipynb)
 - Multi-material
     - [compositional_buoyancy](compositional_buoyancy.ipynb)
     - [thermochemical_buoyancy](thermochemical_buoyancy.ipynb)


### PR DESCRIPTION
The awesome-pages plugin interacts badly with the mkdocs material blog, so we'll switch to literate-nav which requires this format instead.