### PR TITLE
Fix pytest directory for longtest

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test results
         if: ${{ success() }}
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && python3 -m pytest -m longtest --junit-xml=test_results.xml demos"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && python3 -m pytest -m longtest --junit-xml=test_results.xml --ignore=tests/unit tests"
 
       - name: Retrieve test results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
We also skip the unit test directory, since pytest collection will fail when trying to import Firedrake in some of the tests.