### PR TITLE
Generate optimisation checkpoints with collective ID

### DIFF
--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -5,8 +5,8 @@ relevant parameters and call the `run` method to perform the optimisation.
 """
 
 from pathlib import Path
-import uuid
 
+import firedrake.utils
 import pyadjoint.optimization.rol_solver as pyadjoint_rol
 import ROL
 from firedrake import CheckpointFile, Function
@@ -246,6 +246,7 @@ class CheckpointedROLVector(pyadjoint_rol.ROLVector):
         """
         super().__init__(dat, inner_product)
 
+        self.comm = dat[0].comm
         self._optimiser = optimiser
 
     def clone(self):
@@ -297,7 +298,8 @@ class CheckpointedROLVector(pyadjoint_rol.ROLVector):
     def __getstate__(self):
         """Returns a state tuple suitable for pickling"""
 
-        checkpoint_filename = f"vector_checkpoint_{uuid.uuid4()}.h5"
+        checkpoint_id = firedrake.utils._new_uid(self.comm)
+        checkpoint_filename = f"vector_checkpoint_{checkpoint_id}.h5"
         checkpoint_path = self._optimiser.checkpoint_dir / checkpoint_filename
         self.save(checkpoint_path)
 

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -1,12 +1,11 @@
-all: checkpointing
+all: full_optimisation_np1.dat full_optimisation_np2.dat
 
-checkpointing: helmholtz.py
-	echo "running helmholtz checkpointing" >&2
-	/usr/bin/time --format="helmholtz checkpointing took %E" tsp -f python3 $<
-	echo 'done' > checkpointing
+full_optimisation_np%.dat: helmholtz.py
+	echo "running helmholtz checkpointing (np $*)" >&2
+	/usr/bin/time --format="helmholtz checkpointing (np $*) took %E" tsp -N $* -f mpiexec -np $* python3 $<
 
 clean:
-	rm -rf optimisation_checkpoint __pycache__ *.h5 *.dat checkpointing
+	rm -rf optimisation_checkpoint_* __pycache__ *.h5 *.dat
 
-check: checkpointing
+check: full_optimisation_np1.dat full_optimisation_np2.dat
 	python -m pytest

--- a/tests/optimisation_checkpointing/helmholtz.py
+++ b/tests/optimisation_checkpointing/helmholtz.py
@@ -22,10 +22,12 @@ def run(optimiser, rf, rank, filename):
 
 
 mesh = UnitIntervalMesh(10)
+num_processes = mesh.comm.size
+mesh_checkpoint = f"mesh_helmholtz_np{num_processes}.h5"
 # create a checkpointable mesh by writing to disk and restoring
-with CheckpointFile("mesh_helmholtz.h5", "w") as f:
+with CheckpointFile(mesh_checkpoint, "w") as f:
     f.save_mesh(mesh)
-with CheckpointFile("mesh_helmholtz.h5", "r") as f:
+with CheckpointFile(mesh_checkpoint, "r") as f:
     mesh = f.load_mesh("firedrake_default")
 
 V = FunctionSpace(mesh, "CG", 1)
@@ -54,22 +56,23 @@ minimisation_problem = MinimizationProblem(rf, bounds=(T_lb, T_ub))
 minimisation_parameters["Status Test"]["Iteration Limit"] = 10
 
 # run full optimisation, checkpointing every iteration
+checkpoint_dir = f"optimisation_checkpoint_np{num_processes}"
 optimiser = LinMoreOptimiser(
     minimisation_problem,
     minimisation_parameters,
-    checkpoint_dir="optimisation_checkpoint",
+    checkpoint_dir=checkpoint_dir,
 )
-run(optimiser, rf, mesh.comm.rank, "full_optimisation.dat")
+run(optimiser, rf, mesh.comm.rank, f"full_optimisation_np{num_processes}.dat")
 
 # re-initialise optimiser, and restore from checkpoint 5
 optimiser = LinMoreOptimiser(
     minimisation_problem,
     minimisation_parameters,
-    checkpoint_dir="optimisation_checkpoint",
+    checkpoint_dir=checkpoint_dir,
     auto_checkpoint=False,
 )
 optimiser.restore(5)
-run(optimiser, rf, mesh.comm.rank, "restored_optimisation_from_it_5.dat")
+run(optimiser, rf, mesh.comm.rank, f"restored_optimisation_from_it_5_np{num_processes}.dat")
 
 # re-initialise optimiser, and restore from last stored checkpoint
 
@@ -77,8 +80,8 @@ minimisation_parameters["Status Test"]["Iteration Limit"] = 15
 optimiser = LinMoreOptimiser(
     minimisation_problem,
     minimisation_parameters,
-    checkpoint_dir="optimisation_checkpoint",
+    checkpoint_dir=checkpoint_dir,
     auto_checkpoint=False,
 )
 optimiser.restore()
-run(optimiser, rf, mesh.comm.rank, "restored_optimisation_from_last_it.dat")
+run(optimiser, rf, mesh.comm.rank, f"restored_optimisation_from_last_it_np{num_processes}.dat")

--- a/tests/optimisation_checkpointing/test_checkpointing.py
+++ b/tests/optimisation_checkpointing/test_checkpointing.py
@@ -1,17 +1,19 @@
 import numpy as np
+import pytest
 from pathlib import Path
 
 
-def test_checkpointing():
+@pytest.mark.parametrize("procs", [1, 2])
+def test_checkpointing(procs):
     base = Path(__file__).parent.resolve()
 
-    full_optimisation = np.loadtxt(base / "full_optimisation.dat")
-    restored_optimisation = np.loadtxt(base / "restored_optimisation_from_it_5.dat")
+    full_optimisation = np.loadtxt(base / f"full_optimisation_np{procs}.dat")
+    restored_optimisation = np.loadtxt(base / f"restored_optimisation_from_it_5_np{procs}.dat")
 
     restored_steps = restored_optimisation.size
 
     assert np.allclose(full_optimisation[-restored_steps:], restored_optimisation)
 
-    restored_optimisation_last_it = np.loadtxt(base / "restored_optimisation_from_last_it.dat")
+    restored_optimisation_last_it = np.loadtxt(base / f"restored_optimisation_from_last_it_np{procs}.dat")
 
     assert full_optimisation[-1] > restored_optimisation_last_it[0]


### PR DESCRIPTION
Mistaken change in 30a3388 (Use comm-free UUID for optimisation checkpointing) broke parallel compatibility of optimisation checkpointing. Of course, the checkpoints for the ROL vectors need to be collective, so they all need to write to the same file with the same ID. We can go back to Firedrake's _get_uid, and just use the communicator associated with the function on the vector.