### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install linter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload failed run log
         if: steps.run_tests.conclusion == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: run-log
           path: test_output.log


### PR DESCRIPTION
Just a small maintenance; it should fix a CI [warning](https://github.com/g-adopt/g-adopt/actions/runs/11103281454) regarding Node.js versions.