### PR TITLE
Use firedrake modules on Gadi for longtest

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -34,12 +34,12 @@ jobs:
       - name: Run test cases
         id: run_tests
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && make -j longtest gadopt_checkout=${{secrets.GADI_REPO_PATH}} gadopt_prefix_image=${{secrets.GADI_PREFIX_IMAGE}} project=${{secrets.GADI_PROJECT}}"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && source ${{secrets.GADI_GADOPT_SETUP}} && make -j longtest gadopt_checkout=${{secrets.GADI_REPO_PATH}} gadopt_setup=${{secrets.GADI_GADOPT_SETUP}} project=${{secrets.GADI_PROJECT}}"
 
       - name: Test results
         if: ${{ success() }}
         run: |
-          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && module load python3/3.10.4 && python3 -m pytest -m longtest --junit-xml=test_results.xml --ignore=tests/unit tests"
+          ssh gadi "cd ${{secrets.GADI_REPO_PATH}} && source ${{secrets.GADI_GADOPT_SETUP}} && python3 -m pytest -m longtest --junit-xml=test_results.xml --ignore=tests/unit tests"
 
       - name: Retrieve test results
         if: ${{ !cancelled() }}

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -24,7 +24,7 @@ $(long_cases): analytical.py clean
 	read -u "$$out" sjob
 	echo "running spherical $@, waiting on $$sjob" >&2
 	mkdir -p pbs_output
-	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_PREFIX_IMAGE=$(gadopt_prefix_image) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/$(subst /,-,$@)_l{level}_{params}.out -e pbs_output/$(subst /,-,$@)_l{level}_{params}.err -- ./run_gadi.sh" $@
+	python3 analytical.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_SETUP=$(gadopt_setup) -W depend=beforeany:$$sjob -N analytical_{params} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=01:00:00,mem={mem}GB,wd,jobfs=10GB -q normal -P $(project) -o pbs_output/$(subst /,-,$@)_l{level}_{params}.out -e pbs_output/$(subst /,-,$@)_l{level}_{params}.err -- ./run_gadi.sh" $@
 	wait
 
 clean:

--- a/tests/analytical_comparisons/run_gadi.sh
+++ b/tests/analytical_comparisons/run_gadi.sh
@@ -1,20 +1,6 @@
 #!/bin/bash -i
 
-module load python3/3.10.4 openmpi/4.0.7
-
-export PETSC_DIR=$PBS_JOBFS/firedrake-prefix
-export OMP_NUM_THREADS=1
-export PYTHONUSERBASE=$PBS_JOBFS/firedrake-prefix
-export XDG_CACHE_HOME=$PBS_JOBFS/xdg
-
-mpiexec --map-by ppr:1:node --np $PBS_NNODES bash -c "tar -C $PBS_JOBFS -xf $GADOPT_PREFIX_IMAGE && \
-cat > $PBS_JOBFS/firedrake-prefix/lib/python3.10/site-packages/petsc4py/lib/petsc.cfg <<EOF && \
-cp -r $GADOPT_CHECKOUT $PBS_JOBFS && \
-python3 -m pip install --user --no-build-isolation $PBS_JOBFS/g-adopt
-PETSC_DIR = $PBS_JOBFS/firedrake-prefix
-PETSC_ARCH =
-EOF"
-
-export LD_LIBRARY_PATH=$PBS_JOBFS/firedrake-prefix/lib:$LD_LIBRARY_PATH
+export MY_GADOPT="$GADOPT_CHECKOUT"
+source "$GADOPT_SETUP"
 
 mpiexec $@

--- a/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
@@ -190,9 +190,9 @@ def model(level, k, nn, do_write=False):
 
     l2anal_u = numpy.sqrt(assemble(dot(u_anal, u_anal)*_dx))
     l2anal_p = numpy.sqrt(assemble(dot(p_anal, p_anal)*_dx))
-    l2anal_eta = numpy.sqrt(assemble(dot(eta_anal, eta_anal)*ds(top_id)))
+    l2anal_eta = numpy.sqrt(assemble(dot(eta_anal, eta_anal)*ds(boundary.top)))
     l2error_u = numpy.sqrt(assemble(dot(u_error, u_error)*_dx))
     l2error_p = numpy.sqrt(assemble(dot(p_error, p_error)*_dx))
-    l2error_eta = numpy.sqrt(assemble(dot(eta_error, eta_error)*ds(top_id)))
+    l2error_eta = numpy.sqrt(assemble(dot(eta_error, eta_error)*ds(boundary.top)))
 
     return l2error_u, l2error_p, l2error_eta, l2anal_u, l2anal_p, l2anal_eta

--- a/tests/base_gmsh/Makefile
+++ b/tests/base_gmsh/Makefile
@@ -7,8 +7,7 @@ all: params.log
 
 params.log: base_case.py square.msh
 	echo "running $<" >&2
-#	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
-	/usr/bin/time --format="$@ finished in %E" python3 $<
+	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.msh

