### PR TITLE
Change su_diffusivity back to an on/off flag

### DIFF
--- a/tests/scalar_advection/scalar_advection.py
+++ b/tests/scalar_advection/scalar_advection.py
@@ -77,7 +77,7 @@ bc_in = {"q": q_in}
 bcs = {1: bc_in, 2: bc_in, 3: bc_in, 4: bc_in}
 eq_attrs = {"u": u}
 adv_solver = GenericTransportSolver(
-    "advection", q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_diffusivity=0.0
+    "advection", q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_advection=True
 )
 
 # Get nubar (additional SU diffusion) for plotting

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion.py
@@ -66,7 +66,7 @@ g_top = 1.0
 g_bottom = 0.0
 bcs = {3: {"g": g_bottom}, 4: {"g": g_top}}
 adv_diff_solver = GenericTransportSolver(
-    terms, q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_diffusivity=kappa
+    terms, q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_advection=True
 )
 
 # Get nubar (additional SU diffusion) for plotting

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH219_skew.py
@@ -54,7 +54,7 @@ g_left = conditional(y < 0.2, 0.0, 1.0)
 g_bottom = 0
 bcs = {3: {"g": g_bottom}, 1: {"g": g_left}}
 adv_diff_solver = GenericTransportSolver(
-    terms, q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_diffusivity=kappa
+    terms, q, dt, DIRK33, eq_attrs=eq_attrs, bcs=bcs, su_advection=True
 )
 
 # Get nubar (additional SU diffusion) for plotting

--- a/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
+++ b/tests/scalar_advection_diffusion/scalar_advection_diffusion_DH27.py
@@ -77,7 +77,7 @@ def model(n, Pe=0.25, su_advection=True, do_write=False):
         DIRK33,
         eq_attrs=eq_attrs,
         bcs=bcs,
-        su_diffusivity=kappa if su_advection else None,
+        su_advection=su_advection,
     )
 
     steady_state_tolerance = 1e-7  # this may need tweaking for different length runs/Pe values


### PR DESCRIPTION
PR #114 changed the api to allow users to specify an ```su_diffusivity``` This is maybe confusing because if a 'real' background diffusivity is given then we should use this diffusivity used to calculate the grid peclet number for the su advection scheme.

In the case where there is no diffusion term we just set kappa=0 since we already have a hack to specify a (hopefully) small 1e-12 value for the diffusivity anyway.