### PR TITLE
Allow running demos without task-spooler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,7 @@ jobs:
           S3CONFIG: ${{ secrets.S3CONFIG }}
         run: |
           sudo apt update
-          sudo apt install -y task-spooler time s3cmd unzip git-lfs gmsh
-          tsp -S 48
+          sudo apt install -y time s3cmd unzip git-lfs gmsh gcc cmake libsqlite3-dev
           mkdir -p $HOME/.s3cfg
           echo "${S3CONFIG}" > $HOME/.s3cfg/config
           chmod 600 $HOME/.s3cfg/config
@@ -69,6 +68,23 @@ jobs:
       - name: Fetch LFS artifacts
         run: |
           git lfs checkout
+
+      - name: Fetch task spooler
+        uses: actions/checkout@v4
+        with:
+          repository: dsroberts/tsp_for_hpc
+          path: ./tsp
+
+      - name: Build task spooler
+        uses: threeal/cmake-action@v2
+        with:
+          source-dir: ./tsp
+          build-dir: ./tsp_build
+          options: CGROUPV2=ON
+
+      - name: Put task spooler on PATH
+        run: |
+          mv tsp_build/tsp-hpc /home/firedrake/.local/bin/tsp
 
       - name: Install Python dependencies
         run: |
@@ -107,7 +123,6 @@ jobs:
           make -j test
         env:
           GADOPT_LOGLEVEL: INFO
-          TS_MAXFINISHED: 100
           BATCH_MODE: 1
 
       - name: Pytest
@@ -129,53 +144,11 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          declare -A timings
-          declare -A success
-
-          digest="$(tsp)"
-
-          mkdir test_outputs
-
-          # extract info
-          for id in $(awk 'NR>1 { print $1 }' <<< "$digest"); do
-            st="$(tsp -i $id)"
-            label=$(awk "/^$id[[:space:]]/ { if (match(\$0, /\[[^]]*\]/)) { gsub(\"/\", \"-\"); print substr(\$0, RSTART+1, RLENGTH-2) } }" <<< "$digest")
-            command=$(sed -En 's/^Command.*python3? (.*\/)?//p' <<< "$st")
-            if [ -z "$label" ]; then
-              outfile=$command
-            else
-              outfile="[$label]$command"
-            fi
-            command="$label${label:+: }$command"
-            timings["$command"]=$(sed -n 's/^Time run: //p' <<< "$st")
-
-            tsp -c $id >> "test_outputs/$outfile" || true
-
-            if grep -q "exit code 0" <<< "$st"; then
-              success["$command"]=Yes
-            else
-              success["$command"]=No
-              echo "$command failed:"
-              tsp -c $id | tail -n 10 || true
-              echo $command >> test_outputs/test_output.log
-              tsp -c $id >> test_outputs/test_output.log || true
-            fi
-          done
-
-          # sort by case name
-          declare -a cases
-          while IFS= read -r -d '' entry; do
-            cases+=("$entry")
-          done < <(printf "%s\0" "${!timings[@]}" | sort -z)
-
-          printf "## Case timings\nCase | Time | Success?\n---- | ---- | ----\n" >> "$GITHUB_STEP_SUMMARY"
-          for case in "${cases[@]}"; do
-            printf "%s | %s | %s\n" "$case" ${timings["$case"]} ${success["$case"]} >> "$GITHUB_STEP_SUMMARY"
-          done
+          tsp --gh-summary >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload run log
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: run-log
-          path: test_outputs
+          path: /tmp/tsp_db.sqlite3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,8 @@ jobs:
           # extract info
           for id in $(awk 'NR>1 { print $1 }' <<< "$digest"); do
             st="$(tsp -i $id)"
-            label=$(awk "/^$id[[:space:]]/ { if (match(\$0, /\[[^]]*\]/)) { print substr(\$0, RSTART+1, RLENGTH-2) } }" <<< "$digest")
-            command=$(sed -En 's/^Command.*python3? //p' <<< "$st")
+            label=$(awk "/^$id[[:space:]]/ { if (match(\$0, /\[[^]]*\]/)) { gsub(\"/\", \"-\"); print substr(\$0, RSTART+1, RLENGTH-2) } }" <<< "$digest")
+            command=$(sed -En 's/^Command.*python3? (.*\/)?//p' <<< "$st")
             if [ -z "$label" ]; then
               outfile=$command
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
         env:
           GADOPT_LOGLEVEL: INFO
           TS_MAXFINISHED: 100
+          BATCH_MODE: 1
 
       - name: Pytest
         id: run_pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           repository: dsroberts/tsp_for_hpc
           path: ./tsp
+          ref: v1.0.0
 
       - name: Build task spooler
         uses: threeal/cmake-action@v2

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -1,10 +1,11 @@
+include ../../rules.mk
+
 cases := functional_boundary.txt functional_field.txt
 
 all: $(cases)
 
-functional_%.txt: PDE_constrained_%.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+functional_%.txt : category := pde_constrained
+$(cases): functional_%.txt: run-PDE_constrained_%
 
 clean:
 	rm $(cases) *.h5

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -2,10 +2,13 @@ include ../../rules.mk
 
 cases := functional_boundary.txt functional_field.txt
 
+.PHONY: all clean check
+
 all: $(cases)
 
 functional_%.txt : category := pde_constrained
-$(cases): functional_%.txt: run-PDE_constrained_%
+$(cases): functional_%.txt: PDE_constrained_%.py
+	$(run-python)
 
 clean:
 	rm $(cases) *.h5

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -1,14 +1,13 @@
-all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+include ../../../rules.mk
 