--- a/tests/base_gmsh/Makefile
+++ b/tests/base_gmsh/Makefile
@@ -7,7 +7,8 @@ all: params.log
 
 params.log: base_case.py square.msh
 	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+#	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+	/usr/bin/time --format="$@ finished in %E" python3 $<
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.msh

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -20,7 +20,7 @@ def hash_check():
     return mesh_md5 != expected_md5
 
 
-@pytest.mark.xfail(hash_check(), reason="Mesh file has changed since known good output was created")
+@pytest.mark.xfail("hash_check()", reason="Mesh file has changed since known good output was created")
 def test_base_case():
     df = pd.read_csv(b / "params.log", sep="\\s+", header=0).iloc[-1]
     expected = pd.read_pickle(b / "expected.pkl")

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -6,6 +6,7 @@ import pytest
 # Different variations of gmsh come up with different meshes from the geo file.
 # If we see a mesh different to what we're expecting, warn the user and xfail
 
+
 def test_base_case():
     b = Path(__file__).parent.resolve()
     expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -2,32 +2,23 @@ import pandas as pd
 from pathlib import Path
 import hashlib
 import pytest
-import warnings
 
 # Different variations of gmsh come up with different meshes from the geo file.
-# If we see a mesh different to what we're expecting, warn the user and set
-# the tests to xfail
-b = Path(__file__).parent.resolve()
-expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"
-with open(b / "square.msh", "r") as f:
-    mesh_md5 = h = hashlib.md5(f.read().encode()).hexdigest()
-if mesh_md5 != expected_md5:
-    warn_str = f"""
-    Mesh file has changed since known good output was created:
-    Known good md5sum: {expected_md5}, Created mesh md5sum: {mesh_md5}
-    """
-    warnings.warn(UserWarning(warn_str))
-else:
-    warn_str = ""
+# If we see a mesh different to what we're expecting, warn the user and xfail
 
-
-@pytest.mark.xfail(mesh_md5 != expected_md5, reason=warn_str)
 def test_base_case():
+    b = Path(__file__).parent.resolve()
+    expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"
+    with open(b / "square.msh", "r") as f:
+        mesh_md5 = hashlib.md5(f.read().encode()).hexdigest()
+    if mesh_md5 != expected_md5:
+        warn_str = f"""
+        Mesh file has changed since known good output was created:
+        Known good md5sum: {expected_md5}, Created mesh md5sum: {mesh_md5}
+        """
+        pytest.xfail(warn_str)
     df = pd.read_csv(b / "params.log", sep="\\s+", header=0).iloc[-1]
     expected = pd.read_pickle(b / "expected.pkl")
     kwargs = {"check_names": False}
-    if mesh_md5 != expected_md5:
-        kwargs |= {"rtol": 1e-4}
     pd.testing.assert_series_equal(df[["u_rms", "nu_top"]], expected, **kwargs)
-    if mesh_md5 == expected_md5:
-        assert abs(df.name - expected.name) <= 2
+    assert abs(df.name - expected.name) <= 2

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -9,6 +9,8 @@ import warnings
 # the tests to xfail
 b = Path(__file__).parent.resolve()
 expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"
+
+
 def hash_check():
     with open(b / "square.msh", "r") as f:
         mesh_md5 = hashlib.md5(f.read().encode()).hexdigest()

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -26,8 +26,8 @@ def test_base_case():
     expected = pd.read_pickle(b / "expected.pkl")
     kwargs = {"check_names": False}
     different_mesh = hash_check()
-    if not different_mesh:
+    if different_mesh:
         kwargs |= {"rtol": 1e-4}
     pd.testing.assert_series_equal(df[["u_rms", "nu_top"]], expected, **kwargs)
-    if different_mesh:
+    if not different_mesh:
         assert abs(df.name - expected.name) <= 2

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -2,24 +2,30 @@ import pandas as pd
 from pathlib import Path
 import hashlib
 import pytest
+import warnings
 
 # Different variations of gmsh come up with different meshes from the geo file.
-# If we see a mesh different to what we're expecting, warn the user and xfail
-
-
-def test_base_case():
-    b = Path(__file__).parent.resolve()
-    expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"
+# If we see a mesh different to what we're expecting, warn the user and set
+# the tests to xfail
+b = Path(__file__).parent.resolve()
+expected_md5 = "41b8157a5e18f467dbd1e7538d1236d6"
+def hash_check():
     with open(b / "square.msh", "r") as f:
         mesh_md5 = hashlib.md5(f.read().encode()).hexdigest()
     if mesh_md5 != expected_md5:
-        warn_str = f"""
-        Mesh file has changed since known good output was created:
-        Known good md5sum: {expected_md5}, Created mesh md5sum: {mesh_md5}
-        """
-        pytest.xfail(warn_str)
+        warn_str = f"Known good md5sum: {expected_md5}, Created mesh md5sum: {mesh_md5}"
+        warnings.warn(UserWarning(warn_str))
+    return mesh_md5 != expected_md5
+
+
+@pytest.mark.xfail(hash_check(), reason="Mesh file has changed since known good output was created")
+def test_base_case():
     df = pd.read_csv(b / "params.log", sep="\\s+", header=0).iloc[-1]
     expected = pd.read_pickle(b / "expected.pkl")
     kwargs = {"check_names": False}
