### PR TITLE
Remove unused arguments in `time_stepper.py`

### DIFF
--- a/gadopt/time_stepper.py
+++ b/gadopt/time_stepper.py
@@ -124,7 +124,6 @@ class ERKGeneric(RungeKuttaTimeIntegrator):
       dt: Integration time step
       solution_old: Firedrake function representing the equation's solution
                       at the previous timestep
-      bnd_conditions: Dictionary of boundary conditions passed to the equation
       solver_parameters: Dictionary of solver parameters provided to PETSc
       strong_bcs: List of Firedrake Dirichlet boundary conditions
 
@@ -135,7 +134,6 @@ class ERKGeneric(RungeKuttaTimeIntegrator):
         solution: firedrake.Function,
         dt: float,
         solution_old: Optional[firedrake.Function] = None,
-        bnd_conditions: Optional[dict[int, dict[str, Number]]] = None,
         solver_parameters: Optional[dict[str, Any]] = {},
         strong_bcs: Optional[list[firedrake.DirichletBC]] = None,
     ):
@@ -222,12 +220,8 @@ class DIRKGeneric(RungeKuttaTimeIntegrator):
       dt: Integration time step
       solution_old: Firedrake function representing the equation's solution
                       at the previous timestep
-      bnd_conditions: Dictionary of boundary conditions passed to the equation
       solver_parameters: Dictionary of solver parameters provided to PETSc
       strong_bcs: List of Firedrake Dirichlet boundary conditions
-      terms_to_add: Defines which terms of the equation are to be
-                      added to this solver.
-                      Default 'all' implies ['implicit', 'explicit', 'source'].
 
     """
     def __init__(
@@ -236,10 +230,8 @@ class DIRKGeneric(RungeKuttaTimeIntegrator):
         solution: firedrake.Function,
         dt: float,
         solution_old: Optional[firedrake.Function] = None,
-        bnd_conditions: Optional[dict[int, dict[str, Number]]] = None,
         solver_parameters: Optional[dict[str, Any]] = {},
         strong_bcs: Optional[list[firedrake.DirichletBC]] = None,
-        terms_to_add: Optional[str | list[str]] = "all",
     ):
         super(DIRKGeneric, self).__init__(
             equation, solution, dt, solution_old, solver_parameters, strong_bcs

--- a/gadopt/time_stepper.py
+++ b/gadopt/time_stepper.py
@@ -8,7 +8,6 @@ providing relevant parameters defined in the parent class (i.e. `ERKGeneric` or
 
 import operator
 from abc import ABC, abstractmethod
-from numbers import Number
 from typing import Any, Optional
 
 import firedrake

--- a/tests/free_surface/explicit_free_surface.py
+++ b/tests/free_surface/explicit_free_surface.py
@@ -147,13 +147,12 @@ class ExplicitFreeSurfaceModel:
             mass_term=mass_term,
             eq_attrs=eq_attrs,
         )  # Initialise the separate free surface equation for explicit coupling
-        eta_bcs = {}
         # Apply strong homogenous boundary to interior DOFs to prevent a singular matrix when only integrating the free surface equation over the top surface.
         eta_strong_bcs = [InteriorBC(self.W, 0., self.top_id)]
 
         # Set up a timestepper for the free surface, here we use a first order backward Euler method following Kramer et al. 2012
         self.eta_timestepper = BackwardEuler(
-            eta_eq, self.eta, self.dt, bnd_conditions=eta_bcs, strong_bcs=eta_strong_bcs
+            eta_eq, self.eta, self.dt, strong_bcs=eta_strong_bcs
         )
 
     def update_analytical_free_surfaces(self):


### PR DESCRIPTION
Time integrators in `time_stepper.py` accept two arguments that are not used: `bnd_conditions` and `terms_to_add`. This PR removes these extraneous arguments.