-params.log: 2d_cylindrical.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L gia -f python3 $<
+all: params.log
+
+params.log : category := gia
+params.log: run-2d_cylindrical
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif
 	rm -rf output density ice mesh viscosity __pycache__
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := gia
-params.log: run-2d_cylindrical
+params.log: 2d_cylindrical.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif

--- a/demos/glacial_isostatic_adjustment/Makefile
+++ b/demos/glacial_isostatic_adjustment/Makefile
@@ -13,5 +13,5 @@ clean:
 		$(MAKE) -C $(case) $(MAKECMDGOALS); \
 	)
 
-check:
-	python -m pytest ../test_all.py -k $(gia_dir)
+check: $(cases)
+	python -m pytest $(CURDIR)/../test_all.py -k $(gia_dir)

--- a/demos/glacial_isostatic_adjustment/Makefile
+++ b/demos/glacial_isostatic_adjustment/Makefile
@@ -1,7 +1,8 @@
 include ../makefile.cases.inc
+
 cases := $(notdir $(gia_cases))
 
-.PHONY: all $(cases)
+.PHONY: all $(cases) clean check
 
 all: $(cases)
 

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := gia
-params.log: run-base_case
+params.log: base_case.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -1,14 +1,13 @@
-all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+include ../../../rules.mk
 
-params.log: base_case.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L gia -f python3 $<
+all: params.log
+
+params.log : category := gia
+params.log: run-base_case
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -1,11 +1,14 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
 params.log : PETSC_FLAGS := -Stokes_pc_factor_mat_solver_type superlu_dist
-params.log: run-2d_compressible_ALA
+params.log: 2d_compressible_ALA.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -1,16 +1,15 @@
+include ../../../rules.mk
+
 all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
-ncpus := 4
-
-params.log: 2d_compressible_ALA.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< -Stokes_pc_factor_mat_solver_type superlu_dist
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log : PETSC_FLAGS := -Stokes_pc_factor_mat_solver_type superlu_dist
+params.log: run-2d_compressible_ALA
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output reference_state
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -1,11 +1,14 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
 params.log : PETSC_FLAGS := -Stokes_pc_factor_mat_solver_type superlu_dist
-params.log: run-2d_compressible_TALA
+params.log: 2d_compressible_TALA.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -1,16 +1,15 @@
+include ../../../rules.mk
+
 all: params.log
 
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
-ncpus := 4
-
-params.log: 2d_compressible_TALA.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< -Stokes_pc_factor_mat_solver_type superlu_dist
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log : PETSC_FLAGS := -Stokes_pc_factor_mat_solver_type superlu_dist
+params.log: run-2d_compressible_TALA
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output reference_state
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -1,10 +1,13 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
-params.log: run-2d_cylindrical
+params.log: 2d_cylindrical.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -1,16 +1,14 @@
+include ../../../rules.mk
+
 all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
-ncpus := 4
-
-params.log: 2d_cylindrical.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log: run-2d_cylindrical
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -1,10 +1,13 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
-params.log: run-3d_cartesian
+params.log: 3d_cartesian.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -1,16 +1,14 @@
+include ../../../rules.mk
+
 all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
-ncpus := 4
-
-params.log: 3d_cartesian.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log: run-3d_cartesian
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output reference_state
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -1,16 +1,14 @@
+include ../../../rules.mk
+
 all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
 
-ncpus := 4
-
-params.log: 3d_spherical.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log: run-3d_spherical
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -1,10 +1,13 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
-params.log: run-3d_spherical
+params.log: 3d_spherical.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -1,7 +1,8 @@
 include ../makefile.cases.inc
+
 cases := $(notdir $(mc_cases))
 
-.PHONY: all $(cases)
+.PHONY: all $(cases) clean check
 
 all: $(cases)
 

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -13,5 +13,5 @@ clean:
 		$(MAKE) -C $(case) $(MAKECMDGOALS); \
 	)
 
-check:
-	python -m pytest ../test_all.py -k $(mc_dir)
+check: $(cases)
+	python -m pytest $(CURDIR)/../test_all.py -k $(mc_dir)

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -1,14 +1,13 @@
+include ../../../rules.mk
+
 all: functional.txt
 
-ncpus := 2
+functional.txt : category := mantle_convection
+functional.txt: run-adjoint adjoint-demo-checkpoint-state.h5
 
-functional.txt: adjoint.py adjoint-demo-checkpoint-state.h5
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L mantle_convection -f python3 $<
-
-adjoint-demo-checkpoint-state.h5: adjoint_forward.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+adjoint-demo-checkpoint-state.h5 : category := mantle_convection
+adjoint-demo-checkpoint-state.h5 : ncpus := 2
+adjoint-demo-checkpoint-state.h5: run-adjoint_forward
 
 clean:
 	rm -rf functional.txt *.h5 *.pvd solutions solution visualisation_vtk optimisation_checkpoint

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -5,6 +5,8 @@ all: functional.txt
 functional.txt : category := mantle_convection
 functional.txt: run-adjoint adjoint-demo-checkpoint-state.h5
 
+run-adjoint: adjoint-demo-checkpoint-state.h5
+
 adjoint-demo-checkpoint-state.h5 : category := mantle_convection
 adjoint-demo-checkpoint-state.h5 : ncpus := 2
 adjoint-demo-checkpoint-state.h5: run-adjoint_forward

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -1,15 +1,17 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: functional.txt
 
 functional.txt : category := mantle_convection
