### PR TITLE
Serialise startup of render jobs

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -36,5 +36,9 @@ check:
 	python3 -m pytest -m demo
 
 # pattern rule for executing demo scripts as a notebook
+# because jupyter is an insane jumble of components, there's absolutely no way to configure it
+# to try to bind to its control port when it needs it. instead, the provisioner checks for a free
+# port and writes that to a connection file. this is of course completely prone to race conditions.
+# instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
 %.ipynb: %.py
-	python3 -m jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))
+	(flock 9; sleep 1 && flock -u 9 & python3 -m jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))) 9>render.lock


### PR DESCRIPTION
jupytext calls nbconvert to use its ExecutePreprocessor which starts a NotebookClient which starts a KernelManager through a LocalProvisioner. Of course, KernelManager includes a ConnectionFileMixin and tries to bind 5 random ports when it provisions the manager, then writes this to a file for when the Client actually starts. This is a big race condition, and means that the automatic retry code in the Client for random ports never gets hit, because the port is already specified in the connection file.

The solution herein isn't foolproof, but barring a big hang in the initialisation of jupyter it should work. We serialise just the startup of the render jobs through a lockfile which gives each process 1 second to start before releasing the lock.

Closes #143.