### PR TITLE
Make triggering a documentation rebuild optional

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      trigger:
+        type: boolean
+        default: false
+        description: 'Trigger a website rebuild if this run is successful'
 
 jobs:
   render:
@@ -67,6 +72,7 @@ jobs:
           path: rendered
           include-hidden-files: true
       - name: Trigger documentation build
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.trigger) }}
         run: |
           gh api --method POST \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
Sometimes we want to run a documentation render without updating the website, to check that it would complete. To support this, we add a "trigger" input to the workflow dispatch for this action.