-functional.txt: run-adjoint adjoint-demo-checkpoint-state.h5
-
-run-adjoint: adjoint-demo-checkpoint-state.h5
+functional.txt: adjoint.py adjoint-demo-checkpoint-state.h5
+	$(run-python)
 
 adjoint-demo-checkpoint-state.h5 : category := mantle_convection
 adjoint-demo-checkpoint-state.h5 : ncpus := 2
-adjoint-demo-checkpoint-state.h5: run-adjoint_forward
+adjoint-demo-checkpoint-state.h5: adjoint_forward.py
+	$(run-python)
 
 clean:
 	rm -rf functional.txt *.h5 *.pvd solutions solution visualisation_vtk optimisation_checkpoint

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
-params.log: run-base_case
+params.log: base_case.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -1,14 +1,13 @@
-all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+include ../../../rules.mk
 
-params.log: base_case.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L mantle_convection -f python3 $<
+all: params.log
+
+params.log : category := mantle_convection
+params.log: run-base_case
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -1,14 +1,13 @@
-all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+include ../../../rules.mk
 
-params.log: free_surface.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L mantle_convection -f python3 $<
+all: params.log
+
+params.log : category := mantle_convection
+params.log: run-free_surface
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
-params.log: run-free_surface
+params.log: free_surface.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -1,14 +1,13 @@
-all: params.log
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+include ../../../rules.mk
 
-params.log: gplates_global.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L mantle_convection -f python3 $<
+all: params.log
+
+params.log : category := mantle_convection
+params.log: run-gplates_global
 
 clean:
 	rm -f *.pvd *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
-params.log: run-gplates_global
+params.log: gplates_global.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.h5 params.log

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -1,16 +1,14 @@
+include ../../../rules.mk
+
 all: params.log
 
-current_dir := $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
-ncpus := 4
-
-params.log: viscoplastic_case.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -L mantle_convection -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log : category := mantle_convection
+params.log : ncpus := 4
+params.log: run-viscoplastic_case
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
 
 check: params.log
-	python3 -m pytest ../../test_all.py -k $(test_class)/$(current_dir)
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -1,10 +1,13 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := mantle_convection
 params.log : ncpus := 4
-params.log: run-viscoplastic_case
+params.log: viscoplastic_case.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -1,7 +1,8 @@
 include ../makefile.cases.inc
+
 cases := $(notdir $(mm_cases))
 
-.PHONY: all $(cases)
+.PHONY: all $(cases) clean check
 
 all: $(cases)
 

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -13,5 +13,5 @@ clean:
 		$(MAKE) -C $(case) $(MAKECMDGOALS); \
 	)
 
-check:
-	python -m pytest ../test_all.py -k $(mm_dir)
+check: $(cases)
+	python -m pytest $(CURDIR)/../test_all.py -k $(mm_dir)

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := multi_material
-params.log: run-compositional_buoyancy
+params.log: compositional_buoyancy.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -1,9 +1,13 @@
+include ../../../rules.mk
+
 all: params.log
 
-params.log: compositional_buoyancy.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L multi_material -f python3 $<
+params.log : category := multi_material
+params.log: run-compositional_buoyancy
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
+
+check: params.log
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -1,9 +1,13 @@
+include ../../../rules.mk
+
 all: params.log
 
-params.log: thermochemical_buoyancy.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -L multi_material -f python3 $<
+params.log : category := multi_material
+params.log: run-thermochemical_buoyancy
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output
+
+check: params.log
+	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -1,9 +1,12 @@
 include ../../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
 params.log : category := multi_material
-params.log: run-thermochemical_buoyancy
+params.log: thermochemical_buoyancy.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/rules.mk
+++ b/rules.mk
@@ -1,24 +1,100 @@
-# running in batch mode, we defer scheduling to tsp
-# otherwise, we just run directly
-# in both cases, we print some timing information
+# ==================================
+# Makefile rules for executing tests
+# ==================================
+#
+# To support running tests as a full suite (`make test` from project root),
+# we have a `run-python` canned recipe to include in demo and test Makefiles.
+# This handles "batch mode", where we want to run everything at once, with
+# some kind of scheduling (through task-spooler), or "regular mode", which is
+# used for ad-hoc or targeted testing, where we don't want to have extra
+# utilities installed. In some very isolated cases, we may need to call the
+# underlying macros directly.
+#
+# Variables
+# ---------
+#
+# To configure the recipe, use per-target variables:
+# target : var := value (or the deferred variant)
+#
+# As a matter of style, it makes it more distinct from a regular rule
+# definition to include a space between the target and the first colon.
+#
+# Python script: This should be the *first dependency*, available in $<
+# `category`:    Used for tsp categorisation, and gives more context
+#                for timing information.
+# `ncpus`:       If not specified, defaults to 1 and runs the target
+#                *without* MPI. Any value greater than 1 will use mpiexec.
+# `PETSC_FLAGS`: Could come from the environment, but can also be specified
+#                per-target. Note that target-specific overrides will win
+#                over the environment! These are flags for the PETSc options
+#                database, such as `-log_view`.
+# `exec_args`:   Per-target arguments to pass through to the Python script.
+# `BATCH_MODE`:  This comes from the environment, and should be defined
+#                e.g. in a CI environment where job scheduling needs to be
+#                more granular than "run everything at once".
+#                Note that there is a *2 hour timeout* on jobs in batch mode.
+# `desc`:        A description of the job, if the script name is
+#                insufficient. Could be used when invoking the same script
+#                with several argument combinations.
+
+
+# Run macros
+# ----------
+#
+# These are the underlying macros for "regular" or "batch" mode
+# and handle scheduling and printing timing information.
+# Use `run_cmd` to respect the `BATCH_MODE` environment variable,
+# otherwise use `run_regular` or `run_batch` directly. These should
+# be used sparingly!
+#
+# These macros are designed to be used in a `$(call ...)` construct,
+# where `$(1)` is the command to execute (usually through `exec_wrapper`),
+# and `$(2)` is the description of the job to print in the timing summary.
+# `ncpus` and `category` are described above.
+
 run_regular = d=$$(date +%s); $(1) && echo "$(2) took $$(($$(date +%s)-d)) seconds"
 run_batch = id=$$(tsp -f $(if $(filter-out 1,$(ncpus)),-N $(ncpus)) $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
 run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
+# Execution macro
+# ---------------
+#
+# This determines how to run the underlying script, and handles dispatch
+# to mpiexec, and additional command line arguments.
+# Should not be called directly.
+
 exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS) $(exec_args)
 
