### PR TITLE
Changing interpolate in tests

### DIFF
--- a/tests/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -103,7 +103,7 @@ def model(level, nn, do_write=False):
     solution_lower = assess.CylindricalStokesSolutionDeltaFreeSlip(float(nn), -1, nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal_upper = Function(V, name="AnalyticalVelocityUpper")
     u_anal_lower = Function(V, name="AnalyticalVelocityLower")
     u_anal = Function(V, name="AnalyticalVelocity")
@@ -113,8 +113,8 @@ def model(level, nn, do_write=False):
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Q1DGvec)
-    pdg = interpolate(p, Q1DG)
+    pxy = Function(Q1DGvec).interpolate(as_vector((X[0], X[1])))
+    pdg = Function(Q1DG).interpolate(p)
     p_anal_upper = Function(Q1DG, name="AnalyticalPressureUpper")
     p_anal_lower = Function(Q1DG, name="AnalyticalPressureLower")
     p_anal = Function(Q1DG, name="AnalyticalPressure")

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -103,7 +103,7 @@ def model(level, nn, do_write=False):
     solution_lower = assess.CylindricalStokesSolutionDeltaFreeSlip(float(nn), -1, nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal_upper = Function(V, name="AnalyticalVelocityUpper")
     u_anal_lower = Function(V, name="AnalyticalVelocityLower")
     u_anal = Function(V, name="AnalyticalVelocity")
@@ -113,8 +113,8 @@ def model(level, nn, do_write=False):
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Q1DGvec)
-    pdg = interpolate(p, Q1DG)
+    pxy = Function(Q1DGvec).interpolate(as_vector((X[0], X[1])))
+    pdg = Function(Q1DG).interpolate(p)
     p_anal_upper = Function(Q1DG, name="AnalyticalPressureUpper")
     p_anal_lower = Function(Q1DG, name="AnalyticalPressureLower")
     p_anal = Function(Q1DG, name="AnalyticalPressure")

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -103,7 +103,7 @@ def model(level, nn, do_write=False):
     solution_lower = assess.CylindricalStokesSolutionDeltaZeroSlip(float(nn), -1, nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal_upper = Function(V, name="AnalyticalVelocityUpper")
     u_anal_lower = Function(V, name="AnalyticalVelocityLower")
     u_anal = Function(V, name="AnalyticalVelocity")
@@ -113,8 +113,8 @@ def model(level, nn, do_write=False):
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Q1DGvec)
-    pdg = interpolate(p, Q1DG)
+    pxy = Function(Q1DGvec).interpolate(as_vector((X[0], X[1])))
+    pdg = Function(Q1DG).interpolate(p)
     p_anal_upper = Function(Q1DG, name="AnalyticalPressureUpper")
     p_anal_lower = Function(Q1DG, name="AnalyticalPressureLower")
     p_anal = Function(Q1DG, name="AnalyticalPressure")

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -103,7 +103,7 @@ def model(level, nn, do_write=False):
     solution_lower = assess.CylindricalStokesSolutionDeltaZeroSlip(float(nn), -1, nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal_upper = Function(V, name="AnalyticalVelocityUpper")
     u_anal_lower = Function(V, name="AnalyticalVelocityLower")
     u_anal = Function(V, name="AnalyticalVelocity")
@@ -113,8 +113,8 @@ def model(level, nn, do_write=False):
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Q1DGvec)
-    pdg = interpolate(p, Q1DG)
+    pxy = Function(Q1DGvec).interpolate(as_vector((X[0], X[1])))
+    pdg = Function(Q1DG).interpolate(p)
     p_anal_upper = Function(Q1DG, name="AnalyticalPressureUpper")
     p_anal_lower = Function(Q1DG, name="AnalyticalPressureLower")
     p_anal = Function(Q1DG, name="AnalyticalPressure")

--- a/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -93,13 +93,13 @@ def model(level, k, nn, do_write=False):
     solution = assess.CylindricalStokesSolutionSmoothFreeSlip(int(float(nn)), int(float(k)), nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal = Function(V, name="AnalyticalVelocity")
     u_anal.dat.data[:] = [solution.velocity_cartesian(xyi) for xyi in uxy.dat.data]
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Wvec)
+    pxy = Function(Wvec).interpolate(as_vector((X[0], X[1])))
     p_anal = Function(W, name="AnalyticalPressure")
     p_anal.dat.data[:] = [solution.pressure_cartesian(xyi) for xyi in pxy.dat.data]
     p_error = Function(W, name="PressureError").assign(p_-p_anal)

--- a/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
@@ -136,17 +136,17 @@ def model(level, k, nn, do_write=False):
     solution = assess.CylindricalStokesSolutionSmoothFreeSlip(int(float(nn)), int(float(k)), nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal = Function(V, name="AnalyticalVelocity")
     u_anal.dat.data[:] = [solution.velocity_cartesian(xyi) for xyi in uxy.dat.data]
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Wvec)
+    pxy = Function(Wvec).interpolate(as_vector((X[0], X[1])))
     p_anal = Function(W, name="AnalyticalPressure")
     p_anal.dat.data[:] = [solution.pressure_cartesian(xyi) for xyi in pxy.dat.data]
 
     # compute eta analytical and error
-    etaxy = interpolate(as_vector((X[0], X[1])), Wvec)
+    etaxy = Function(Wvec).interpolate(as_vector((X[0], X[1])))
     eta_anal = Function(W, name="AnalyticalEta")
     eta_anal.dat.data[:] = [-solution.radial_stress_cartesian(xyi) for xyi in etaxy.dat.data]
 

