### PR TITLE
Update `generate_expected.py` to allow trailing slash

### DIFF
--- a/demos/generate_expected.py
+++ b/demos/generate_expected.py
@@ -1,20 +1,27 @@
-import sys
+#!/usr/bin/env python3
+import argparse
 from pathlib import Path
 
 from test_all import cases, get_convergence
 
 if __name__ == "__main__":
-    all_cases = cases
+    parser = argparse.ArgumentParser(
+        prog="Expected demo results",
+        description="Generates a pickle file with the expected demo results.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("cases", nargs="*", help="Cases to process")
+    args = parser.parse_args()
 
-    if sys.argv[1:]:
-        requested_cases = set(sys.argv[1:])
-        cases = [
-            case for case in all_cases.keys() if
-            case in requested_cases
-        ]
+    requested_cases = {case.rstrip("/") for case in args.cases}
 
-    for case in cases:
-        extra_checks = all_cases[case].get("extra_checks", [])
+    for case in requested_cases:
+        try:
+            extra_checks = cases[case].get("extra_checks", [])
+        except KeyError:
+            print(f"Skipping unknown case: {case}")
+            continue
+
         b = Path(__file__).parent.resolve() / case
         df = get_convergence(b)[["u_rms"] + extra_checks]
 


### PR DESCRIPTION
While working on the level-set API changes, I updated pickle files for expected values. It was frustrating that `generate_expected.py` would silently do nothing if the demo path I passed as a command argument contained a trailing slash. The proposed changes here should ensure this does not happen anymore.