### PR TITLE
Backend changes: Stokes integrators and Approximations

### DIFF
--- a/demos/mantle_convection/base_case/base_case.py
+++ b/demos/mantle_convection/base_case/base_case.py
@@ -224,8 +224,7 @@ z.subfunctions[1].rename("Pressure")
 # allowing the simulation to exit when a steady-state has been achieved.
 
 # +
-Ra = Constant(1e4)  # Rayleigh number
-approximation = BoussinesqApproximation(Ra)
+approximation = Approximation("BA", dimensional=False, parameters={"Ra": 1e4})
 
 time = 0.0  # Initial time
 delta_t = Constant(1e-6)  # Initial time-step
@@ -312,7 +311,7 @@ output_frequency = 50
 plog = ParameterLog('params.log', mesh)
 plog.log_str("timestep time dt maxchange u_rms u_rms_surf ux_max nu_top nu_base energy avg_t")
 
-gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z, T, bottom_id=bottom_id, top_id=top_id)
 # -
 
 # We finally come to solving the variational problem, with solver
@@ -330,9 +329,14 @@ gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    approximation,
+    T,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # We can now initiate the time-loop, with the Stokes and energy

--- a/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
+++ b/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
@@ -72,7 +72,6 @@ left_id, right_id, bottom_id, top_id = 1, 2, 3, 4  # Boundary IDs
 V = VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
 W = FunctionSpace(mesh, "CG", 1)  # Pressure function space (scalar)
 Z = MixedFunctionSpace([V, W])  # Stokes function space (mixed)
-Q = FunctionSpace(mesh, "CG", 2)  # Temperature function space (scalar)
 K = FunctionSpace(mesh, "DQ", 2)  # Level-set function space (scalar, discontinuous)
 R = FunctionSpace(mesh, "R", 0)  # Real space for time step
 
@@ -80,7 +79,6 @@ z = Function(Z)  # A field over the mixed function space Z
 u, p = split(z)  # Symbolic UFL expressions for velocity and pressure
 z.subfunctions[0].rename("Velocity")  # Associated Firedrake velocity function
 z.subfunctions[1].rename("Pressure")  # Associated Firedrake pressure function
-T = Function(Q, name="Temperature")  # Firedrake function for temperature
 psi = Function(K, name="Level set")  # Firedrake function for level set
 # -
 
@@ -149,17 +147,8 @@ psi.interpolate((1 + tanh(signed_dist_to_interface / 2 / epsilon)) / 2)
 
 
 # +
-buoyant_material = Material(RaB=-1)  # Vertical direction is flipped in the benchmark
-dense_material = Material(RaB=0)
-materials = [buoyant_material, dense_material]
-
-Ra = 0  # Thermal Rayleigh number
-
-RaB = field_interface(
-    [psi], [material.RaB for material in materials], method="arithmetic"
-)  # Compositional Rayleigh number, defined based on each material value and location
-
-approximation = BoussinesqApproximation(Ra, RaB=RaB)
+Ra_c = field_interface([psi], [Ra_c_buoyant := 0, Ra_c_dense := 1], method="sharp")
+approximation = Approximation("BA", dimensional=False, parameters={"Ra_c": Ra_c})
 # -
 
 # As with the previous examples, we set up an instance of the `TimestepAdaptor` class
@@ -201,7 +190,7 @@ output_file = VTKFile("output.pvd")
 plog = ParameterLog("params.log", mesh)
 plog.log_str("step time dt u_rms entrainment")
 
-gd = GeodynamicalDiagnostics(z, T, bottom_id, top_id)
+gd = GeodynamicalDiagnostics(z)
 
 material_area = material_interface_y * lx  # Area of tracked material in the domain
 entrainment_height = 0.2  # Height above which entrainment diagnostic is calculated
@@ -216,11 +205,9 @@ entrainment_height = 0.2  # Height above which entrainment diagnostic is calcula
 # +
 stokes_solver = StokesSolver(
     z,
-    T,
     approximation,
     bcs=stokes_bcs,
-    nullspace=Z_nullspace,
-    transpose_nullspace=Z_nullspace,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
 )
 
 subcycles = 1  # Number of advection solves to perform within one time step
@@ -239,7 +226,7 @@ time_end = 2000
 while True:
     # Write output
     if time_now >= output_counter * output_frequency:
-        output_file.write(*z.subfunctions, T, psi)
+        output_file.write(*z.subfunctions, psi)
         output_counter += 1
 
     # Update timestep
@@ -276,7 +263,6 @@ plog.close()
 
 with CheckpointFile("Final_State.h5", "w") as final_checkpoint:
     final_checkpoint.save_mesh(mesh)
-    final_checkpoint.save_function(T, name="Temperature")
     final_checkpoint.save_function(z, name="Stokes")
     final_checkpoint.save_function(psi, name="Level set")
 # -

--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -1,13 +1,7 @@
 from firedrake import *
 from firedrake.output import VTKFile
 