-# running in batch mode (i.e. from the CI) we want to set a timeout
-# so that we can get useful output without hitting the GitHub Actions
-# hard limit of 6 hours
+# Execution wrapper
+# -----------------
+#
+# When running in batch mode, we want an additional wrap inside the
+# `timeout` utility to enforce a 2 hour time limit on any given task.
+# This ensures that CI jobs don't exceed the 6 hour time limit on
+# GitHub Actions so they can be torn down gracefully and provide
+# output information.
+
 exec_wrapper = $(if $(BATCH_MODE),timeout 2h $(exec_cmd),$(exec_cmd))
+
+# Canned recipe
+# -------------
+#
+# In *most* cases, this is the preferred method of executing tasks.
+# For example:
+#
+#   target : var := value
+#   target: script.py
+#   	$(run-python)
 
 define run-python =
 @$(call run_cmd,$(exec_wrapper),$(or $(desc),$<))
 endef
 
-run-%: %.py
-	$(run-python)
+# Test-related variables
+# ----------------------
+#
+# These are expansion rules that can be used to call the generic test_all.py
+# with reference to the current test/demo.
 
-# define these as expansion rules so they can be used to refer to the calling case
 current_dir = $(notdir $(patsubst %/,%,$(CURDIR)))
 test_class = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))

--- a/rules.mk
+++ b/rules.mk
@@ -1,11 +1,19 @@
-# if we're running from the CI, we want to run everything
-# with tsp, echo the job on start and finish, and
-# set a timeout
+# running in batch mode, we defer scheduling to tsp
+# otherwise, we just run directly
+# in both cases, we print some timing information
+run_regular = d=$$(date +%s); $(1) && echo "$(2) took $$(($$(date +%s)-d)) seconds"
+run_batch = id=$$(tsp -f $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
+run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
-RUN_CMD = $(if $(BATCH_MODE),tsp $(if $(category),-L $(category),))
+exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS)
+
+# running in batch mode (i.e. from the CI) we want to set a timeout
+# so that we can get useful output without hitting the GitHub Actions
+# hard limit of 6 hours
+exec_wrapper = $(if $(BATCH_MODE),timeout 2h $(exec_cmd),$(exec_cmd))
 
 run-%: %.py
-	$(RUN_CMD) $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS)
+	@$(call run_cmd,$(exec_wrapper),$(or $(desc),$<))
 
 
 # define these as expansion rules so they can be used to refer to the calling case

--- a/rules.mk
+++ b/rules.mk
@@ -5,16 +5,19 @@ run_regular = d=$$(date +%s); $(1) && echo "$(2) took $$(($$(date +%s)-d)) secon
 run_batch = id=$$(tsp -f $(if $(filter-out 1,$(ncpus)),-N $(ncpus)) $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
 run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
-exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS)
+exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS) $(exec_args)
 
 # running in batch mode (i.e. from the CI) we want to set a timeout
 # so that we can get useful output without hitting the GitHub Actions
 # hard limit of 6 hours
 exec_wrapper = $(if $(BATCH_MODE),timeout 2h $(exec_cmd),$(exec_cmd))
 
-run-%: %.py
-	@$(call run_cmd,$(exec_wrapper),$(or $(desc),$<))
+define run-python =
+@$(call run_cmd,$(exec_wrapper),$(or $(desc),$<))
+endef
 
+run-%: %.py
+	$(run-python)
 
 # define these as expansion rules so they can be used to refer to the calling case
 current_dir = $(notdir $(patsubst %/,%,$(CURDIR)))

--- a/rules.mk
+++ b/rules.mk
@@ -2,7 +2,7 @@
 # otherwise, we just run directly
 # in both cases, we print some timing information
 run_regular = d=$$(date +%s); $(1) && echo "$(2) took $$(($$(date +%s)-d)) seconds"
-run_batch = id=$$(tsp -f $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
+run_batch = id=$$(tsp -f $(if $(filter-out 1,$(ncpus)),-N $(ncpus)) $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
 run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
 exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS)

--- a/rules.mk
+++ b/rules.mk
@@ -53,7 +53,7 @@
 # `ncpus` and `category` are described above.
 
 run_regular = d=$$(date +%s); $(1) && echo "$(2) took $$(($$(date +%s)-d)) seconds"
-run_batch = id=$$(tsp -f $(if $(filter-out 1,$(ncpus)),-N $(ncpus)) $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp -i $$id | sed -n 's/Time run: //p')"
+run_batch = id=$$(tsp -f $(if $(filter-out 1,$(ncpus)),-N $(ncpus)) $(if $(category),-L $(category)) $(1)) && echo "[$(category)]$(2) took $$(tsp --print-total-time $$id)"
 run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
 # Execution macro

--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,13 @@
+# if we're running from the CI, we want to run everything
+# with tsp, echo the job on start and finish, and
+# set a timeout
+
+RUN_CMD = $(if $(BATCH_MODE),tsp $(if $(category),-L $(category),))
+
+run-%: %.py
+	$(RUN_CMD) $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS)
+
+
+# define these as expansion rules so they can be used to refer to the calling case
+current_dir = $(notdir $(patsubst %/,%,$(CURDIR)))
+test_class = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))

