### PR TITLE
Address warnings in tutorials

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -18,12 +18,15 @@ jobs:
       GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 
     steps:
+      - name: Install Git LFS
+        run: |
+          sudo apt update
+          sudo apt install -y git-lfs
       - uses: actions/checkout@v4
       - name: Install dependencies
         env:
           S3CONFIG: ${{ secrets.S3CONFIG }}
         run: |
-          sudo apt update
           sudo apt install -y xvfb gmsh gh s3cmd unzip
 
           mkdir -p $HOME/.s3cfg

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -34,7 +34,7 @@ jobs:
           ln -s /usr/lib/pygplates.so /home/firedrake/firedrake/lib/python3.*/site-packages/
 
           . /home/firedrake/firedrake/bin/activate
-          python3 -m pip install nbval nbconvert jupytext
+          python3 -m pip install nbval nbconvert jupytext siphash24
           python3 -m pip install .[demos]
           python3 -m ipykernel install --name firedrake --user
 

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -52,6 +52,7 @@ jobs:
           export DISPLAY=:99
           export PYVISTA_OFF_SCREEN=true
           export LIBGL_ALWAYS_SOFTWARE=true
+          export GADOPT_RENDER=true
           Xvfb $DISPLAY -screen 0 1024x768x24 > /dev/null 2>&1 &
           sleep 3
           make -j convert_demos

--- a/demos/3d_spherical/3d_spherical.py
+++ b/demos/3d_spherical/3d_spherical.py
@@ -68,10 +68,6 @@ steady_state_tolerance = 1e-6  # Used to determine if solution has reached a ste
 # lateral deviations from a radial layer average.
 
 # +
-T = Function(Q, name="Temperature")
-T_avg = Function(Q, name='Layer_Averaged_Temp')
-T_dev = Function(Q, name='Temperature_Deviation')
-
 X = SpatialCoordinate(mesh)
 r = sqrt(X[0]**2 + X[1]**2 + X[2]**2)
 theta = atan2(X[1], X[0])  # Theta (longitude - different symbol to Zhong)
@@ -80,13 +76,22 @@ phi = atan2(sqrt(X[0]**2+X[1]**2), X[2])  # Phi (co-latitude - different symbol 
 conductive_term = rmin*(rmax - r) / (r*(rmax - rmin))
 l, m, eps_c, eps_s = 3, 2, 0.01, 0.01
 Plm = Function(Q, name="P_lm")
-cos_phi = interpolate(cos(phi), Q)
+cos_phi = Function(Q).interpolate(cos(phi))
 Plm.dat.data[:] = scipy.special.lpmv(m, l, cos_phi.dat.data_ro)  # Evaluate P_lm node-wise using scipy lpmv
 Plm.assign(Plm*math.sqrt(((2*l+1)*math.factorial(l-m))/(2*math.pi*math.factorial(l+m))))
 if m == 0:
     Plm.assign(Plm/math.sqrt(2))
-T.interpolate(conductive_term +
-              (eps_c*cos(m*theta) + eps_s*sin(m*theta)) * Plm * sin(pi*(r - rmin)/(rmax-rmin)))
+
+T = (
+    Function(Q, name="Temperature")
+    .interpolate(
+        conductive_term +
+        (eps_c*cos(m*theta) + eps_s*sin(m*theta)) * Plm * sin(pi*(r - rmin)/(rmax-rmin))
+    )
+)
+
+T_avg = Function(Q, name="Layer_Averaged_Temp")
+T_dev = Function(Q, name="Temperature_Deviation")
 # -
 
 # Compute layer average for initial temperature field, using the LayerAveraging functionality provided by G-ADOPT.

--- a/demos/gplates_global/gplates_global.py
+++ b/demos/gplates_global/gplates_global.py
@@ -224,10 +224,15 @@ gplates_velocities = GplatesVelocityFunction(
 #     vtk_file.write(gplates_velocities)
 #
 # import pyvista as pv
+# import os
 # dataset = pv.read("gplates_velocity/gplates_velocity_0.vtu")
 #
 # # Create a plotter object
 # plotter = pv.Plotter()
+# # Whether our plot should be interactive or not
+# backend = None
+# if os.environ.get("GADOPT_RENDER", "false").lower() == "true":
+#     backend = "static"
 # # Add the dataset to the plotter
 # plotter.add_mesh(dataset, scalars="GPlates_Velocity", cmap="coolwarm")
 # glyphs = dataset.glyph(orient="GPlates_Velocity", scale=1, factor=1e-4)
@@ -236,7 +241,7 @@ gplates_velocities = GplatesVelocityFunction(
 # # Adjust the camera position
 # plotter.camera_position = [(10.0, 10.0, 10.0), (0.0, 0.0, 0), (0, 1, 0)]
 # # Show the plot
-# plotter.show()
+# plotter.show(jupyter_backend=backend)
 # -
 
 # And last but not least, we need to inform our solver of our choice

--- a/demos/gplates_global/gplates_global.py
+++ b/demos/gplates_global/gplates_global.py
@@ -28,6 +28,10 @@
 # Let's begin with the usual import of G-ADOPT, set up of the mesh,
 # function spaces, functions to hold our solutions, material
 # properties, approximations and initial conditions:
+#
+# Note that sometimes we get a confusing `SyntaxWarning` during the
+# set up. This is due to the pyGPlates module itself, but doesn't
+# affect any functionality and is safe to ignore.
 
 # +
 from gadopt import *
@@ -95,6 +99,11 @@ averager.extrapolate_layer_average(T_avg, averager.get_layer_average(T))
 # space. The 1-D profile data is located in the file
 # `./mu2_radial.rad`, and we will use interpolation functionalities
 # provided by G-ADOPT to populate the viscosity field.
+#
+# This expression generates a warning from TSFC, the Two-Stage Form
+# Compiler. The underlying interpolation routine on a non-Cartesian
+# geometry hits an edge case in the form optimisation, but this can
+# safely be ignored.
 
 mu = Function(Q, name="Viscosity")
 interpolate_1d_profile(function=mu, one_d_filename="mu2_radial.rad")


### PR DESCRIPTION
There are a few irrelevant warnings in our tutorials (an import warning from Firedrake, interpolation, plotting, etc.) that we can improve upon. There is one outstanding warning from the gplates demo:
```
/home/firedrake/firedrake/lib/python3.12/site-packages/gadopt/gplates/gplates.py:407: RuntimeWarning: Issues finding plate ids for some of the seeds.
  warnings.warn("Issues finding plate ids for some of the seeds.", category=RuntimeWarning)
```

I think this can go up as an issue for @sghelichkhani to address later.