-from .approximations import (
-    AnelasticLiquidApproximation,
-    BoussinesqApproximation,
-    ExtendedBoussinesqApproximation,
-    SmallDisplacementViscoelasticApproximation,
-    TruncatedAnelasticLiquidApproximation,
-)
+from .approximations import Approximation
 from .diagnostics import GeodynamicalDiagnostics
 from .level_set_tools import (
     LevelSetSolver,
@@ -19,8 +13,9 @@ from .level_set_tools import (
 from .limiter import VertexBasedP1DGLimiter
 from .preconditioners import FreeSurfaceMassInvPC, SPDAssembledPC
 from .stokes_integrators import (
+    InternalVariableSolver,
     StokesSolver,
-    ViscoelasticStokesSolver,
+    ViscoelasticSolver,
     create_stokes_nullspace,
 )
 from .time_stepper import (

--- a/gadopt/diagnostics.py
+++ b/gadopt/diagnostics.py
@@ -42,22 +42,23 @@ class GeodynamicalDiagnostics:
     def __init__(
         self,
         z: Function,
-        T: Function,
-        bottom_id: int,
-        top_id: int,
+        T: Function = 0,
+        /,
+        *,
+        bottom_id: int = None,
+        top_id: int = None,
         quad_degree: int = 4,
-    ):
+    ) -> None:
         mesh = extract_unique_domain(z)
 
         self.u, self.p, *_ = z.subfunctions
         self.T = T
 
         self.dx = dx(domain=mesh, degree=quad_degree)
-        self.ds = (
-            CombinedSurfaceMeasure(mesh, quad_degree)
-            if T.function_space().extruded
-            else ds(mesh)
-        )
+        if self.u.function_space().extruded:
+            self.ds = CombinedSurfaceMeasure(mesh, quad_degree)
+        else:
+            self.ds = ds(mesh)
         self.ds_t = self.ds(top_id)
         self.ds_b = self.ds(bottom_id)
 

--- a/gadopt/equations.py
+++ b/gadopt/equations.py
@@ -14,7 +14,7 @@ from warnings import warn
 
 import firedrake as fd
 
-from .approximations import BaseApproximation
+from .approximations import Approximation
 from .utility import CombinedSurfaceMeasure
 
 __all__ = ["Equation"]
@@ -56,7 +56,7 @@ class Equation:
     _: KW_ONLY
     mass_term: Callable | None = None
     eq_attrs: InitVar[dict[str, Any]] = {}
-    approximation: BaseApproximation | None = None
+    approximation: Approximation | None = None
     bcs: dict[int, dict[str, Any]] = field(default_factory=dict)
     quad_degree: InitVar[int | None] = None
     rescale_factor: Number | fd.Constant = 1

--- a/gadopt/scalar_equation.py
+++ b/gadopt/scalar_equation.py
@@ -126,7 +126,7 @@ def diffusion_term(
 
 def source_term(eq: Equation, trial: Argument | ufl.indexed.Indexed | Function) -> Form:
     r"""Scalar source term `s_T`."""
-    F = -dot(eq.test, eq.source) * eq.dx
+    F = -inner(eq.test, eq.source) * eq.dx
 
     return -F
 
@@ -134,7 +134,7 @@ def source_term(eq: Equation, trial: Argument | ufl.indexed.Indexed | Function) 
 def sink_term(eq: Equation, trial: Argument | ufl.indexed.Indexed | Function) -> Form:
     r"""Scalar sink term `\alpha_T T`."""
     # Implement sink term implicitly at current time step.
-    F = dot(eq.test, eq.sink_coeff * trial) * eq.dx
+    F = inner(eq.test, eq.sink_coeff * trial) * eq.dx
 
     return -F
 
@@ -152,7 +152,7 @@ def mass_term(eq: Equation, trial: Argument | ufl.indexed.Indexed | Function) ->
         The UFL form associated with the mass term of the equation.
 
     """
-    return dot(eq.test, trial) * eq.dx
+    return inner(eq.test, trial) * eq.dx
 
 
 advection_term.required_attrs = {"u"}
@@ -163,3 +163,5 @@ source_term.required_attrs = {"source"}
 source_term.optional_attrs = set()
 sink_term.required_attrs = {"sink_coeff"}
 sink_term.optional_attrs = set()
+
+residual_terms_internal_variable = [source_term, sink_term]

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -5,17 +5,23 @@ instantiate the `StokesSolver` class by providing relevant parameters and call t
 
 """
 
+import abc
+from collections import defaultdict
 from numbers import Number
-from typing import Optional
+from typing import Any
 
-import firedrake as fd
+from firedrake import *
 
-from .approximations import BaseApproximation, AnelasticLiquidApproximation
+from .approximations import Approximation
 from .equations import Equation
 from .free_surface_equation import free_surface_term
 from .free_surface_equation import mass_term as mass_term_fs
-from .momentum_equation import residual_terms_stokes
-from .utility import DEBUG, INFO, InteriorBC, depends_on, log_level, upward_normal
+from .momentum_equation import (
+    residual_terms_compressible_viscoelastic,
+    residual_terms_stokes,
+)
+from .scalar_equation import mass_term, residual_terms_internal_variable
+from .utility import DEBUG, INFO, InteriorBC, depends_on, log_level, vertical_component
 
 iterative_stokes_solver_parameters = {
     "mat_type": "matfree",
@@ -46,31 +52,27 @@ iterative_stokes_solver_parameters = {
         "Mp_ksp_ksp_rtol": 1e-5,
         "Mp_ksp_ksp_type": "cg",
         "Mp_ksp_pc_type": "sor",
-    }
+    },
 }
-"""Default iterative solver parameters for solution of stokes system.
+"""Default iterative solver parameters for solution of Stokes system.
 
-We configure the Schur complement approach as described in Section of
-4.3 of Davies et al. (2022), using PETSc's fieldsplit preconditioner
-type, which provides a class of preconditioners for mixed problems
-that allows a user to apply different preconditioners to different
-blocks of the system.
+We configure the Schur complement approach as described in Section of 4.3 of Davies et
+al. (2022), using PETSc's fieldsplit preconditioner type, which provides a class of
+preconditioners for mixed problems that allows a user to apply different preconditioners
+to different blocks of the system.
 
-The fieldsplit_0 entries configure solver options for the velocity
-block. The linear systems associated with this matrix are solved using
-a combination of the Conjugate Gradient (cg) method and an algebraic
-multigrid preconditioner (GAMG).
+The fieldsplit_0 entries configure solver options for the velocity block. The linear
+systems associated with this matrix are solved using a combination of the Conjugate
+Gradient (cg) method and an algebraic multigrid preconditioner (GAMG).
 
-The fieldsplit_1 entries contain solver options for the Schur
-complement solve itself. For preconditioning, we approximate the Schur
-complement matrix with a mass matrix scaled by viscosity, with the
-viscosity provided through the optional mu keyword argument to Stokes
-solver. Since this preconditioner step involves an iterative solve,
-the Krylov method used for the Schur complement needs to be of
-flexible type, and we use FGMRES by default.
+The fieldsplit_1 entries contain solver options for the Schur complement solve itself.
+For preconditioning, we approximate the Schur complement matrix with a mass matrix
+scaled by viscosity. Since this preconditioner step involves an iterative solve, the
+Krylov method used for the Schur complement needs to be of flexible type, and we use
+FGMRES by default.
 
-We note that our default solver parameters can be augmented or
-adjusted by accessing the solver_parameter dictionary, for example:
+We note that our default solver parameters can be augmented or adjusted by accessing the
+solver_parameter dictionary, for example:
 
 ```
    stokes_solver.solver_parameters['fieldsplit_0']['ksp_converged_reason'] = None
@@ -107,50 +109,584 @@ newton_stokes_solver_parameters = {
 }
 """Default solver parameters for non-linear systems.
 
-We use a setup based on Newton's method (newtonls) with a secant line
-search over the L2-norm of the function.
+We use a setup based on Newton's method (newtonls) with a secant line search over the
+L2-norm of the function.
 """
 
 
+class MetaPostInit(abc.ABCMeta):
+    """Calls the implemented __post_init__ method after __init__ returns.
+
+    The implemented behaviour allows any subclass __init__ method to first call its
+    parent class's __init__ through super(), then execute its own code, and finally call
+    __post_init__. The latter call is automatic and does not require any attention from
+    the developer or user.
+    """
+
+    def __call__(cls, *args, **kwargs):
+        class_instance = super().__call__(*args, **kwargs)
+        class_instance.__post_init__()
+
+        return class_instance
+
+
+class MassMomentumBase(abc.ABC, metaclass=MetaPostInit):
+    """Solver for a system involving mass and momentum conservation.
+
+    ### Valid keys for boundary conditions
+    |   Condition   |  Type  |                 Description                  |
+    | :------------ | :----- | :------------------------------------------: |
+    | u             | Strong | Solution                                     |
+    | ux            | Strong | Solution along the first Cartesian axis      |
+    | uy            | Strong | Solution along the second Cartesian axis     |
+    | uz            | Strong | Solution along the third Cartesian axis      |
+    | un            | Weak   | Solution along the normal to the boundary    |
+    | stress        | Weak   | Traction across the boundary                 |
+    | normal_stress | Weak   | Stress component normal to the boundary      |
+    | free_surface  | Weak   | Free-surface characteristics of the boundary |
+
+    ### Valid keys describing the free surface boundary:
+    |     Argument     | Required |                  Description                   |
+    | :--------------- | :------: | :--------------------------------------------: |
+    | eta_index        | True     | Function index in mixed space                  |
+    | rho_ext          | False    | Exterior density along the free surface        |
+    | Ra_fs            | False    | Rayleigh number at the free surface            |
+    | include_buoyancy | False    | Whether the interior density includes buoyancy |
+
+    ### Classic theta values for coupled implicit time integration
+    | Theta |        Scheme         |
+    | :---- | :-------------------: |
+    | 0.5   | Crank-Nicolson method |
+    | 1.0   | Backward Euler method |
+
+    Args:
+      solution:
+        Firedrake function representing the field over the mixed Stokes space
+      approximation:
+        G-ADOPT approximation defining terms in the system of equations
+      coupled_tstep:
+        Float quantifying the time step used in a coupled time integration
+      theta:
+        Float quantifying the implicit contribution in a coupled time integration
+      bcs:
+        Dictionary specifying boundary conditions (identifier, type, and value)
+      quad_degree:
+        Integer denoting the quadrature degree
+      solver_parameters:
+        Dictionary of PETSc solver options or string matching a default set thereof
+      J:
+        Firedrake function representing the Jacobian of the mixed Stokes system
+      constant_jacobian:
+        Boolean specifying whether the Jacobian of the system is constant
+      nullspace:
+        Dictionary of nullspace options, including transpose and near nullspaces
+    """
+
+    name = "MassMomentum"
+
+    def __init__(
+        self,
+        solution: Function,
+        approximation: Approximation,
+        /,
+        *,
+        coupled_tstep: float | None = None,
+        theta: float = 0.5,
+        bcs: dict[int, dict[str, Any]] = {},
+        quad_degree: int = 6,
+        solver_parameters: dict[str, str | Number] | str | None = None,
+        J: Function | None = None,
+        constant_jacobian: bool = False,
+        nullspace: dict[str, MixedVectorSpaceBasis] = {},
+    ) -> None:
+        self.solution = solution
+        self.approximation = approximation
+        self.coupled_tstep = coupled_tstep
+        self.theta = theta
+        self.bcs = bcs
+        self.quad_degree = quad_degree
+        self.solver_parameters = solver_parameters
+        self.J = J
+        self.constant_jacobian = constant_jacobian
+        self.nullspace = nullspace
+
+        self.solution_old = solution.copy(deepcopy=True)
+        self.solution_split = split(solution)
+        self.solution_old_split = split(self.solution_old)
+        self.solution_theta_split = [
+            theta * sol + (1 - theta) * sol_old
+            for sol, sol_old in zip(self.solution_split, self.solution_old_split)
+        ]
+
+        self.solution_space = solution.function_space()
+        self.mesh = self.solution_space.mesh()
+        self.tests = TestFunctions(self.solution_space)
+
+        self.equations = []
+        self.F = 0.0  # Weak form of the system
+
+        # Solver object is set up later to permit editing default solver options.
+        self._solver_ready = False
+
+    def __post_init__(self) -> None:
+        """Executes selected methods after the class is instantiated."""
+        self.set_boundary_conditions()
+        self.set_equations()
+        self.set_form()
+        self.set_solver_options()
+
+    def set_boundary_conditions(self) -> None:
+        """Sets strong and weak boundary conditions."""
+        self.strong_bcs = []
+        self.weak_bcs = {}
+
+        bc_map = {"u": self.solution_space.sub(0)}
+        if self.mesh.cartesian:
+            bc_map["ux"] = bc_map["u"].sub(0)
+            bc_map["uy"] = bc_map["u"].sub(1)
+            if self.mesh.geometric_dimension == 3:
+                bc_map["uz"] = bc_map["u"].sub(2)
+
+        for bc_id, bc in self.bcs.items():
+            weak_bc = defaultdict(float)
+
+            for bc_type, val in bc.items():
+                match bc_type:
+                    case "u" | "ux" | "uy" | "uz":
+                        self.strong_bcs.append(DirichletBC(bc_map[bc_type], val, bc_id))
+                    case "free_surface":
+                        weak_bc["normal_stress"] += self.set_free_surface_boundary(
+                            val, bc_id
+                        )
+                    case _:
+                        weak_bc[bc_type] += val
+
+            self.weak_bcs[bc_id] = weak_bc
+
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> ufl.algebra.Product | ufl.algebra.Sum:
+        """Sets the given boundary as a free surface.
+
+        This method calculates the normal stress at the free surface boundary. In the
+        coupled approach, it also sets a zero-interior strong condition away from that
+        boundary and populates the `free_surface_map` dictionary used to calculate the
+        free-surface contribution to the momentum weak form.
+
+        Args:
+          params_fs:
+            Dictionary holding information about the free surface boundary
+          bc_id:
+            Integer representing the index of the mesh boundary
+
+        Returns:
+          UFL expression for the normal stress at the free surface boundary
+        """
+
+    @abc.abstractmethod
+    def set_equations(self):
+        """Sets Equation instances for each equation in the system.
+
+        Equations must be ordered like solutions in the mixed space.
+        """
+
+    def set_form(self) -> None:
+        """Sets the weak form including linear and bilinear terms."""
+        for equation, solution, solution_old in zip(
+            self.equations, self.solution_split, self.solution_old_split
+        ):
+            if equation.mass_term:
+                assert equation.scaling_factor == -self.theta
+                self.F += equation.mass((solution - solution_old) / self.coupled_tstep)
+            self.F -= equation.residual(solution)
+
+    def set_solver_options(self) -> None:
+        """Sets PETSc solver parameters."""
+        # Application context for the inverse mass matrix preconditioner
+        self.appctx = {"mu": self.approximation.mu / self.approximation.rho}
+
+        if isinstance(solver_preset := self.solver_parameters, dict):
+            return
+
+        if not depends_on(self.approximation.mu, self.solution):
+            self.solver_parameters = {"snes_type": "ksponly"}
+        else:
+            self.solver_parameters = newton_stokes_solver_parameters.copy()
+
+        if INFO >= log_level:
+            self.solver_parameters["snes_monitor"] = None
+
+        if solver_preset is not None:
+            match solver_preset:
+                case "direct":
+                    self.solver_parameters.update(direct_stokes_solver_parameters)
+                case "iterative":
+                    self.solver_parameters.update(iterative_stokes_solver_parameters)
+                case _:
+                    raise ValueError("Solver type must be 'direct' or 'iterative'.")
+        elif self.mesh.topological_dimension() == 2 and self.mesh.cartesian:
+            self.solver_parameters.update(direct_stokes_solver_parameters)
+        else:
+            self.solver_parameters.update(iterative_stokes_solver_parameters)
+
+        # Extra options for iterative solvers
+        if self.solver_parameters.get("pc_type") == "fieldsplit":
+            if DEBUG >= log_level:
+                self.solver_parameters["fieldsplit_0"]["ksp_converged_reason"] = None
+                self.solver_parameters["fieldsplit_1"]["ksp_monitor"] = None
+            elif INFO >= log_level:
+                self.solver_parameters["fieldsplit_1"]["ksp_converged_reason"] = None
+
+    def setup_solver(self) -> None:
+        """Sets up the solver."""
+        if self.constant_jacobian:
+            trial = TrialFunction(self.solution_space)
+            F = replace(self.F, {self.solution: trial})
+            a, L = lhs(F), rhs(F)
+
+            self.problem = LinearVariationalProblem(
+                a, L, self.solution, bcs=self.strong_bcs, constant_jacobian=True
+            )
+            self.solver = LinearVariationalSolver(
+                self.problem,
+                solver_parameters=self.solver_parameters,
+                **self.nullspace,
+                options_prefix=self.name,
+                appctx=self.appctx,
+            )
+        else:
+            self.problem = NonlinearVariationalProblem(
+                self.F, self.solution, bcs=self.strong_bcs, J=self.J
+            )
+            self.solver = NonlinearVariationalSolver(
+                self.problem,
+                solver_parameters=self.solver_parameters,
+                **self.nullspace,
+                options_prefix=self.name,
+                appctx=self.appctx,
+            )
+
+        self._solver_ready = True
+
+    def solver_callback(self) -> None:
+        """Instructions to execute right after a solve."""
+        self.solution_old.assign(self.solution)
+
+    def solve(self) -> None:
+        """Solves the system."""
+        if not self._solver_ready:
+            self.setup_solver()
+
+        self.solver.solve()
+        self.solver_callback()
+
+
+class StokesSolver(MassMomentumBase):
+    """Solver for the Stokes system.
+
+    Args:
+      solution:
+        Firedrake function representing the field over the mixed Stokes space
+      approximation:
+        G-ADOPT approximation defining terms in the system of equations
+      T:
+        Firedrake function representing the temperature field
+      coupled_fields:
+        Dictionary in a coupled time integration
+      coupled_tstep:
+        Float quantifying the time step used in a coupled time integration
+      theta:
+        Float quantifying the implicit contribution in a coupled time integration
+      bcs:
+        Dictionary specifying boundary conditions (identifier, type, and value)
+      quad_degree:
+        Integer denoting the quadrature degree
+      solver_parameters:
+        Dictionary of PETSc solver options or string matching a default set thereof
+      J:
+        Firedrake function representing the Jacobian of the mixed Stokes system
+      constant_jacobian:
+        Boolean specifying whether the Jacobian of the system is constant
+      nullspace:
+        Dictionary of nullspace options, including transpose and near nullspaces
+    """
+
+    name = "Stokes"
+
+    def __init__(
+        self,
+        solution: Function,
+        approximation: Approximation,
+        T: Function | float = 0.0,
+        /,
+        **kwargs,
+    ) -> None:
+        super().__init__(solution, approximation, **kwargs)
+
+        self.T = T
+
+        self.free_surface_map = {}
+        self.buoyancy_fs = [None] * len(self.solution_split)
+
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> ufl.algebra.Product | ufl.algebra.Sum:
+        # Extract the free-surface index and associate it with the boundary id
+        eta_ind = params_fs["eta_index"]
+        self.free_surface_map[bc_id] = eta_ind
+
+        # Set internal degrees of freedom to zero to prevent singular matrix
+        self.strong_bcs.append(InteriorBC(self.solution_space[eta_ind], 0, bc_id))
+
+        self.buoyancy_fs[eta_ind] = self.approximation.buoyancy(
+            p=self.solution_split[1], T=self.T, params_fs=params_fs
+        )
+
+        return self.buoyancy_fs[eta_ind] * self.solution_theta_split[eta_ind]
+
+    def set_equations(self) -> None:
+        u, p = self.solution_split[:2]
+        eqs_attrs = [{"p": p, "T": self.T}, {"u": u}]
+
+        for i in range(len(residual_terms_stokes)):
+            self.equations.append(
+                Equation(
+                    self.tests[i],
+                    self.solution_space[i],
+                    residual_terms_stokes[i],
+                    eq_attrs=eqs_attrs[i],
+                    approximation=self.approximation,
+                    bcs=self.weak_bcs,
+                    quad_degree=self.quad_degree,
+                )
+            )
+
+        for bc_id, eta_ind in self.free_surface_map.items():
+            eq_attrs = {
+                "boundary_id": bc_id,
+                "buoyancy": self.buoyancy_fs[eta_ind],
+                "u": u,
+            }
+
+            self.equations.append(
+                Equation(
+                    self.tests[eta_ind],
+                    self.solution_space[eta_ind],
+                    free_surface_term,
+                    mass_term=mass_term_fs,
+                    eq_attrs=eq_attrs,
+                    quad_degree=self.quad_degree,
+                    scaling_factor=-self.theta,
+                )
+            )
+
+    def set_solver_options(self) -> None:
+        super().set_solver_options()
+
+        if (
+            self.free_surface_map
+            and self.solver_parameters.get("pc_type") == "fieldsplit"
+        ):
+            # Update application context
+            self.appctx["free_surface"] = self.free_surface_map
+            self.appctx["ds"] = self.equations[-1].ds
+
+            # Gather pressure and free surface fields for Schur complement solve
+            fields_ind = ",".join(map(str, range(1, len(self.solution_split))))
+            self.solver_parameters.update(
+                {"pc_fieldsplit_0_fields": "0", "pc_fieldsplit_1_fields": fields_ind}
+            )
+            # Update mass inverse preconditioner
+            self.solver_parameters["fieldsplit_1"].update(
+                {"pc_python_type": "gadopt.FreeSurfaceMassInvPC"}
+            )
+
+
+class ViscoelasticSolver(MassMomentumBase):
+    """Solves the Stokes system assuming a Maxwell viscoelastic rheology.
+
+    Args:
+      solution:
+        Firedrake function representing the field over the mixed Stokes space.
+      displ:
+        Firedrake function representing the total displacement.
+      tau_old:
+        Firedrake function representing the deviatoric stress at the previous time step.
+      approximation:
+        G-ADOPT approximation defining terms in the system of equations.
+      dt:
+        Float representing the simulation's timestep.
+      bcs:
+        Dictionary specifying boundary conditions (identifier, type, and value).
+      quad_degree:
+        Integer denoting the quadrature degree. Default value is `2p + 1`, where p is
+        the polynomial degree of the trial space.
+      solver_parameters:
+        Either a dictionary of PETSc solver parameters or a string specifying a default
+        set of parameters defined in G-ADOPT.
+      J:
+        Firedrake function representing the Jacobian of the mixed Stokes system.
+      constant_jacobian:
+        A boolean specifying whether the Jacobian of the system is constant.
+      nullspace:
+        Dictionary of nullspace options, including transpose and near nullspaces.
+    """
+
+    name = "Viscoelastic"
+
+    def __init__(
+        self,
+        solution: Function,
+        displ: Function,
+        tau_old: Function,
+        approximation: Approximation,
+        dt: float | Constant | Function,
+        **kwargs,
+    ) -> None:
+        super().__init__(solution, approximation, **kwargs)
+
+        self.displ = displ
+        self.tau_old = tau_old
+
+        # Characteristic time scale
+        maxwell_time = approximation.mu / approximation.G
+        # Effective viscosity
+        approximation.mu = approximation.mu / (maxwell_time + dt / 2)
+        # Scaling factor for the previous stress
+        self.stress_scale = (maxwell_time - dt / 2) / (maxwell_time + dt / 2)
+
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> ufl.algebra.Product | ufl.algebra.Sum:
+        # First, make the displacement term implicit by incorporating the unknown
+        # `incremental displacement' (u) that we are solving for. Then, calculate the
+        # free surface stress term. This is also referred to as the Hydrostatic
+        # Prestress advection term in the GIA literature.
+        u, p = self.solution_split[:2]
+        buoyancy_fs = self.approximation.buoyancy(
+            p=p, displ=self.displ, params_fs=params_fs
+        )
+
+        return buoyancy_fs * vertical_component(u + self.displ)
+
+    def set_equations(self) -> None:
+        """Sets up UFL forms for the viscoelastic Stokes equations residual."""
+        u, p = self.solution_split
+        eqs_attrs = [
+            {"p": p, "displ": self.displ, "stress_old": self.tau_old},
+            {"u": u},
+        ]
+
+        for i in range(len(residual_terms_stokes)):
+            self.equations.append(
+                Equation(
+                    self.tests[i],
+                    self.solution_space[i],
+                    residual_terms_stokes[i],
+                    eq_attrs=eqs_attrs[i],
+                    approximation=self.approximation,
+                    bcs=self.weak_bcs,
+                    quad_degree=self.quad_degree,
+                )
+            )
+
+    def solver_callback(self) -> None:
+        u = self.solution_split[0]
+        self.displ.interpolate(self.displ + u)
+        self.tau_old.interpolate(
+            self.stress_scale * self.approximation.stress(u, stress_old=self.tau_old)
+        )
+
+
+class InternalVariableSolver(MassMomentumBase):
+    name = "InternalVariable"
+
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> ufl.algebra.Product | ufl.algebra.Sum:
+        u = self.solution_split[0]
+        buoyancy_fs = self.approximation.buoyancy(displ=u, params_fs=params_fs)
+
+        return buoyancy_fs * vertical_component(u)
+
+    def set_equations(self) -> None:
+        u, *m = self.solution_split
+        maxwell_time = self.approximation.mu / self.approximation.G
+        strain = self.approximation.strain(u)
+
+        residual_terms = [
+            residual_terms_compressible_viscoelastic,
+            residual_terms_internal_variable,
+        ]
+        eqs_attrs = [
+            {"m": m, "displ": u},
+            {"source": strain / maxwell_time, "sink_coeff": 1 / maxwell_time},
+        ]
+        mass_terms = [None, mass_term]
+        scaling_factors = [1, -self.theta]
+
+        for i in range(len(self.tests)):
+            self.equations.append(
+                Equation(
+                    self.tests[i],
+                    self.solution_space[i],
+                    residual_terms[i],
+                    mass_term=mass_terms[i],
+                    eq_attrs=eqs_attrs[i],
+                    approximation=self.approximation,
+                    bcs=self.weak_bcs,
+                    quad_degree=self.quad_degree,
+                    scaling_factor=scaling_factors[i],
+                )
+            )
+
+
 def create_stokes_nullspace(
-    Z: fd.functionspaceimpl.WithGeometry,
+    Z: functionspaceimpl.WithGeometry,
     closed: bool = True,
     rotational: bool = False,
-    translations: Optional[list[int]] = None,
-    ala_approximation: Optional[AnelasticLiquidApproximation] = None,
-    top_subdomain_id: Optional[str | int] = None,
-) -> fd.nullspace.MixedVectorSpaceBasis:
+    translations: list[int] | None = None,
+    approximation: Approximation | None = None,
+    top_subdomain_id: str | int | None = None,
+) -> nullspace.MixedVectorSpaceBasis:
     """Create a null space for the mixed Stokes system.
 
-    Arguments:
-      Z: Firedrake mixed function space associated with the Stokes system
-      closed: Whether to include a constant pressure null space
-      rotational: Whether to include all rotational modes
-      translations: List of translations to include
-      ala_approximation: AnelasticLiquidApproximation for calculating (non-constant) right nullspace
-      top_subdomain_id: Boundary id of top surface. Required when providing
-                        ala_approximation.
+    Args:
+      Z:
+        Firedrake mixed function space associated with the Stokes system
+      closed:
+        Whether to include a constant pressure null space
+      rotational:
+        Whether to include all rotational modes
+      translations:
+        List of translations to include
+      approximation:
+        Approximation (ALA) for calculating (non-constant) right nullspace
+      top_subdomain_id:
+        Boundary id of top surface; required when providing approximation
 
     Returns:
       A Firedrake mixed vector space basis incorporating the null space components
-
     """
-    # ala_approximation and top_subdomain_id are both needed when calculating right nullspace for ala
-    if (ala_approximation is None) != (top_subdomain_id is None):
-        raise ValueError("Both ala_approximation and top_subdomain_id must be provided, or both must be None.")
+    # approximation and top_subdomain_id are both needed when calculating right
+    # nullspace for ala
+    if (approximation is None) != (top_subdomain_id is None):
+        raise ValueError(
+            "Both approximation and top_subdomain_id must be provided, or both "
+            "must be None."
+        )
 
-    X = fd.SpatialCoordinate(Z.mesh())
+    X = SpatialCoordinate(Z.mesh())
     dim = len(X)
-    stokes_subspaces = Z.subfunctions
 
     if rotational:
         if dim == 2:
-            rotV = fd.Function(stokes_subspaces[0]).interpolate(fd.as_vector((-X[1], X[0])))
+            rotV = Function(Z[0]).interpolate(as_vector((-X[1], X[0])))
             basis = [rotV]
         elif dim == 3:
-            x_rotV = fd.Function(stokes_subspaces[0]).interpolate(fd.as_vector((0, -X[2], X[1])))
-            y_rotV = fd.Function(stokes_subspaces[0]).interpolate(fd.as_vector((X[2], 0, -X[0])))
-            z_rotV = fd.Function(stokes_subspaces[0]).interpolate(fd.as_vector((-X[1], X[0], 0)))
+            x_rotV = Function(Z[0]).interpolate(as_vector((0, -X[2], X[1])))
+            y_rotV = Function(Z[0]).interpolate(as_vector((X[2], 0, -X[0])))
+            z_rotV = Function(Z[0]).interpolate(as_vector((-X[1], X[0], 0)))
             basis = [x_rotV, y_rotV, z_rotV]
         else:
             raise ValueError("Unknown dimension")
@@ -161,485 +697,106 @@ def create_stokes_nullspace(
         for tdim in translations:
             vec = [0] * dim
             vec[tdim] = 1
-            basis.append(fd.Function(stokes_subspaces[0]).interpolate(fd.as_vector(vec)))
+            basis.append(Function(Z[0]).interpolate(as_vector(vec)))
 
     if basis:
-        V_nullspace = fd.VectorSpaceBasis(basis, comm=Z.mesh().comm)
+        V_nullspace = VectorSpaceBasis(basis, comm=Z.mesh().comm)
         V_nullspace.orthonormalize()
     else:
-        V_nullspace = stokes_subspaces[0]
+        V_nullspace = Z[0]
 
     if closed:
-        if ala_approximation:
-            p = ala_right_nullspace(W=stokes_subspaces[1], approximation=ala_approximation, top_subdomain_id=top_subdomain_id)
-            p_nullspace = fd.VectorSpaceBasis([p], comm=Z.mesh().comm)
+        if approximation and approximation.preset == "ALA":
+            p = ala_right_nullspace(Z[1], approximation, top_subdomain_id)
+            p_nullspace = VectorSpaceBasis([p], comm=Z.mesh().comm)
             p_nullspace.orthonormalize()
         else:
-            p_nullspace = fd.VectorSpaceBasis(constant=True, comm=Z.mesh().comm)
+            p_nullspace = VectorSpaceBasis(constant=True, comm=Z.mesh().comm)
     else:
-        p_nullspace = stokes_subspaces[1]
+        p_nullspace = Z[1]
 
     null_space = [V_nullspace, p_nullspace]
 
     # If free surface unknowns, add dummy free surface nullspace
-    null_space += stokes_subspaces[2:]
+    null_space += Z[2:]
 
-    return fd.MixedVectorSpaceBasis(Z, null_space)
-
-
-class StokesSolver:
-    """Solves the Stokes system in place.
-
-    Arguments:
-      z: Firedrake function representing mixed Stokes system
-      T: Firedrake function representing temperature
-      approximation: Approximation describing system of equations
-      bcs: Dictionary of identifier-value pairs specifying boundary conditions
-      quad_degree: Quadrature degree. Default value is `2p + 1`, where
-                   p is the polynomial degree of the trial space
-      solver_parameters: Either a dictionary of PETSc solver parameters or a string
-                         specifying a default set of parameters defined in G-ADOPT
-      J: Firedrake function representing the Jacobian of the system
-      constant_jacobian: Whether the Jacobian of the system is constant
-      free_surface_dt: Timestep for advancing free surface equation
-      free_surface_theta: Timestepping prefactor for free surface equation, where
-                          theta = 0: Forward Euler, theta = 0.5: Crank-Nicolson (default),
-                          or theta = 1: Backward Euler
-
-    """
-
-    name = "Stokes"
-
-    def __init__(
-        self,
-        z: fd.Function,
-        T: fd.Function,
-        approximation: BaseApproximation,
-        bcs: dict[int, dict[str, Number]] = {},
-        quad_degree: int = 6,
-        solver_parameters: Optional[dict[str, str | Number] | str] = None,
-        J: Optional[fd.Function] = None,
-        constant_jacobian: bool = False,
-        free_surface_dt: Optional[float] = None,
-        free_surface_theta: float = 0.5,
-        **kwargs,
-    ):
-        self.Z = z.function_space()
-        self.mesh = self.Z.mesh()
-        self.test = fd.TestFunctions(self.Z)
-        self.solution = z
-        self.T = T
-        self.approximation = approximation
-        self.quad_degree = quad_degree
-
-        self.J = J
-        self.constant_jacobian = constant_jacobian
-        self.linear = not depends_on(self.approximation.mu, self.solution)
-
-        self.solver_kwargs = kwargs
-
-        self.k = upward_normal(self.mesh)
-
-        # Setup boundary conditions
-        self.weak_bcs = {}
-        self.strong_bcs = []
-
-        # Free surface parameters
-        self.free_surface_dict = {}
-        self.free_surface_dt = free_surface_dt
-        self.free_surface_theta = free_surface_theta  # theta = 0.5 gives a second order accurate integration scheme in time
-        self.free_surface = False
-
-        for id, bc in bcs.items():
-            weak_bc = {}
-            for bc_type, value in bc.items():
-                if bc_type == 'u':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0), value, id))
-                elif bc_type == 'ux':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(0), value, id))
-                elif bc_type == 'uy':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(1), value, id))
-                elif bc_type == 'uz':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(2), value, id))
-                elif bc_type == 'free_surface':
-                    # N.b. stokes_integrators assumes that the order of the bcs matches the order of the
-                    # free surfaces defined in the mixed space. This is not ideal - python dictionaries
-                    # are ordered by insertion only since recently (since 3.7) - so relying on their order
-                    # is fraught and not considered pythonic. At the moment let's consider having more
-                    # than one free surface a bit of a niche case for now, and leave it as is...
-
-                    # Copy free surface information to a new dictionary
-                    self.free_surface_dict[id] = value
-                    self.free_surface = True
-                else:
-                    weak_bc[bc_type] = value
-            self.weak_bcs[id] = weak_bc
-
-        # eta is a list of 0, 1 or multiple free surface fields
-        self.u, self.p, *self.eta = fd.split(self.solution)
-
-        self.rho_mass = self.approximation.rho_continuity()
-        self.setup_equation_attributes()
-
-        self.equations = []
-        for i, (terms_eq, eq_attrs) in enumerate(zip(residual_terms_stokes, self.eqs_attrs)):
-            self.equations.append(
-                Equation(
-                    self.test[i],
-                    self.Z[i],
-                    terms_eq,
-                    eq_attrs=eq_attrs,
-                    approximation=self.approximation,
-                    bcs=self.weak_bcs,
-                    quad_degree=quad_degree,
-                )
-            )
-
-        if self.free_surface:
-            self.setup_free_surface()
-
-        self.F = 0
-        for eq, trial in zip(self.equations, fd.split(self.solution)):
-            self.F -= eq.residual(trial)
-
-        if self.free_surface:
-            for i in range(len(self.eta)):
-                # Add free surface time derivative term
-                # (N.b. we already have two equations from StokesEquations)
-                self.F += self.equations[2+i].mass((self.eta[i]-self.eta_old[i])/self.free_surface_dt)
-
-        if isinstance(solver_parameters, dict):
-            self.solver_parameters = solver_parameters
-        else:
-            if self.linear:
-                self.solver_parameters = {"snes_type": "ksponly"}
-            else:
-                self.solver_parameters = newton_stokes_solver_parameters.copy()
-
-            if INFO >= log_level:
-                self.solver_parameters["snes_monitor"] = None
-
-            if isinstance(solver_parameters, str):
-                match solver_parameters:
-                    case "direct":
-                        self.solver_parameters.update(direct_stokes_solver_parameters)
-                    case "iterative":
-                        self.solver_parameters.update(
-                            iterative_stokes_solver_parameters
-                        )
-                    case _:
-                        raise ValueError(
-                            f"Solver type '{solver_parameters}' not implemented."
-                        )
-            elif self.mesh.topological_dimension() == 2 and self.mesh.cartesian:
-                self.solver_parameters.update(direct_stokes_solver_parameters)
-            else:
-                self.solver_parameters.update(iterative_stokes_solver_parameters)
-
-            if self.solver_parameters.get("pc_type") == "fieldsplit":
-                # extra options for iterative solvers
-                if DEBUG >= log_level:
-                    self.solver_parameters['fieldsplit_0']['ksp_converged_reason'] = None
-                    self.solver_parameters['fieldsplit_1']['ksp_monitor'] = None
-                elif INFO >= log_level:
-                    self.solver_parameters['fieldsplit_1']['ksp_converged_reason'] = None
-
-                if self.free_surface:
-                    # merge free surface fields with pressure field for Schur complement solve
-                    self.solver_parameters.update({"pc_fieldsplit_0_fields": '0',
-                                                   "pc_fieldsplit_1_fields": '1,'+','.join(str(2+i) for i in range(len(self.eta)))})
-
-                    # update keys for GADOPT's free surface mass inverse preconditioner
-                    self.solver_parameters["fieldsplit_1"].update({"pc_python_type": "gadopt.FreeSurfaceMassInvPC"})
-
-        # solver object is set up later to permit editing default solver parameters specified above
-        self._solver_setup = False
-
-    def setup_equation_attributes(self):
-        stress = self.approximation.stress(self.u)
-        source = self.approximation.buoyancy(self.p, self.T) * self.k
-        self.eqs_attrs = [{"p": self.p, "stress": stress, "source": source}, {"u": self.u, "rho_mass": self.rho_mass}]
-
-    def setup_free_surface(self):
-        if self.free_surface_dt is None:
-            raise TypeError(
-                "Please provide a timestep to advance the free surface, currently free_surface_dt=None."
-            )
-
-        u_, p_, *self.eta_ = self.solution.subfunctions
-        self.eta_old = []
-        self.eta_theta = []
-        self.free_surface_id_list = []
-
-        c = 0  # Counter for free surfaces (N.b. we already have two equations from StokesEquations)
-        for free_surface_id, free_surface_params in self.free_surface_dict.items():
-            # Define free surface variables for timestepping
-            self.eta_old.append(fd.Function(self.eta_[c]))
-            self.eta_theta.append(
-                (1 - self.free_surface_theta) * self.eta_old[c]
-                + self.free_surface_theta * self.eta[c]
-            )
-
-            # Normal stress #
-            # Depending on variable_free_surface_density flag provided to approximation the
-            # interior density below the free surface is either set to a constant density or
-            # varies spatially according to the buoyancy field
-            # N.b. constant reference density is needed for analytical cylindrical cases
-            # Prefactor #
-            # To ensure the top right and bottom left corners of the block matrix remains symmetric we need to
-            # multiply the free surface equation (kinematic bc) with -theta * delta_rho * g. This is similar
-            # to rescaling eta -> eta_tilde in Kramer et al. 2012 (e.g. see block matrix shown in Eq 23)
-            # N.b. in the case where the density contrast across the free surface is spatially variant due to
-            # interior buoyancy changes then the matrix will not be exactly symmetric.
-            normal_stress, prefactor = self.approximation.free_surface_terms(
-                self.p, self.T, self.eta_theta[c], self.free_surface_theta, **free_surface_params
-            )
-
-            # Add free surface stress term
-            if 'normal_stress' in self.weak_bcs[free_surface_id]:
-                # Usually there will be also an ice/water loadi acting as a normal stress in the GIA problem
-                existing_value = self.weak_bcs[free_surface_id]['normal_stress']
-                self.weak_bcs[free_surface_id]['normal_stress'] = existing_value + normal_stress
-            else:
-                self.weak_bcs[free_surface_id] = {'normal_stress': normal_stress}
-
-            eq_attrs = {
-                "boundary_id": free_surface_id,
-                "buoyancy_scale": prefactor,
-                "u": self.u,
-            }
-
-            # Add the free surface equation
-            self.equations.append(
-                Equation(
-                    self.test[2 + c],
-                    self.Z[2 + c],
-                    free_surface_term,
-                    mass_term=mass_term_fs,
-                    eq_attrs=eq_attrs,
-                    quad_degree=self.quad_degree,
-                )
-            )
-
-            # Set internal dofs to zero to prevent singular matrix for free surface equation
-            self.strong_bcs.append(
-                InteriorBC(self.Z.sub(2 + c), 0, free_surface_id)
-            )
-
-            self.free_surface_id_list.append(free_surface_id)
-
-            c += 1
-
-    def setup_solver(self):
-        """Sets up the solver."""
-        # mu used in MassInvPC:
-        appctx = {"mu": self.approximation.mu / self.approximation.rho_continuity()}
-
-        if self.free_surface:
-            appctx["free_surface_id_list"] = self.free_surface_id_list
-            appctx["ds"] = self.equations[2].ds
-
-        if self.constant_jacobian:
-            z_tri = fd.TrialFunction(self.Z)
-            F_stokes_lin = fd.replace(self.F, {self.solution: z_tri})
-            a, L = fd.lhs(F_stokes_lin), fd.rhs(F_stokes_lin)
-            self.problem = fd.LinearVariationalProblem(
-                a, L, self.solution, bcs=self.strong_bcs, constant_jacobian=True
-            )
-            self.solver = fd.LinearVariationalSolver(
-                self.problem,
-                solver_parameters=self.solver_parameters,
-                options_prefix=self.name,
-                appctx=appctx,
-                **self.solver_kwargs,
-            )
-        else:
-            self.problem = fd.NonlinearVariationalProblem(
-                self.F, self.solution, bcs=self.strong_bcs, J=self.J
-            )
-            self.solver = fd.NonlinearVariationalSolver(
-                self.problem,
-                solver_parameters=self.solver_parameters,
-                options_prefix=self.name,
-                appctx=appctx,
-                **self.solver_kwargs,
-            )
-
-        self._solver_setup = True
-
-    def solve(self):
-        """Solves the system."""
-        if not self._solver_setup:
-            self.setup_solver()
-
-        # Need to update old free surface height for implicit free surface
-        if self.free_surface:
-            for i in range(len(self.eta_)):
-                self.eta_old[i].assign(self.eta_[i])
-
-        self.solver.solve()
+    return MixedVectorSpaceBasis(Z, null_space)
 
 
 def ala_right_nullspace(
-        W: fd.functionspaceimpl.WithGeometry,
-        approximation: AnelasticLiquidApproximation,
-        top_subdomain_id: str | int):
+    W: functionspaceimpl.WithGeometry,
+    approximation: Approximation,
+    top_subdomain_id: str | int,
+) -> Function:
     r"""Compute pressure nullspace for Anelastic Liquid Approximation.
 
-        Arguments:
-          W: pressure function space
-          approximation: AnelasticLiquidApproximation with equation parameters
-          top_subdomain_id: boundary id of top surface
+    Args:
+      W: pressure function space
+      approximation: AnelasticLiquidApproximation with equation parameters
+      top_subdomain_id: boundary id of top surface
 
-        Returns:
-          pressure nullspace solution
+    Returns:
+      pressure nullspace solution
 
-        To obtain the pressure nullspace solution for the Stokes equation in Anelastic Liquid Approximation,
-        which includes a pressure-dependent buoyancy term, we try to solve the equation:
+    To obtain the pressure nullspace solution for the Stokes equation in the Anelastic
+    Liquid Approximation (which includes a pressure-dependent buoyancy term), we try to
+    solve the equation:
 
-        $$
-          -nabla p + g "Di" rho chi c_p/(c_v gamma) hatk p = 0
-        $$
+    $$
+      -nabla p + g "Di" rho chi c_p/(c_v gamma) hatk p = 0
+    $$
 
-        Taking the divergence:
+    Taking the divergence:
 
-        $$
-          -nabla * nabla p + nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) = 0,
-        $$
+    $$
+      -nabla * nabla p + nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) = 0,
+    $$
 
-        then testing it with q:
+    then testing it with q:
 
-        $$
-            int_Omega -q nabla * nabla p dx + int_Omega q nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) dx = 0
-        $$
+    $$
+        int_Omega -q nabla * nabla p dx + int_Omega q nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) dx = 0
+    $$
 
-        followed by integration by parts:
+    followed by integration by parts:
 
-        $$
-            int_Gamma -bb n * q nabla p ds + int_Omega nabla q cdot nabla p dx +
-            int_Gamma bb n * hatk q g "Di" rho chi c_p/(c_v gamma) p dx -
-            int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0
-        $$
+    $$
+        int_Gamma -bb n * q nabla p ds + int_Omega nabla q cdot nabla p dx +
+        int_Gamma bb n * hatk q g "Di" rho chi c_p/(c_v gamma) p dx -
+        int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0
+    $$
 
-        This elliptic equation can be solved with natural boundary conditions by imposing our original equation above, which eliminates
-        all boundary terms:
+    This elliptic equation can be solved with natural boundary conditions by imposing
+    our original equation above, which eliminates all boundary terms:
 
-        $$
-          int_Omega nabla q * nabla p dx - int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0.
-        $$
+    $$
+      int_Omega nabla q * nabla p dx - int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0.
+    $$
 
-        However, if we do so on all boundaries we end up with a system that has the same nullspace, as the one we are after (note that
-        we ended up merely testing the original equation with $nabla q$). Instead we use the fact that the gradient of the null mode
-        is always vertical, and thus the null mode is constant at any horizontal level (geoid), specifically the top surface. Choosing
-        any nonzero constant for this surface fixes the arbitrary scalar multiplier of the null mode. We choose the value of one
-        and apply it as a Dirichlet boundary condition.
+    However, if we do so on all boundaries we end up with a system that has the same
+    nullspace as the one we are after (note that we ended up merely testing the original
+    equation with $nabla q$). Instead, we use the fact that the gradient of the null
+    mode is always vertical, and thus the null mode is constant at any horizontal level
+    (geoid), such as the top surface. Choosing any nonzero constant for this surface
+    fixes the arbitrary scalar multiplier of the null mode. We choose the value of one
+    and apply it as a Dirichlet boundary condition.
 
-        Note that this procedure does not necessarily compute the exact nullspace of the *discretised* Stokes system. In particular,
-        since not every test function $v in V$, the velocity test space, can be written as $v=nabla q$ with $q in W$, the
-        pressure test space, the two terms do not necessarily exactly cancel when tested with $v$ instead of $nabla q$ as in our
-        final equation. However, in practice the discrete error appears to be small enough, and providing this nullspace gives
-        an improved convergence of the iterative Stokes solver.
+    Note that this procedure does not necessarily compute the exact nullspace of the
+    *discretised* Stokes system. In particular, since not every test function $v$ in
+    $V$, the velocity test space, can be written as $v=nabla q$ with $q in W$, the
+    pressure test space, the two terms do not necessarily exactly cancel when tested
+    with $v$ instead of $nabla q$ as in our final equation. However, in practice, the
+    discrete error appears to be small enough, and providing this nullspace gives an
+    improved convergence of the iterative Stokes solver.
     """