+    different_mesh = hash_check()
+    if not different_mesh:
+        kwargs |= {"rtol": 1e-4}
     pd.testing.assert_series_equal(df[["u_rms", "nu_top"]], expected, **kwargs)
-    assert abs(df.name - expected.name) <= 2
+    if different_mesh:
+        assert abs(df.name - expected.name) <= 2

--- a/tests/parallel_scaling/Makefile
+++ b/tests/parallel_scaling/Makefile
@@ -10,7 +10,7 @@ SHELL = /bin/bash
 profile_%.txt: scaling.py stokes_cubed_sphere.py
 	echo "running parallel scaling on level $*"
 	mkdir -p pbs_output
-	python3 scaling.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_PREFIX_IMAGE=$(gadopt_prefix_image) -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P $(project) -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}" $*
+	python3 scaling.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_SETUP=$(gadopt_setup) -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P $(project) -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}" $*
 
 clean:
 	rm -rf pbs_output profile_*.txt level_*.out level_*.err

--- a/tests/parallel_scaling/Makefile
+++ b/tests/parallel_scaling/Makefile
@@ -10,7 +10,7 @@ SHELL = /bin/bash
 profile_%.txt: scaling.py stokes_cubed_sphere.py
 	echo "running parallel scaling on level $*"
 	mkdir -p pbs_output
-	python3 scaling.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_SETUP=$(gadopt_setup) -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P $(project) -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}" $*
+	python3 scaling.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_SETUP=$(gadopt_setup) -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2+gdata/fp50,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P $(project) -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}" $*
 
 clean:
 	rm -rf pbs_output profile_*.txt level_*.out level_*.err

--- a/tests/parallel_scaling/run_gadi.sh
+++ b/tests/parallel_scaling/run_gadi.sh
@@ -3,25 +3,8 @@
 level=$1
 shift
 
-module load python3/3.10.4 openmpi/4.0.7
-
-export PETSC_DIR=$PBS_JOBFS/firedrake-prefix
-export OMP_NUM_THREADS=1
-export PYTHONUSERBASE=$PBS_JOBFS/firedrake-prefix
-export XDG_CACHE_HOME=$PBS_JOBFS/xdg
-export FIREDRAKE_TSFC_KERNEL_CACHE_DIR=$PBS_JOBFS/tsfc
-export PYOP2_CACHE_DIR=$PBS_JOBFS/pyop2
-export MPLCONFIGDIR=$HOME/.config/matplotlib
-
-mpiexec --map-by ppr:1:node --np $PBS_NNODES bash -c "tar -C $PBS_JOBFS -xf $GADOPT_PREFIX_IMAGE && \
-cat > $PBS_JOBFS/firedrake-prefix/lib/python3.10/site-packages/petsc4py/lib/petsc.cfg <<EOF && \
-cp -r $GADOPT_CHECKOUT $PBS_JOBFS && \
-python3 -m pip install --user --no-build-isolation $PBS_JOBFS/g-adopt
-PETSC_DIR = $PBS_JOBFS/firedrake-prefix
-PETSC_ARCH =
-EOF"
-
-export LD_LIBRARY_PATH=$PBS_JOBFS/firedrake-prefix/lib:$LD_LIBRARY_PATH
+export MY_GADOPT="$GADOPT_CHECKOUT"
+source "$GADOPT_SETUP"
 
 mpiexec $@ -n 1 2> level_${level}_warmup.err > level_${level}_warmup.out
 export PETSC_OPTIONS="-log_view :profile_${level}.txt"

--- a/tests/parallel_scaling/scaling.py
+++ b/tests/parallel_scaling/scaling.py
@@ -43,7 +43,7 @@ def get_data(level, base_path=None):
     data = {}
 
     iteration_component_map = {
-        "ImplicitMidpoint-EnergyEquation_stage0_": "energy",
+        "ImplicitMidpoint-Equation_stage0_": "energy",
         "Stokes_fieldsplit_0_": "velocity",
         "Stokes_fieldsplit_1_": "pressure",
     }

--- a/tests/parallel_scaling/test_scaling.py
+++ b/tests/parallel_scaling/test_scaling.py
@@ -8,7 +8,7 @@ from scaling import get_data
 levels = [5, 6, 7]
 
 iteration_components = {
-    "energy": "ImplicitMidpoint-EnergyEquation_stage0_",
+    "energy": "ImplicitMidpoint-Equation_stage0_",
     "velocity": "Stokes_fieldsplit_0_",
     "pressure": "Stokes_fieldsplit_1_",
 }


### PR DESCRIPTION
Works fine, just had to change that iteration component name to get it to work. I was going to put the `module use`, `module load` steps in `run_gadi.sh`, but I changed my mind as its a good idea to have that separate to the repository so that we can test new firedrake branches as well. Location and usage of `$GADOPT_SETUP` would be good to add to our hypothetical internal docs page.