### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,9 @@ longtest_output:
 # convert demo Python scripts to executed notebooks
 convert_demos:
 	$(MAKE) -C demos convert_demos
+
+clean:
+	$(MAKE) -C demos clean & $(MAKE) -C tests clean & wait
+
+check:
+	python -m pytest -m 'not longtest'

--- a/demos/2d_compressible_ALA/Makefile
+++ b/demos/2d_compressible_ALA/Makefile
@@ -1,4 +1,5 @@
 all: params.log
+current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
 
 ncpus := 4
 
@@ -8,3 +9,7 @@ params.log: 2d_compressible_ALA.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output reference_state
+
+check: params.log
+	python3 -m pytest ../test_all.py -k $(current_dir)

--- a/demos/2d_compressible_TALA/Makefile
+++ b/demos/2d_compressible_TALA/Makefile
@@ -1,5 +1,6 @@
 all: params.log
 
+current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
 ncpus := 4
 
 params.log: 2d_compressible_TALA.py
@@ -8,3 +9,7 @@ params.log: 2d_compressible_TALA.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output reference_state
+
+check: params.log
+	python3 -m pytest ../test_all.py -k $(current_dir)

--- a/demos/2d_cylindrical/Makefile
+++ b/demos/2d_cylindrical/Makefile
@@ -8,3 +8,7 @@ params.log: 2d_cylindrical.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output
+
+check: params.log
+	python3 -m pytest ../test_all.py -k 2d_cylindrical

--- a/demos/3d_cartesian/Makefile
+++ b/demos/3d_cartesian/Makefile
@@ -8,3 +8,7 @@ params.log: 3d_cartesian.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output reference_state
+
+check: params.log
+	python3 -m pytest ../test_all.py -k 3d_cartesian

--- a/demos/3d_spherical/Makefile
+++ b/demos/3d_spherical/Makefile
@@ -8,3 +8,7 @@ params.log: 3d_spherical.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output
+
+check: params.log
+	python3 -m pytest ../test_all.py -k 3d_spherical

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -3,7 +3,7 @@ demo_cases := base_case 2d_cylindrical 3d_spherical 2d_compressible_ALA visualis
 
 notebook_files := $(foreach case,$(demo_cases),$(case)/$(notdir $(case)).ipynb) adjoint/adjoint_forward.ipynb
 
-.PHONY: all convert_demos $(cases) $(demo_cases) clean generate
+.PHONY: all convert_demos $(cases) $(demo_cases) clean generate check
 
 all: $(cases)
 
@@ -27,6 +27,10 @@ generate:
 	python3 generate_expected.py
 
 clean: $(cases)
+	rm -rf __pycache__
+
+check:
+	python3 -m pytest -m demo
 
 # pattern rule for executing demo scripts as a notebook
 %.ipynb: %.py

--- a/demos/base_case/Makefile
+++ b/demos/base_case/Makefile
@@ -1,4 +1,5 @@
 all: params.log
+current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
 
 params.log: base_case.py
 	echo "running $<" >&2
@@ -6,3 +7,7 @@ params.log: base_case.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output
+
+check: params.log
+	python3 -m pytest ../test_all.py -k $(current_dir)

--- a/demos/free_surface/Makefile
+++ b/demos/free_surface/Makefile
@@ -6,3 +6,4 @@ params.log: free_surface.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output

--- a/demos/gplates_global/Makefile
+++ b/demos/gplates_global/Makefile
@@ -1,8 +1,13 @@
 all: params.log
+current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
 
 params.log: gplates_global.py
 	echo "running $<" >&2
 	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
 
 clean:
-	rm -f output* *.h5 params.log
+	rm -f *.pvd *.h5 params.log
+	rm -rf output
+
+check: params.log
+	python3 -m pytest ../test_all.py -k $(current_dir)

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -7,3 +7,8 @@ all: $(cases)
 $(cases):
 	cd $@; /usr/bin/time --format="$@ finished in %E" tsp -f python3 $@.py
 
