### PR TITLE
Ensure approximation is aware of viscosity.

### DIFF
--- a/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
+++ b/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
@@ -29,6 +29,7 @@ rmin, rmax, ncells, nlayers = 1.208, 2.208, 512, 128
 # In this example, we load the mesh from a checkpoint, although the following code was used to generate
 # the original mesh. It is included here for completeness.
 
+
 def original_mesh():
     def gaussian(center, c, a):
         return a*np.exp(-(np.linspace(rmin, rmax, nlayers)-center)**2/(2*c**2))
@@ -49,6 +50,7 @@ def original_mesh():
     )
 
     return mesh
+
 
 with CheckpointFile("initial_condition_mat_prop/Final_State.h5", mode="r") as f:
     mesh = f.load_mesh("firedrake_default_extruded")
@@ -121,20 +123,6 @@ Tbar = approximation_profiles["Tbar"]
 mu_rad = Function(Q, name="Viscosity_Radial")  # Depth dependent component of viscosity
 interpolate_1d_profile(function=mu_rad, one_d_filename="initial_condition_mat_prop/mu2_radial.txt")
 
-# These fields are used to set up our Truncated Anelastic Liquid Approximation.
-approximation = TruncatedAnelasticLiquidApproximation(Ra, Di, H=H_int, **approximation_profiles)
-
-# As with the previous examples, we set up a *Timestep Adaptor*,
-# for controlling the time-step length (via a CFL
-# criterion) as the simulation advances in time. For the latter,
-# we specify the initial time, initial timestep $\Delta t$, and number of
-# timesteps.
-
-time = 0.0  # Initial time
-delta_t = Constant(1e-6)  # Initial time-step
-timesteps = 21  # Maximum number of timesteps
-t_adapt = TimestepAdaptor(delta_t, u, V, target_cfl=0.8, maximum_timestep=0.1, increase_tolerance=1.5)
-
 # We next set up and initialise our Temperature field from a checkpoint:
 X = SpatialCoordinate(mesh)
 T = Function(Q, name="Temperature")
@@ -151,6 +139,20 @@ T_dev = Function(Q, name='Temperature_Deviation').assign(FullT-T_avg)
 mu_field = Function(Q, name="Viscosity")
 delta_mu_T = Constant(1000.)
 mu = mu_rad * exp(-ln(delta_mu_T) * T_dev)
+
+# These fields are used to set up our Truncated Anelastic Liquid Approximation.
+approximation = TruncatedAnelasticLiquidApproximation(Ra, Di, H=H_int, mu=mu, **approximation_profiles)
+
+# As with the previous examples, we set up a *Timestep Adaptor*,
+# for controlling the time-step length (via a CFL
+# criterion) as the simulation advances in time. For the latter,
+# we specify the initial time, initial timestep $\Delta t$, and number of
+# timesteps.
+
+time = 0.0  # Initial time
+delta_t = Constant(1e-6)  # Initial time-step
+timesteps = 21  # Maximum number of timesteps
+t_adapt = TimestepAdaptor(delta_t, u, V, target_cfl=0.8, maximum_timestep=0.1, increase_tolerance=1.5)
 
 # With a free-slip boundary condition on both boundaries, one can add an arbitrary rotation
 # of the form $(-y, x)=r\hat{\mathbf{\theta}}$ to the velocity solution (i.e. this case incorporates a velocity nullspace,


### PR DESCRIPTION
Address Issue highlighted here: https://github.com/g-adopt/g-adopt/issues/111

Where TALA approximation is not aware of the viscosity. This change necessitates a change to the expected values for the TALA_DG test, which I append below. 

`20 9.179973966724344e-05 4.817959005812114e-06 570.4729595213425 4.0527513455978985 15.18647692671351 11.133725581115613 0.6363801581209881 0.0001688057305039466 1.0011841176113832`