--- a/tests/2d_cylindrical_TALA_DG/Makefile
+++ b/tests/2d_cylindrical_TALA_DG/Makefile
@@ -1,14 +1,15 @@
+include ../../rules.mk
+
 all: params.log
 
-ncpus := 16
+params.log: category := tests
+params.log: ncpus := 16
 
-params.log: 2d_cylindrical_TALA_DG.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log: run-2d_cylindrical_TALA_DG
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output reference_state __pycache__
 
 check: params.log
-	python3 -m pytest ../../demos/test_all.py -k "../tests/2d_cylindrical_TALA_DG"
+	python3 -m pytest $(CURDIR)/../../demos/test_all.py -k "../tests/2d_cylindrical_TALA_DG"

--- a/tests/2d_cylindrical_TALA_DG/Makefile
+++ b/tests/2d_cylindrical_TALA_DG/Makefile
@@ -1,11 +1,13 @@
 include ../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
-params.log: category := tests
-params.log: ncpus := 16
-
-params.log: run-2d_cylindrical_TALA_DG
+params.log : category := tests
+params.log : ncpus := 16
+params.log: 2d_cylindrical_TALA_DG.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/tests/Drucker-Prager_rheology/Makefile
+++ b/tests/Drucker-Prager_rheology/Makefile
@@ -1,10 +1,14 @@
+include ../../rules.mk
+
 cases := $(shell python3 test_spiegelman.py)
 
 all: $(cases)
 
+$(cases): category := Drucker-Prager_rheology
+$(cases): exec_args = $@
+$(cases): desc = $(exec_args)
 $(cases): spiegelman.py
-	echo "running spiegelman $@" >&2
-	/usr/bin/time --format="spiegelman $@ finished in %E" tsp -f python3 $< $@
+	$(run-python)
 
 clean:
 	rm -rf $(addprefix spiegelman_,$(cases)) __pycache__

--- a/tests/Drucker-Prager_rheology/Makefile
+++ b/tests/Drucker-Prager_rheology/Makefile
@@ -2,12 +2,14 @@ include ../../rules.mk
 
 cases := $(shell python3 test_spiegelman.py)
 
-all: $(cases)
+.PHONY: all clean check
 
-$(cases): category := Drucker-Prager_rheology
-$(cases): exec_args = $@
-$(cases): desc = $(exec_args)
-$(cases): spiegelman.py
+all: $(addprefix spiegelman_,$(cases))
+
+spiegelman_% : category := Drucker-Prager_rheology
+spiegelman_% : exec_args = $*
+spiegelman_% : desc = $(exec_args)
+spiegelman_%: spiegelman.py
 	$(run-python)
 
 clean:

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -2,20 +2,20 @@ include ../../rules.mk
 
 cases := damping smoothing Tobs uobs
 
+.PHONY: all clean check
+
 all: $(addsuffix .conv,$(cases))
 
-%.conv: category := tests/adjoint
-%.conv: ncpus := 2
-%.conv: exec_args = $*
-%.conv: desc = $(exec_args)
-
+%.conv : category := tests/adjoint
+%.conv : ncpus := 2
+%.conv : exec_args = $*
+%.conv : desc = $(exec_args)
 %.conv: taylor_test.py adjoint-demo-checkpoint-state.h5
 	$(run-python)
 
-adjoint-demo-checkpoint-state.h5: category := tests/adjoint
-adjoint-demo-checkpoint-state.h5: ncpus := 2
-adjoint-demo-checkpoint-state.h5: desc := forward
-
+adjoint-demo-checkpoint-state.h5 : category := tests/adjoint
+adjoint-demo-checkpoint-state.h5 : ncpus := 2
+adjoint-demo-checkpoint-state.h5 : desc := forward
 adjoint-demo-checkpoint-state.h5: ../../demos/mantle_convection/adjoint/adjoint_forward.py
 	$(run-python)
 

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -1,16 +1,23 @@
+include ../../rules.mk
+
 cases := damping smoothing Tobs uobs
 
 all: $(addsuffix .conv,$(cases))
 
-ncpus := 2
+%.conv: category := tests/adjoint
+%.conv: ncpus := 2
+%.conv: exec_args = $*
+%.conv: desc = $(exec_args)
 
 %.conv: taylor_test.py adjoint-demo-checkpoint-state.h5
-	echo "running $< on case $*" >&2
-	/usr/bin/time --format="$< on case $* took %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $< $*
+	$(run-python)
+
+adjoint-demo-checkpoint-state.h5: category := tests/adjoint
+adjoint-demo-checkpoint-state.h5: ncpus := 2
+adjoint-demo-checkpoint-state.h5: desc := forward
 
 adjoint-demo-checkpoint-state.h5: ../../demos/mantle_convection/adjoint/adjoint_forward.py
-	echo "running forward adjoint case" >&2
-	/usr/bin/time --format="forward adjoint case took %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+	$(run-python)
 
 clean:
 	rm -f *.h5 *.conv *.dat

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -13,10 +13,9 @@ longtest: $(long_cases)
 
 $(cases): %: .sentinel.%
 