+clean:
+	@$(foreach case, $(cases), \
+		rm -rf $(case)/*.h5 $(case)/*.pvd $(case)/params.log $(case)/*.msh $(case)/output ; \
+	)
+

--- a/demos/test_all.py
+++ b/demos/test_all.py
@@ -12,9 +12,21 @@ cases = {
     "3d_spherical": {"extra_checks": ["t_dev_avg"]},
     "3d_cartesian": {"rtol": 1e-4},
     "gplates_global": {"extra_checks": ["u_rms_top"]},
-    "../tests/2d_cylindrical_TALA_DG": {"extra_checks": ["avg_t", "FullT_min", "FullT_max"]},
+    "../tests/2d_cylindrical_TALA_DG": {
+        "extra_checks": ["avg_t", "FullT_min", "FullT_max"]
+    },
     "../tests/viscoplastic_case_dg": {"extra_checks": ["avg_t"]},
 }
+
+
+def construct_pytest_params():
+    out = []
+    for case in cases:
+        if case.startswith(".."):
+            out.append(case)
+        else:
+            out.append(pytest.param(case, marks=pytest.mark.demo))
+    return out
 
 
 def get_convergence(base):
@@ -30,14 +42,16 @@ def check_series(
     extra_checks,
 ):
     pd.testing.assert_series_equal(
-        actual[["u_rms", "nu_top"] + extra_checks], expected,
-        check_names=False, **compare_params
+        actual[["u_rms", "nu_top"] + extra_checks],
+        expected,
+        check_names=False,
+        **compare_params,
     )
 
     assert abs(actual.name - expected.name) <= convergence_tolerance
 
 
-@pytest.mark.parametrize("benchmark", cases.keys())
+@pytest.mark.parametrize("benchmark", construct_pytest_params())
 def test_benchmark(benchmark):
     """Test a benchmark case against the expected convergence result.
 

--- a/demos/viscoplastic_case/Makefile
+++ b/demos/viscoplastic_case/Makefile
@@ -1,5 +1,6 @@
 all: params.log
 
+current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
 ncpus := 4
 
 params.log: viscoplastic_case.py
@@ -8,3 +9,7 @@ params.log: viscoplastic_case.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output
+
+check: params.log
+	python3 -m pytest ../test_all.py -k $(current_dir)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 python_files = test_*.py
 markers =
   longtest
+  demo

--- a/tests/2d_cylindrical_TALA_DG/Makefile
+++ b/tests/2d_cylindrical_TALA_DG/Makefile
@@ -8,3 +8,7 @@ params.log: 2d_cylindrical_TALA_DG.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output reference_state __pycache__
+
+check: params.log
+	python3 -m pytest ../../demos/test_all.py -k "../tests/2d_cylindrical_TALA_DG"

--- a/tests/Drucker-Prager_rheology/Makefile
+++ b/tests/Drucker-Prager_rheology/Makefile
@@ -7,4 +7,7 @@ $(cases): spiegelman.py
 	/usr/bin/time --format="spiegelman $@ finished in %E" tsp -f python3 $< $@
 
 clean:
-	rm -rf $(addprefix spiegelman_,$(cases))
+	rm -rf $(addprefix spiegelman_,$(cases)) __pycache__
+
+check: $(addprefix spiegelman_,$(cases))
+	python -m pytest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 cases := analytical_comparisons multi_material optimisation_checkpointing scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_dg free_surface
 long_cases := analytical_comparisons parallel_scaling
 
-.PHONY: all longtest longtest_output $(cases) $(long_cases) clean
+.PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
 
 all: $(cases)
 
@@ -14,3 +14,10 @@ $(sort $(cases) $(long_cases)):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
 clean: $(cases)
+	rm -rf __pycache__
+
+check:
+	python -m pytest . ../demos -m 'not demo and not longtest'
+
+longcheck:
+	python -m pytest -m longtest

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -14,3 +14,7 @@ adjoint-demo-checkpoint-state.h5: ../../demos/adjoint/adjoint_forward.py
 
 clean:
 	rm -f *.h5 *.conv *.dat
+	rm -rf __pycache__
+
+check: $(addsuffix .conv,$(cases))
+	python -m pytest

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -1,15 +1,20 @@
-cases := smooth/cylindrical/free_slip smooth/cylindrical/zero_slip delta/cylindrical/free_slip delta/cylindrical/zero_slip delta/cylindrical/free_slip_dpc delta/cylindrical/zero_slip_dpc
-long_cases := smooth/cylindrical/free_surface smooth/spherical/free_slip smooth/spherical/zero_slip
+cases := smooth_cylindrical_freeslip smooth_cylindrical_zeroslip delta_cylindrical_freeslip delta_cylindrical_zeroslip delta_cylindrical_freeslip_dpc delta_cylindrical_zeroslip_dpc
+long_cases := smooth_cylindrical_freesurface smooth_spherical_freeslip smooth_spherical_zeroslip
 
-.PHONY: all longtest longtest_output $(cases) $(long_cases) clean
+sentinels := $(addprefix .sentinel.,$(cases))
+
+.PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
 
 all: $(cases)
 
 longtest: $(long_cases)
 
-$(cases): analytical.py
-	echo "running analytical $@" >&2
-	/usr/bin/time --format="analytical $@ finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $@
+$(cases): %: .sentinel.%
+
+$(sentinels): analytical.py
+	echo "running analytical $(subst .sentinel.,,$@)" >&2
+	/usr/bin/time --format="analytical $(subst .sentinel.,,$@) finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $(subst .sentinel.,,$@)
+	echo "done" > $@
 
 .ONESHELL:
 SHELL = /bin/bash
@@ -23,7 +28,13 @@ $(long_cases): analytical.py clean
 	wait
 
 clean:
-	rm -rf pbs_output *.dat sentinel.*
+	rm -rf pbs_output *.dat sentinel.* .sentinel.* __pycache__
 
 longtest_output:
 	[[ -d pbs_output ]] && tail -n +1 pbs_output/*
+
+check: $(sentinels)
+	python -m pytest -m 'not longtest'
+
+longcheck:
+	python -m pytest -m longtest

--- a/tests/analytical_comparisons/analytical.py
+++ b/tests/analytical_comparisons/analytical.py
@@ -73,7 +73,6 @@ cases = {
 
 
 def get_case(cases, config):
-    print(config)
     config = config.split("_", maxsplit=2)
     while config:
         cases = cases[config.pop(0)]

--- a/tests/analytical_comparisons/analytical.py
+++ b/tests/analytical_comparisons/analytical.py
@@ -2,23 +2,24 @@ import argparse
 import itertools
 import subprocess
 import sys
+import importlib
 
 cases = {
     "smooth": {
         "cylindrical": {
-            "free_slip": {
+            "freeslip": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "k": [2, 8],
                 "n": [1, 4],
             },
-            "zero_slip": {
+            "zeroslip": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "k": [2, 8],
                 "n": [1, 4],
             },
-            "free_surface": {
+            "freesurface": {
                 "cores": [1, 4, 6],
                 "levels": [2**i for i in [1, 2, 3]],
                 "k": [2, 8],
@@ -26,7 +27,7 @@ cases = {
             },
         },
         "spherical": {
-            "free_slip": {
+            "freeslip": {
                 "cores": [24, 48, 96, 192],  # cascade lake
                 "levels": [3, 4, 5, 6],
                 "l": [2, 8],
@@ -34,7 +35,7 @@ cases = {
                 "k": [3, 9],
                 "permutate": False,
             },
-            "zero_slip": {
+            "zeroslip": {
                 "cores": [24, 48, 96, 192],
                 "levels": [3, 4, 5, 6],
                 "l": [2, 8],
@@ -46,22 +47,22 @@ cases = {
     },
     "delta": {
         "cylindrical": {
-            "free_slip": {
+            "freeslip": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "n": [2, 8],
             },
-            "free_slip_dpc": {
+            "freeslip_dpc": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "n": [2, 8],
             },
-            "zero_slip": {
+            "zeroslip": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "n": [2, 8],
             },
-            "zero_slip_dpc": {
+            "zeroslip_dpc": {
                 "cores": [4, 16, 24],
                 "levels": [2**i for i in [2, 3, 4]],
                 "n": [2, 8],
@@ -72,7 +73,8 @@ cases = {
 
 
 def get_case(cases, config):
-    config = config.split("/")
+    print(config)
+    config = config.split("_", maxsplit=2)
     while config:
         cases = cases[config.pop(0)]
 
@@ -89,25 +91,9 @@ def param_sets(config, permutate=False):
 def run_subcommand(args):
     from mpi4py import MPI
 
-    if args.case == "smooth/cylindrical/free_slip":
-        from smooth_cylindrical_freeslip import model
-    elif args.case == "smooth/cylindrical/zero_slip":
-        from smooth_cylindrical_zeroslip import model
-    elif args.case == "smooth/cylindrical/free_surface":
-        from smooth_cylindrical_freesurface import model
-    elif args.case == "delta/cylindrical/free_slip":
-        from delta_cylindrical_freeslip import model
-    elif args.case == "delta/cylindrical/zero_slip":
-        from delta_cylindrical_zeroslip import model
-    elif args.case == "delta/cylindrical/free_slip_dpc":
-        from delta_cylindrical_freeslip_dpc import model
-    elif args.case == "delta/cylindrical/zero_slip_dpc":
-        from delta_cylindrical_zeroslip_dpc import model
-    elif args.case == "smooth/spherical/free_slip":
-        from smooth_spherical_freeslip import model
-    elif args.case == "smooth/spherical/zero_slip":
-        from smooth_spherical_zeroslip import model
-    else:
+    try:
+        model = importlib.import_module(args.case).model
+    except ModuleNotFoundError:
         raise ValueError(f"unknown case {args.case}")
 
     errors = model(*args.params)
@@ -116,7 +102,7 @@ def run_subcommand(args):
         config.pop("cores")
         errfile_name = "errors-{}-{}.dat".format(
             args.case.replace("/", "_"),
-            "-".join([f"{k}{v}" for k, v in zip(config.keys(), args.params)])
+            "-".join([f"{k}{v}" for k, v in zip(config.keys(), args.params)]),
         )
 
         with open(errfile_name, "w") as f:
@@ -132,12 +118,19 @@ def submit_subcommand(args):
     for level, cores in zip(config.pop("levels"), config.pop("cores")):
         for params in param_sets(config, permutate):
             paramstr = "-".join([str(v) for v in params])
-            command = args.template.format(cores=cores, mem=4*cores, params=paramstr, level=level)
+            command = args.template.format(
+                cores=cores, mem=4 * cores, params=paramstr, level=level
+            )
 
             procs[paramstr] = subprocess.Popen(
                 [
-                    *command.split(), sys.executable, sys.argv[0],
-                    "run", args.case, str(level), *[str(v) for v in params],
+                    *command.split(),
+                    sys.executable,
+                    sys.argv[0],
+                    "run",
+                    args.case,
+                    str(level),
+                    *[str(v) for v in params],
                 ]
             )
 
@@ -169,15 +162,27 @@ if __name__ == "__main__":
     )
     subparsers = parser.add_subparsers(title="subcommands")
 
-    parser_run = subparsers.add_parser("run", help="run a specific configuration of a case (usually not manually invoked)")
+    parser_run = subparsers.add_parser(
+        "run",
+        help="run a specific configuration of a case (usually not manually invoked)",
+    )
     parser_run.add_argument("case")
     parser_run.add_argument("params", type=int, nargs="*")
     parser_run.set_defaults(func=run_subcommand)
-    parser_submit = subparsers.add_parser("submit", help="submit a PBS job to run a specific case")
-    parser_submit.add_argument("-t", "--template", default="mpiexec -np {cores}", help="template command for running commands under MPI")
+    parser_submit = subparsers.add_parser(
+        "submit", help="submit a PBS job to run a specific case"
+    )
+    parser_submit.add_argument(
+        "-t",
+        "--template",
+        default="mpiexec -np {cores}",
+        help="template command for running commands under MPI",
+    )
     parser_submit.add_argument("case")
     parser_submit.set_defaults(func=submit_subcommand)
-    parser_count = subparsers.add_parser("count", help="return the number of jobs to run for a specific case")
+    parser_count = subparsers.add_parser(
+        "count", help="return the number of jobs to run for a specific case"
+    )
     parser_count.add_argument("case")
     parser_count.set_defaults(func=count_subcommand)
 

--- a/tests/analytical_comparisons/test_analytical.py
+++ b/tests/analytical_comparisons/test_analytical.py
@@ -5,28 +5,28 @@ import pandas as pd
 from pathlib import Path
 
 enabled_cases = {
-    "smooth/cylindrical/free_slip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
-    "smooth/cylindrical/zero_slip": {"convergence": (4.0, 2.0)},
-    "smooth/cylindrical/free_surface": {"convergence": (4.0, 2.0, 2.0), "rtol": 1e-1},
-    "delta/cylindrical/free_slip": {"convergence": (1.5, 0.5)},
-    "delta/cylindrical/zero_slip": {"convergence": (1.5, 0.5)},
-    "delta/cylindrical/free_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 1e-1},
-    "delta/cylindrical/zero_slip_dpc": {"convergence": (3.5, 2.0), "rtol": 2e-1},
-    "smooth/spherical/free_slip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
-    "smooth/spherical/zero_slip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
+    "smooth_cylindrical_freeslip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
+    "smooth_cylindrical_zeroslip": {"convergence": (4.0, 2.0)},
+    "smooth_cylindrical_freesurface": {"convergence": (4.0, 2.0, 2.0), "rtol": 1e-1},
+    "delta_cylindrical_freeslip": {"convergence": (1.5, 0.5)},
+    "delta_cylindrical_zeroslip": {"convergence": (1.5, 0.5)},
+    "delta_cylindrical_freeslip_dpc": {"convergence": (3.5, 2.0), "rtol": 1e-1},
+    "delta_cylindrical_zeroslip_dpc": {"convergence": (3.5, 2.0), "rtol": 2e-1},
+    "smooth_spherical_freeslip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
+    "smooth_spherical_zeroslip": {"convergence": (4.0, 2.0), "rtol": 1e-1},
 }
 
 longtest_cases = [
-    "smooth/cylindrical/free_surface",
-    "smooth/spherical/free_slip",
-    "smooth/spherical/zero_slip",
+    "smooth_cylindrical_freesurface",
+    "smooth_spherical_freeslip",
+    "smooth_spherical_zeroslip",
 ]
 
 params = {
-    f"{l1}/{l2}/{l3}": v3 for l1, v1 in analytical.cases.items()
+    f"{l1}_{l2}_{l3}": v3 for l1, v1 in analytical.cases.items()
     for l2, v2 in v1.items()
     for l3, v3 in v2.items()
-    if f"{l1}/{l2}/{l3}" in enabled_cases.keys()
+    if f"{l1}_{l2}_{l3}" in enabled_cases.keys()
 }
 
 configs = []
@@ -65,7 +65,7 @@ def test_analytical(name, expected, config):
         for level in levels
     ]
 
-    if name.split("/")[-1] == "free_surface":
+    if name.split("_")[-1] == "freesurface":
         columns = ["l2error_u", "l2error_p", "l2error_eta", "l2anal_u", "l2anal_p", "l2anal_eta"]
         variables = 3  # u, p and eta
 

--- a/tests/free_surface/Makefile
+++ b/tests/free_surface/Makefile
@@ -3,13 +3,28 @@ parallel_cases := implicit_top_bottom_buoyancy implicit_cylindrical
 
 ncpus := 8
 
+serial_sentinels := $(addprefix .sentinel.,$(serial_cases))
+parallel_sentinels := $(addprefix .sentinel.,$(parallel_cases))
+
+.PHONY: all clean check $(serial_cases) $(parallel_cases)
+
 all: $(serial_cases) $(parallel_cases)
 
+#Allow 'make <easy name>' to effectively alias to 'make <long ugly file name>'
+$(serial_cases) $(parallel_cases): %: .sentinel.%
 
-$(serial_cases): 
-	echo "running $@ free surface coupling "
-	tsp -N 1 -f python3 $@_free_surface.py
+$(serial_sentinels):
+	echo "running $(subst .sentinel.,,$@) free surface coupling "
+	tsp -N 1 -f python3 $(subst .sentinel.,,$@)_free_surface.py
+	echo "done" > $@
 
-$(parallel_cases):
-	echo "running $@ free surface coupling "
-	tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $@_free_surface.py
+$(parallel_sentinels):
+	echo "running $(subst .sentinel.,,$@) free surface coupling "
+	tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $(subst .sentinel.,,$@)_free_surface.py
+	echo "done" > $@
+
+clean:
+	rm -rf *.dat .sentinel.* __pycache__
+
+check: $(serial_sentinels) $(parallel_sentinels)
+	python3 -m pytest

--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -7,3 +7,12 @@ all: $(cases)
 $(cases):
 	echo "running $@ multi-material benchmark"
 	tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 run_benchmark.py benchmarks.$@
+
+clean:
+	@$(foreach case, $(cases), \
+		rm -rf $(case) ; \
+	)
+	rm -rf __pycache__ benchmarks/*.msh benchmarks/__pycache__
+
+check: $(cases)
+	python3 -m pytest

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -3,6 +3,10 @@ all: checkpointing
 checkpointing: helmholtz.py
 	echo "running helmholtz checkpointing" >&2
 	/usr/bin/time --format="helmholtz checkpointing took %E" tsp -f python3 $<
+	echo 'done' > checkpointing
 
 clean:
-	rm -rf optimisation_checkpoint
+	rm -rf optimisation_checkpoint __pycache__ *.h5 *.dat checkpointing
+
+check: checkpointing
+	python -m pytest

--- a/tests/parallel_scaling/Makefile
+++ b/tests/parallel_scaling/Makefile
@@ -1,7 +1,7 @@
 levels := 5 6 7
 levels := $(addsuffix .txt,$(addprefix profile_,$(levels)))
 
-.PHONY: longtest clean
+.PHONY: longtest clean check
 
 longtest: $(levels)
 
@@ -17,3 +17,6 @@ clean:
 
 longtest_output:
 	tail -n +1 level_*.{err,out}
+
+check: $(levels)
+	python3 -m pytest

--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -1,8 +1,21 @@
 cases := $(shell python3 test_scalar_advection_diffusion_DH27.py)
 
+sentinels := $(addprefix .sentinel.,$(cases))
+
+.PHONY: all $(cases) clean
+
 all: $(cases)
 
-$(cases): scalar_advection_diffusion_DH27.py
-	echo "running advection diffusion $@" >&2
-	tsp -N 1 -f python3 $< $@
+$(cases): %: .sentinel.%
 
+$(sentinels): scalar_advection_diffusion_DH27.py
+	echo "running advection diffusion $(subst .sentinel.,,$@)" >&2
+	tsp -N 1 -f python3 $< $(subst .sentinel.,,$@)
+	echo 'done' > $@
+
+clean:
+	rm -f *.dat .sentinel.*
+	rm -rf __pycache__
+
+check: $(sentinels)
+	python3 -m pytest

--- a/tests/viscoplastic_case_dg/Makefile
+++ b/tests/viscoplastic_case_dg/Makefile
@@ -8,3 +8,7 @@ params.log: viscoplastic_case_DG.py
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
+	rm -rf output __pycache__
+
+check: params.log
+	python3 -m pytest ../../demos/test_all.py -k "../tests/viscoplastic_case_dg"


### PR DESCRIPTION
Revamp makefiles. make check now runs appropriate tests wherever its invoked. Top level behaviour remains the same, make check in demos only tests demos, make check in an individual test only tests that, etc. Most make check invocations depend on test output. Some tests were modified to make this work properly. make clean now removes all artefacts from testing.