--- a/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -93,13 +93,13 @@ def model(level, k, nn, do_write=False):
     solution = assess.CylindricalStokesSolutionSmoothZeroSlip(int(float(nn)), int(float(k)), nu=float(mu))
 
     # compute u analytical and error
-    uxy = interpolate(as_vector((X[0], X[1])), V)
+    uxy = Function(V).interpolate(as_vector((X[0], X[1])))
     u_anal = Function(V, name="AnalyticalVelocity")
     u_anal.dat.data[:] = [solution.velocity_cartesian(xyi) for xyi in uxy.dat.data]
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxy = interpolate(as_vector((X[0], X[1])), Wvec)
+    pxy = Function(Wvec).interpolate(as_vector((X[0], X[1])))
     p_anal = Function(W, name="AnalyticalPressure")
     p_anal.dat.data[:] = [solution.pressure_cartesian(xyi) for xyi in pxy.dat.data]
     p_error = Function(W, name="PressureError").assign(p_-p_anal)

--- a/tests/analytical_comparisons/smooth_spherical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_freeslip.py
@@ -59,7 +59,7 @@ def model(level, l, mm, k, do_write=False):
 
     # RHS provided by assess solution: rho'=r**k Y_lm
     solution = assess.SphericalStokesSolutionSmoothFreeSlip(float(l), float(m), float(k), nu=float(mu), Rp=rmax, Rm=rmin, g=1.0)
-    u_xyz = interpolate(X, V)
+    u_xyz = Function(V).interpolate(X)
     rhop = Function(Vscl)
     rhop.dat.data[:] = [solution.delta_rho_cartesian(xyzi) for xyzi in u_xyz.dat.data]
 
@@ -103,13 +103,13 @@ def model(level, l, mm, k, do_write=False):
     p_.project(p_ - coef, solver_parameters=_project_solver_parameters)
 
     # compute u analytical and error
-    uxzy = interpolate(as_vector((X[0], X[1], X[2])), V)
+    uxzy = Function(V).interpolate(as_vector((X[0], X[1], X[2])))
     u_anal = Function(V, name="AnalyticalVelocity")
     u_anal.dat.data[:] = [solution.velocity_cartesian(xyzi) for xyzi in uxzy.dat.data]
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxyz = interpolate(as_vector((X[0], X[1], X[2])), Wvec)
+    pxyz = Function(Wvec).interpolate(as_vector((X[0], X[1], X[2])))
     p_anal = Function(W, name="AnalyticalPressure")
     p_anal.dat.data[:] = [solution.pressure_cartesian(xyzi) for xyzi in pxyz.dat.data]
     p_error = Function(W, name="PressureError").assign(p_-p_anal)

--- a/tests/analytical_comparisons/smooth_spherical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_zeroslip.py
@@ -59,7 +59,7 @@ def model(level, l, mm, k, do_write=False):
 
     # RHS provided by assess solution: rho'=r**k Y_lm
     solution = assess.SphericalStokesSolutionSmoothZeroSlip(float(l), float(m), float(k), nu=float(mu), Rp=rmax, Rm=rmin, g=1.0)
-    u_xyz = interpolate(X, V)
+    u_xyz = Function(V).interpolate(X)
     rhop = Function(Vscl)
     rhop.dat.data[:] = [solution.delta_rho_cartesian(xyzi) for xyzi in u_xyz.dat.data]
 
@@ -103,13 +103,13 @@ def model(level, l, mm, k, do_write=False):
     p_.project(p_ - coef, solver_parameters=_project_solver_parameters)
 
     # compute u analytical and error
-    uxzy = interpolate(as_vector((X[0], X[1], X[2])), V)
+    uxzy = Function(V).interpolate(as_vector((X[0], X[1], X[2])))
     u_anal = Function(V, name="AnalyticalVelocity")
     u_anal.dat.data[:] = [solution.velocity_cartesian(xyzi) for xyzi in uxzy.dat.data]
     u_error = Function(V, name="VelocityError").assign(u_-u_anal)
 
     # compute p analytical and error
-    pxyz = interpolate(as_vector((X[0], X[1], X[2])), Wvec)
+    pxyz = Function(Wvec).interpolate(as_vector((X[0], X[1], X[2])))
     p_anal = Function(W, name="AnalyticalPressure")
     p_anal.dat.data[:] = [solution.pressure_cartesian(xyzi) for xyzi in pxyz.dat.data]
     p_error = Function(W, name="PressureError").assign(p_-p_anal)

--- a/tests/parallel_scaling/stokes_cubed_sphere.py
+++ b/tests/parallel_scaling/stokes_cubed_sphere.py
@@ -44,7 +44,7 @@ def model(ref_level, nlayers, delta_t, steps=None):
     # evaluate P_lm node-wise using scipy lpmv
     l, m, eps_c, eps_s = 3, 2, 0.01, 0.01
     Plm = Function(Q, name="P_lm")
-    cos_phi = interpolate(cos(phi), Q)
+    cos_phi = Function(Q).interpolate(cos(phi))
     Plm.dat.data[:] = scipy.special.lpmv(m, l, cos_phi.dat.data_ro)
     Plm.assign(Plm*math.sqrt(((2*l+1)*math.factorial(l-m))/(2*math.pi*math.factorial(l+m))))
     if m == 0:


### PR DESCRIPTION
In few of the tests we are still using `interpolate` as a stand-alone function for the `assemble(interpolate(*))` behaviour. This will get rid of the warnings. 