-    W = fd.FunctionSpace(mesh=W.mesh(), family=W.ufl_element())
-    q = fd.TestFunction(W)
-    p = fd.Function(W, name="pressure_nullspace")
+    W = FunctionSpace(mesh=W.mesh(), family=W.ufl_element())
+    q = TestFunction(W)
+    p = Function(W, name="Pressure nullspace")
+
+    F = inner(grad(q), grad(p)) * dx
+    F += vertical_component(grad(q) * approximation.buoyancy(p=p)) * dx
 
     # Fix the solution at the top boundary
-    bc = fd.DirichletBC(W, 1., top_subdomain_id)
+    solve(F == 0, p, bcs=DirichletBC(W, 1.0, top_subdomain_id))
 
-    F = fd.inner(fd.grad(q), fd.grad(p)) * fd.dx
-
-    k = upward_normal(W.mesh())
-
-    F += - fd.inner(fd.grad(q), k * approximation.dbuoyancydp(p, fd.Constant(1.0)) * p) * fd.dx
-
-    fd.solve(F == 0, p, bcs=bc)
     return p
-
-
-class ViscoelasticStokesSolver(StokesSolver):
-    """Solves the Stokes system assuming a Maxwell viscoelastic rheology.
-
-    Arguments:
-      z: Firedrake function representing mixed Stokes system
-      stress_old: Firedrake function representing deviatoric stress from previous timestep
-      displacement: Firedrake function representing displacement field
-      approximation: Approximation describing system of equations
-      dt: Timestep for viscoelastic rheology
-      bcs: Dictionary of identifier-value pairs specifying boundary conditions
-      quad_degree: Quadrature degree. Default value is `2p + 1`, where
-                   p is the polynomial degree of the trial space
-      solver_parameters: Either a dictionary of PETSc solver parameters or a string
-                         specifying a default set of parameters defined in G-ADOPT
-      J: Firedrake function representing the Jacobian of the system
-      constant_jacobian: Whether the Jacobian of the system is constant
-    """
-
-    name = "ViscoelasticStokesSolver"
-
-    def __init__(
-        self,
-        z: fd.Function,
-        stress_old: fd.Function,
-        displacement: fd.Function,
-        approximation: BaseApproximation,
-        dt: Number | fd.Constant,
-        bcs: dict[int, dict[str, Number]] = {},
-        quad_degree: int = 6,
-        solver_parameters: Optional[dict[str, str | Number] | str] = None,
-        J: Optional[fd.Function] = None,
-        constant_jacobian: bool = False,
-        **kwargs,
-    ):
-        self.stress_old = stress_old  # Function to store deviatoric stress from previous time step
-        self.displacement = displacement
-        self.dt = dt
-
-        approximation.mu = approximation.effective_viscosity(self.dt)
-
-        # This isn't used in the viscoelastic code but StokesSolver currently assumes temperature is required as an argument
-        T_placeholder = fd.Constant(0)
-
-        super().__init__(z, T_placeholder, approximation, bcs=bcs,
-                         quad_degree=quad_degree, solver_parameters=solver_parameters,
-                         J=J, constant_jacobian=constant_jacobian, free_surface_dt=self.dt,
-                         **kwargs)
-
-        scale_mu = fd.Constant(1e10)  # this is a scaling factor roughly size of mantle maxwell time to make sure that solve converges with strong bcs in parallel...
-        self.F = (1 / scale_mu)*self.F
-
-    def setup_equation_attributes(self):
-        stress = self.approximation.stress(self.u, self.stress_old, self.dt)
-        source = self.approximation.buoyancy(self.displacement) * self.k
-        self.eqs_attrs = [{"p": self.p, "stress": stress, "source": source}, {"u": self.u, "rho_mass": self.rho_mass}]
-
-    def setup_free_surface(self):
-        # Overload method
-        for free_surface_id, free_surface_params in self.free_surface_dict.items():
-            # First, make the displacement term implicit by incorporating
-            # the unknown `incremental displacement' (u) that
-            # we are solving for
-            implicit_displacement = self.u + self.displacement
-            implicit_displacement_up = fd.dot(implicit_displacement, self.k)
-            # Add free surface stress term. This is also referred to as the Hydrostatic Prestress advection term in the GIA literature.
-            normal_stress, _ = self.approximation.free_surface_terms(
-                self.p, self.T, implicit_displacement_up, self.free_surface_theta, **free_surface_params
-            )
-            if 'normal_stress' in self.weak_bcs[free_surface_id]:
-                # Usually there will be also an ice/water loadi acting as a normal stress in the GIA problem
-                existing_value = self.weak_bcs[free_surface_id]['normal_stress']
-                self.weak_bcs[free_surface_id]['normal_stress'] = existing_value + normal_stress
-            else:
-                self.weak_bcs[free_surface_id] = {'normal_stress': normal_stress}
-
-        # Turn off free surface flag because the viscoelastic free surface (for the small displacement approximation) is now setup
-        self.free_surface = False
-
-    def solve(self):
-        super().solve()
-        # Update history stress term for using as a RHS explicit forcing in the next timestep
-        # Interpolating with adjoint seems to need subfunction...
-        # otherwise 'map toset must be same as Dataset' error
-        u_sub = self.solution.subfunctions[0]
-        self.stress_old.interpolate(self.approximation.prefactor_prestress(self.dt) * self.approximation.stress(u_sub, self.stress_old, self.dt))
-        self.displacement.interpolate(self.displacement+u_sub)


### PR DESCRIPTION
Continuing the series of PRs tackling G-ADOPT's backend, the current set of changes demonstrates an alternate way to structure `approximations.py` and `stokes_integrators.py` alongside minimal changes to base demos. While early motivation included removing the need to provide a temperature field and a Rayleigh number, more recent endeavours focused on achieving a structure that can provide a basis for future solver developments and original contributions to G-ADOPT.

One can see that current GIA, MC, and MM paradigms fit well under the proposed structure. However, implementing the internal variable approach for compressible viscoelastic models demonstrates that a unique approximation model may not be desirable. I envisage that a family of approximations can be grouped within a class, as implemented here for viscous mantle approximations, and each family can inherit from a base approximation class. This differs from the current `master` implementation where the notion of family is approached through class inheritance. The structure I envisage will become more explicit as the internal variable development progresses.

For the solvers' structure, the inheritance from a common abstract base class drastically simplifies the implementation of new solvers with minimal, if any, code duplication.

Discussion regarding these proposed changes is most welcomed.