### PR TITLE
Run render jobs with namespaced networking

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: self-hosted
     container:
       image: ghcr.io/g-adopt/firedrake:2024-11-05
-      options: --shm-size 2g
+      options: --shm-size 2g --cap-add=SYS_ADMIN
 
     env:
       OMP_NUM_THREADS: 1
@@ -50,6 +50,16 @@ jobs:
         run: |
           s3cmd --config=$HOME/.s3cfg/config get s3://gadopt/github-actions/Muller_etal_2022_SE_1Ga_Opt_PlateMotionModel_v1.2.zip .
           unzip Muller_etal_2022_SE_1Ga_Opt_PlateMotionModel_v1.2.zip -d demos/mantle_convection/gplates_global
+
+      - name: Set up for network namespacing
+        run: |
+          sudo sed -i 's/ubuntu/firedrake/' /etc/subuid
+          sudo sed -i 's/ubuntu/firedrake/' /etc/subgid
+          sudo apt install -y uidmap
+          . /home/firedrake/firedrake/bin/activate
+          jupytext_location="$(which jupytext)"
+          cp .testing/jupytext "$jupytext_location"
+          chmod +x "$jupytext_location"
 
       - name: Convert notebooks
         run: |

--- a/.testing/jupytext
+++ b/.testing/jupytext
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+XDG_CACHE_HOME=$HOME/.cache unshare --map-root-user --net bash -c "ip link set lo up && python3 -m jupytext $*" -- "$@"

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -41,4 +41,4 @@ check:
 # port and writes that to a connection file. this is of course completely prone to race conditions.
 # instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
 %.ipynb: %.py
-	(flock 9; sleep 1 && flock -u 9 & python3 -m jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))) 9>render.lock
+	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))


### PR DESCRIPTION
This is possibly a less hacky alternative to #147 for ensuring all the jupyter kernels don't run into each other when they try to bind ports on startup.

There are plusses and minuses to this approach. The environment needs to be more carefully set up so that the namespace works, including setting subuid and subgid. I think it's probably also the case that the render jobs won't have external network access without setting up a veth device in the namespace. Maybe that's not the worst thing -- we get a fairly robust guarantee that we don't have any network dependencies.

Actions run: https://github.com/g-adopt/g-adopt/actions/runs/11848173592