### PR TITLE
Swap argument order in timestepper advance method

### DIFF
--- a/gadopt/level_set_tools.py
+++ b/gadopt/level_set_tools.py
@@ -274,7 +274,7 @@ class LevelSetSolver:
 
         return fd.LinearVariationalSolver(problem, solver_parameters=solver_params)
 
-    def update_level_set_gradient(self, *args, **kwargs):
+    def update_level_set_gradient(self):
         """Calls the gradient projection solver.
 
         Can be used as a callback.
@@ -332,7 +332,7 @@ class LevelSetSolver:
             if step % self.reini_params["frequency"] == 0:
                 for reini_step in range(self.reini_params["iterations"]):
                     self.reini_ts.advance(
-                        0, update_forcings=self.update_level_set_gradient
+                        update_forcings=self.update_level_set_gradient
                     )
 
                 self.ls_solver.solution_old.assign(self.level_set)

--- a/gadopt/transport_solver.py
+++ b/gadopt/transport_solver.py
@@ -238,12 +238,14 @@ class GenericTransportBase(abc.ABC):
         """Optional instructions to execute right after a solve."""
         pass
 
-    def solve(self, t: Number = 0, update_forcings: Callable | None = None) -> None:
+    def solve(
+        self, update_forcings: Callable | None = None, t: float | None = None
+    ) -> None:
         """Advances solver in time."""
         if not self._solver_ready:
             self.setup_solver()
 
-        self.ts.advance(t, update_forcings)
+        self.ts.advance(update_forcings, t)
 
         self.solver_callback()
 
@@ -254,16 +256,16 @@ class GenericTransportSolver(GenericTransportBase):
     **Note**: The solution field is updated in place.
 
     Terms and Attributes:
-        This solver handles all combinations of advection, diffusion, sink, and source
-        terms. Depending on the included terms, specific attributes must be provided
-        according to:
+      This solver handles all combinations of advection, diffusion, sink, and source
+      terms. Depending on the included terms, specific attributes must be provided
+      according to:
 
-        |   Term    | Required attribute(s) |           Optional attribute(s)           |
-        | --------- | --------------------- | ----------------------------------------- |
-        | advection | u                     | advective_velocity_scaling, su_nubar      |
-        | diffusion | diffusivity           | reference_for_diffusion, interior_penalty |
-        | source    | source                |                                           |
-        | sink      | sink_coeff            |                                           |
+      |   Term    | Required attribute(s) |           Optional attribute(s)           |
+      | --------- | --------------------- | ----------------------------------------- |
+      | advection | u                     | advective_velocity_scaling, su_nubar      |
+      | diffusion | diffusivity           | reference_for_diffusion, interior_penalty |
+      | source    | source                |                                           |
+      | sink      | sink_coeff            |                                           |
 
     Args:
       terms:

--- a/gadopt/transport_solver.py
+++ b/gadopt/transport_solver.py
@@ -256,16 +256,16 @@ class GenericTransportSolver(GenericTransportBase):
     **Note**: The solution field is updated in place.
 
     Terms and Attributes:
-      This solver handles all combinations of advection, diffusion, sink, and source
-      terms. Depending on the included terms, specific attributes must be provided
-      according to:
+        This solver handles all combinations of advection, diffusion, sink, and source
+        terms. Depending on the included terms, specific attributes must be provided
+        according to:
 
-      |   Term    | Required attribute(s) |           Optional attribute(s)           |
-      | --------- | --------------------- | ----------------------------------------- |
-      | advection | u                     | advective_velocity_scaling, su_nubar      |
-      | diffusion | diffusivity           | reference_for_diffusion, interior_penalty |
-      | source    | source                |                                           |
-      | sink      | sink_coeff            |                                           |
+        |   Term    | Required attribute(s) |           Optional attribute(s)           |
+        | --------- | --------------------- | ----------------------------------------- |
+        | advection | u                     | advective_velocity_scaling, su_nubar      |
+        | diffusion | diffusivity           | reference_for_diffusion, interior_penalty |
+        | source    | source                |                                           |
+        | sink      | sink_coeff            |                                           |
 
     Args:
       terms:

--- a/tests/free_surface/explicit_free_surface.py
+++ b/tests/free_surface/explicit_free_surface.py
@@ -177,7 +177,7 @@ class ExplicitFreeSurfaceModel:
     def advance_timestep(self):
         # Solve Stokes sytem:
         self.stokes_solver.solve()
-        self.eta_timestepper.advance(self.time)
+        self.eta_timestepper.advance()
 
     def run_simulation(self):
         # Now perform the time loop:

--- a/tests/multi_material/run_benchmark.py
+++ b/tests/multi_material/run_benchmark.py
@@ -312,7 +312,7 @@ while True:
     t_adapt.update_timestep()
 
     # Solve energy system
-    energy_solver.solve(t=time_now, update_forcings=update_forcings)
+    energy_solver.solve(update_forcings=update_forcings, t=time_now)
 
     # Advect each level set
     for ls_solv in level_set_solver:


### PR DESCRIPTION
The current argument order in `TimeIntegratorBase.advance` and `RungeKuttaTimeIntegrator.advance` is not ideal. `t` is a required argument, whilst `update_forcings` is an optional argument. However, `t` is only used as an argument to `update_forcings`, which breaks the previous logic. In other words, passing `t` currently without providing `update_forcings` has no impact, as can be seen from `tests/free_surface/explicit_free_surface.py`. Here, the argument order is swapped, and both arguments become optional.