-# This is the one place that it's just a bit too complex to handle batch vs. non-batch
-# modes, so we will always assume tsp is available.
+tsp_string = $(if $(BATCH_MODE),tsp -N {cores} -f)
 $(sentinels): analytical.py
-	@$(call run_regular,python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $(subst .sentinel.,,$@),analytical $(subst .sentinel.,,$@))
+	@$(call run_regular,python3 analytical.py submit -t "$(tsp_string) mpiexec -np {cores}" $(subst .sentinel.,,$@),analytical $(subst .sentinel.,,$@))
 	@echo "done" > $@
 
 .ONESHELL:

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -13,6 +13,8 @@ longtest: $(long_cases)
 
 $(cases): %: .sentinel.%
 
+# This is the one place that it's just a bit too complex to handle batch vs. non-batch
+# modes, so we will always assume tsp is available.
 $(sentinels): analytical.py
 	@$(call run_regular,python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $(subst .sentinel.,,$@),analytical $(subst .sentinel.,,$@))
 	@echo "done" > $@

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -1,3 +1,5 @@
+include ../../rules.mk
+
 cases := smooth_cylindrical_freeslip smooth_cylindrical_zeroslip delta_cylindrical_freeslip delta_cylindrical_zeroslip delta_cylindrical_freeslip_dpc delta_cylindrical_zeroslip_dpc
 long_cases := smooth_cylindrical_freesurface smooth_spherical_freeslip smooth_spherical_zeroslip
 
@@ -12,9 +14,8 @@ longtest: $(long_cases)
 $(cases): %: .sentinel.%
 
 $(sentinels): analytical.py
-	echo "running analytical $(subst .sentinel.,,$@)" >&2
-	/usr/bin/time --format="analytical $(subst .sentinel.,,$@) finished in %E" python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $(subst .sentinel.,,$@)
-	echo "done" > $@
+	@$(call run_regular,python3 analytical.py submit -t "tsp -N {cores} -f mpiexec -np {cores}" $(subst .sentinel.,,$@),analytical $(subst .sentinel.,,$@))
+	@echo "done" > $@
 
 .ONESHELL:
 SHELL = /bin/bash

--- a/tests/base_gmsh/Makefile
+++ b/tests/base_gmsh/Makefile
@@ -1,16 +1,15 @@
 include ../../rules.mk
 
-all: params.log
+.PHONY: all clean check
 
-.PHONY: all clean
+all: params.log
 
 %.msh: %.geo
 	gmsh -2 $<
 
-params.log: category := tests/gmsh
-params.log: run-base_case square.msh
-
-run-base_case: square.msh
+params.log : category := tests/gmsh
+params.log: base_case.py square.msh
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.msh

--- a/tests/base_gmsh/Makefile
+++ b/tests/base_gmsh/Makefile
@@ -1,3 +1,5 @@
+include ../../rules.mk
+
 all: params.log
 
 .PHONY: all clean
@@ -5,9 +7,10 @@ all: params.log
 %.msh: %.geo
 	gmsh -2 $<
 
-params.log: base_case.py square.msh
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+params.log: category := tests/gmsh
+params.log: run-base_case square.msh
+
+run-base_case: square.msh
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.msh

--- a/tests/free_surface/Makefile
+++ b/tests/free_surface/Makefile
@@ -13,8 +13,8 @@ all: $(serial_cases) $(parallel_cases)
 #Allow 'make <easy name>' to effectively alias to 'make <long ugly file name>'
 $(serial_cases) $(parallel_cases): %: .sentinel.%
 
-$(serial_sentinels) $(parallel_sentinels): category := tests/free_surface
-$(parallel_sentinels): ncpus := 8
+$(serial_sentinels) $(parallel_sentinels) : category := tests/free_surface
+$(parallel_sentinels) : ncpus := 8
 
 $(serial_sentinels) $(parallel_sentinels): .sentinel.%: %_free_surface.py
 	$(run-python)

--- a/tests/free_surface/Makefile
+++ b/tests/free_surface/Makefile
@@ -1,7 +1,7 @@
+include ../../rules.mk
+
 serial_cases := explicit implicit implicit_top_bottom
 parallel_cases := implicit_top_bottom_buoyancy implicit_cylindrical
-
-ncpus := 8
 
 serial_sentinels := $(addprefix .sentinel.,$(serial_cases))
 parallel_sentinels := $(addprefix .sentinel.,$(parallel_cases))
@@ -13,15 +13,12 @@ all: $(serial_cases) $(parallel_cases)
 #Allow 'make <easy name>' to effectively alias to 'make <long ugly file name>'
 $(serial_cases) $(parallel_cases): %: .sentinel.%
 
-$(serial_sentinels):
-	echo "running $(subst .sentinel.,,$@) free surface coupling "
-	tsp -N 1 -f python3 $(subst .sentinel.,,$@)_free_surface.py
-	echo "done" > $@
+$(serial_sentinels) $(parallel_sentinels): category := tests/free_surface
+$(parallel_sentinels): ncpus := 8
 
-$(parallel_sentinels):
-	echo "running $(subst .sentinel.,,$@) free surface coupling "
-	tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $(subst .sentinel.,,$@)_free_surface.py
-	echo "done" > $@
+$(serial_sentinels) $(parallel_sentinels): .sentinel.%: %_free_surface.py
+	$(run-python)
+	@echo "done" > $@
 
 clean:
 	rm -rf *.dat .sentinel.* __pycache__

