### PR TITLE
Handle MixedFunctionSpace.mesh() being a MeshSequence

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -250,14 +250,14 @@ class StokesSolver:
 
         # Detect if solver should be direct, iterative or whatever the user has chosen
         solver_auto_is_direct = None
-        if solver_parameters is not None:
-            if isinstance(self.mesh, fd.MeshSequence):
-                solver_auto_is_direct = self.mesh.topological_dimension() and all(
-                    hasattr(m, "cartesian") and m.cartesian for m in self.mesh
-                )
-        else:
+        if isinstance(self.mesh, fd.MeshGeometry):
             solver_auto_is_direct = (
                 self.mesh.topological_dimension() == 2 and hasattr(self.mesh, "cartesian") and self.mesh.cartesian
+            )
+        else:
+            ### A MeshSequence is a tuple of MeshGeometry's
+            solver_auto_is_direct = self.mesh.topological_dimension() and all(
+                hasattr(m, "cartesian") and m.cartesian for m in self.mesh
             )
 
         for id, bc in bcs.items():

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -255,7 +255,7 @@ class StokesSolver:
                 self.mesh.topological_dimension() == 2 and hasattr(self.mesh, "cartesian") and self.mesh.cartesian
             )
         else:
-            ### A MeshSequence is a tuple of MeshGeometry's
+            # A MeshSequence is a tuple of MeshGeometry's
             solver_auto_is_direct = self.mesh.topological_dimension() and all(
                 hasattr(m, "cartesian") and m.cartesian for m in self.mesh
             )

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -93,7 +93,7 @@ class TimestepAdaptor:
 
 
 def upward_normal(mesh):
-    if hasattr(mesh,"cartesian") and mesh.cartesian:
+    if hasattr(mesh, "cartesian") and mesh.cartesian:
         n = mesh.geometric_dimension()
         return as_vector([0]*(n-1) + [1])
     else:
@@ -105,7 +105,7 @@ def upward_normal(mesh):
 def vertical_component(u):
     mesh = extract_unique_domain(u)
 
-    if hasattr(mesh,"cartesian") and mesh.cartesian:
+    if hasattr(mesh, "cartesian") and mesh.cartesian:
         return u[u.ufl_shape[0]-1]
     else:
         n = upward_normal(mesh)
@@ -303,7 +303,7 @@ class LayerAveraging:
         self.mesh = mesh
         XYZ = SpatialCoordinate(mesh)
 
-        if hasattr(mesh,"cartesian") and mesh.cartesian:
+        if hasattr(mesh, "cartesian") and mesh.cartesian:
             self.r = XYZ[len(XYZ)-1]
         else:
             self.r = sqrt(dot(XYZ, XYZ))

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -93,7 +93,7 @@ class TimestepAdaptor:
 
 
 def upward_normal(mesh):
-    if mesh.cartesian:
+    if hasattr(mesh,"cartesian") and mesh.cartesian:
         n = mesh.geometric_dimension()
         return as_vector([0]*(n-1) + [1])
     else:
@@ -105,7 +105,7 @@ def upward_normal(mesh):
 def vertical_component(u):
     mesh = extract_unique_domain(u)
 
-    if mesh.cartesian:
+    if hasattr(mesh,"cartesian") and mesh.cartesian:
         return u[u.ufl_shape[0]-1]
     else:
         n = upward_normal(mesh)
@@ -303,7 +303,7 @@ class LayerAveraging:
         self.mesh = mesh
         XYZ = SpatialCoordinate(mesh)
 
-        if mesh.cartesian:
+        if hasattr(mesh,"cartesian") and mesh.cartesian:
             self.r = XYZ[len(XYZ)-1]
         else:
             self.r = sqrt(dot(XYZ, XYZ))


### PR DESCRIPTION
Currently, a MixedFunctionSpace in firedrake can only be defined on a single mesh. The `_mesh` attribute of the mixed function space is set to the mesh object referenced in the first of the `FunctionSpace`'s passed to MixedFunctionSpace (see [here](https://github.com/firedrakeproject/firedrake/blob/a8fbe18ca607f0f79a5f7db336950b43f96a43b0/firedrake/functionspace.py#L290)). In the submesh branch, this requirement is dropped, and a new `MeshSequenceGeometry` object is created for the MixedFunctionSpace, regardless of whether the meshes are identical or not (see [here](https://github.com/firedrakeproject/firedrake/blob/18de7f0435f32c54d2b6c0491d3eb07d8aa3de68/firedrake/functionspace.py#L300)). The implication for g-adopt is that the `mesh.cartesian` property is no longer guaranteed to be present on a mesh passed to `upward_normal` via the `StokesSolver.__init__` method. Rather than storing `self.k` during `__init__`, I've replaced every reference to `self.k` with `upward_normal(fd.ufl_expr.extract_unique_domain(<function space>))`, which is guaranteed to return a `Mesh` object if passed a `FunctionSpace`, which it always is in g-adopt. The references are only in setup functions, so there shouldn't be much additional overhead. 

I've also made the `cartesian` parameter for the mesh optional since (as far as I can see) it was only used for `upward_normal` calculations. The assumption being that we're in working in polar coordinates unless told otherwise. The change is backward compatible, so `mesh.cartesian = False` is still valid. I wasn't around for the discussions related to the `cartesian` parameter, so if this idea was already dismissed, I'll revert the changes.