--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -1,12 +1,15 @@
-cases := crameri_2012 gerya_2003 robey_2019 schmalholz_2011 schmeling_2008 tosi_2015 trim_2023 van_keken_1997_isothermal van_keken_1997_thermochemical
+include ../../rules.mk
 
-ncpus := 8
+cases := crameri_2012 gerya_2003 robey_2019 schmalholz_2011 schmeling_2008 tosi_2015 trim_2023 van_keken_1997_isothermal van_keken_1997_thermochemical
 
 all: $(cases)
 
-$(cases):
-	echo "running $@ multi-material benchmark"
-	tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 run_benchmark.py benchmarks.$@
+$(cases): ncpus := 8
+$(cases): category := multi_material
+$(cases): exec_cmd = mpiexec -np $(ncpus) python3 $< benchmarks.$*
+
+$(cases): %: run_benchmark.py benchmarks/%.py
+	@$(call run_cmd,$(exec_wrapper),$*)
 
 clean:
 	@$(foreach case, $(cases), \

--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -2,14 +2,16 @@ include ../../rules.mk
 
 cases := crameri_2012 gerya_2003 robey_2019 schmalholz_2011 schmeling_2008 tosi_2015 trim_2023 van_keken_1997_isothermal van_keken_1997_thermochemical
 
+.PHONY: all clean check
+
 all: $(cases)
 
-$(cases): ncpus := 8
-$(cases): category := multi_material
-$(cases): exec_cmd = mpiexec -np $(ncpus) python3 $< benchmarks.$*
-
+$(cases) : ncpus := 8
+$(cases) : category := multi_material
+$(cases) : exec_cmd = mpiexec -np $(ncpus) python3 $< benchmarks.$*
+$(cases): desc = $*
 $(cases): %: run_benchmark.py benchmarks/%.py
-	@$(call run_cmd,$(exec_wrapper),$*)
+	$(run-python)
 
 clean:
 	@$(foreach case, $(cases), \

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -2,10 +2,12 @@ include ../../rules.mk
 
 cases := full_optimisation_np1.dat full_optimisation_np2.dat
 
+.PHONY: all clean check
+
 all: $(cases)
 
-full_optimisation_np%.dat: category := optimisation_checkpointing
-full_optimisation_np%.dat: ncpus = $*
+full_optimisation_np%.dat : category := optimisation_checkpointing
+full_optimisation_np%.dat : ncpus = $*
 
 $(cases): full_optimisation_np%.dat: helmholtz.py
 	$(run-python)

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -1,11 +1,17 @@
-all: full_optimisation_np1.dat full_optimisation_np2.dat
+include ../../rules.mk
 
-full_optimisation_np%.dat: helmholtz.py
-	echo "running helmholtz checkpointing (np $*)" >&2
-	/usr/bin/time --format="helmholtz checkpointing (np $*) took %E" tsp -N $* -f mpiexec -np $* python3 $<
+cases := full_optimisation_np1.dat full_optimisation_np2.dat
+
+all: $(cases)
+
+full_optimisation_np%.dat: category := optimisation_checkpointing
+full_optimisation_np%.dat: ncpus = $*
+
+$(cases): full_optimisation_np%.dat: helmholtz.py
+	$(run-python)
 
 clean:
 	rm -rf optimisation_checkpoint_* __pycache__ *.h5 *.dat
 
-check: full_optimisation_np1.dat full_optimisation_np2.dat
+check: $(cases)
 	python -m pytest

--- a/tests/scalar_advection/Makefile
+++ b/tests/scalar_advection/Makefile
@@ -1,10 +1,12 @@
+include ../../rules.mk
+
 all: final_error.log
 
 .PHONY: all clean
 
-final_error.log: scalar_advection.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+final_error.log: category := tests
+
+final_error.log: run-scalar_advection
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 final_error.log

--- a/tests/scalar_advection/Makefile
+++ b/tests/scalar_advection/Makefile
@@ -1,12 +1,12 @@
 include ../../rules.mk
 
+.PHONY: all clean check
+
 all: final_error.log
 
-.PHONY: all clean
-
-final_error.log: category := tests
-
-final_error.log: run-scalar_advection
+final_error.log : category := tests
+final_error.log: scalar_advection.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 final_error.log

--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -1,3 +1,5 @@
+include ../../rules.mk
+
 cases := $(shell python3 test_scalar_advection_diffusion_DH27.py)
 
 sentinels := $(addprefix .sentinel.,$(cases))
@@ -8,18 +10,17 @@ all: $(cases) integrated_q.log integrated_q_DH219.log
 
 $(cases): %: .sentinel.%
 
+$(sentinels): category := scalar_advection_diffusion_DH27
+$(sentinels): exec_args = $(subst .sentinel.,,$@)
+$(sentinels): desc = $(exec_args)
 $(sentinels): scalar_advection_diffusion_DH27.py
-	echo "running advection diffusion $(subst .sentinel.,,$@)" >&2
-	tsp -N 1 -f python3 $< $(subst .sentinel.,,$@)
-	echo 'done' > $@
+	$(run-python)
 
-integrated_q.log: scalar_advection_diffusion.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+integrated_q.log: category := tests
+integrated_q.log: run-scalar_advection_diffusion
 
-integrated_q_DH219.log: scalar_advection_diffusion_DH219_skew.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$@ finished in %E" tsp -f python3 $<
+integrated_q_DH219.log: category := tests
+integrated_q_DH219.log: run-scalar_advection_diffusion_DH219_skew
 
 clean:
 	rm -f *.dat .sentinel.* *.log

--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -4,23 +4,25 @@ cases := $(shell python3 test_scalar_advection_diffusion_DH27.py)
 
 sentinels := $(addprefix .sentinel.,$(cases))
 
-.PHONY: all $(cases) clean
+.PHONY: all $(cases) clean check
 
 all: $(cases) integrated_q.log integrated_q_DH219.log
 
 $(cases): %: .sentinel.%
 
-$(sentinels): category := scalar_advection_diffusion_DH27
-$(sentinels): exec_args = $(subst .sentinel.,,$@)
-$(sentinels): desc = $(exec_args)
-$(sentinels): scalar_advection_diffusion_DH27.py
+$(sentinels) : category := scalar_advection_diffusion_DH27
+$(sentinels) : exec_args = $(subst .sentinel.,,$@)
+$(sentinels) : desc = $(exec_args)
+$(sentinels) : scalar_advection_diffusion_DH27.py
 	$(run-python)
 
-integrated_q.log: category := tests
-integrated_q.log: run-scalar_advection_diffusion
+integrated_q.log : category := tests
+integrated_q.log: scalar_advection_diffusion.py
+	$(run-python)
 
-integrated_q_DH219.log: category := tests
-integrated_q_DH219.log: run-scalar_advection_diffusion_DH219_skew
+integrated_q_DH219.log : category := tests
+integrated_q_DH219.log: scalar_advection_diffusion_DH219_skew.py
+	$(run-python)
 
 clean:
 	rm -f *.dat .sentinel.* *.log

--- a/tests/viscoelastic/Makefile
+++ b/tests/viscoelastic/Makefile
@@ -1,11 +1,16 @@
+include ../../rules.mk
+
 cases := elastic viscoelastic viscous
 output_files := $(foreach case,$(cases),errors-$(case)-zhong-free-surface.dat)
 
 all: $(output_files)
 
+errors-%-zhong-free-surface.dat: category := tests/viscoelastic
+errors-%-zhong-free-surface.dat: exec_args = --case $*
+errors-%-zhong-free-surface.dat: desc = $*
+
 errors-%-zhong-free-surface.dat: zhong_viscoelastic_free_surface.py
-	echo "running $< on $*" >&1
-	/usr/bin/time --format="$< $* finished in %E" tsp -f python3 $< --case $*
+	$(run-python)
 	
 clean:
 	rm -rf errors*.dat __pycache__

--- a/tests/viscoelastic/Makefile
+++ b/tests/viscoelastic/Makefile
@@ -3,12 +3,13 @@ include ../../rules.mk
 cases := elastic viscoelastic viscous
 output_files := $(foreach case,$(cases),errors-$(case)-zhong-free-surface.dat)
 
+.PHONY: all clean check
+
 all: $(output_files)
 
-errors-%-zhong-free-surface.dat: category := tests/viscoelastic
-errors-%-zhong-free-surface.dat: exec_args = --case $*
-errors-%-zhong-free-surface.dat: desc = $*
-
+errors-%-zhong-free-surface.dat : category := tests/viscoelastic
+errors-%-zhong-free-surface.dat : exec_args = --case $*
+errors-%-zhong-free-surface.dat : desc = $*
 errors-%-zhong-free-surface.dat: zhong_viscoelastic_free_surface.py
 	$(run-python)
 	

--- a/tests/viscoplastic_case_DG/Makefile
+++ b/tests/viscoplastic_case_DG/Makefile
@@ -1,11 +1,13 @@
 include ../../rules.mk
 
+.PHONY: all clean check
+
 all: params.log
 
-params.log: category := tests
-params.log: ncpus := 4
-
-params.log: run-viscoplastic_case_DG
+params.log : category := tests
+params.log : ncpus := 4
+params.log: viscoplastic_case_DG.py
+	$(run-python)
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log

--- a/tests/viscoplastic_case_DG/Makefile
+++ b/tests/viscoplastic_case_DG/Makefile
@@ -1,14 +1,15 @@
+include ../../rules.mk
+
 all: params.log
 
-ncpus := 4
+params.log: category := tests
+params.log: ncpus := 4
 
-params.log: viscoplastic_case_DG.py
-	echo "running $<" >&2
-	/usr/bin/time --format="$< finished in %E" tsp -N $(ncpus) -f mpiexec -np $(ncpus) python3 $<
+params.log: run-viscoplastic_case_DG
 
 clean:
 	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
 	rm -rf output __pycache__
 
 check: params.log
-	python3 -m pytest ../../demos/test_all.py -k "../tests/viscoplastic_case_DG"
+	python3 -m pytest $(CURDIR)/../../demos/test_all.py -k "../tests/viscoplastic_case_DG"


### PR DESCRIPTION
Also gets rid of the requirement on `/usr/bin/time` which has different behaviour on BSD (i.e. macOS).

- [x] also fix up `tests` directory
- [x] fix "Output timing information" step of CI

Closes #175.
Closes #167.

# How it works
This adds a `rules.mk` in the base directory, which has methods for running tests in `BATCH_MODE` (i.e. CI) or interactively, and uses `mpiexec` or not, depending on the case. Both modes will print some timing information. The important section is the `run-python` canned recipe which depends on the following variables: `$ncpus`, `$category`, `$PETSC_FLAGS`, `$exec_args` and expects the Python script to be the first dependency (as `$<`). There's also a pattern rule which uses the canned recipe. For example:

```makefile
params.log : category := mantle_convection
params.log: run-base_case
```

The `check` rules all use a relative path to find the test fixture, so they will work with `make -C` from wherever.

The `analytical_comparisons` test still requires task-spooler.