### PR TITLE
Set comm on restored CheckpointedROLVector

### DIFF
--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -175,6 +175,7 @@ class LinMoreOptimiser:
         for v in _vector_registry:
             x = [p.copy(deepcopy=True) for p in vec]
             v.dat = x
+            v.comm = x[0].comm
             v.load(self._mesh)
             v._optimiser = self
 

--- a/tests/optimisation_checkpointing/helmholtz.py
+++ b/tests/optimisation_checkpointing/helmholtz.py
@@ -81,7 +81,7 @@ optimiser = LinMoreOptimiser(
     minimisation_problem,
     minimisation_parameters,
     checkpoint_dir=checkpoint_dir,
-    auto_checkpoint=False,
+    auto_checkpoint=True,
 )
 optimiser.restore()
 run(optimiser, rf, mesh.comm.rank, f"restored_optimisation_from_last_it_np{num_processes}.dat")


### PR DESCRIPTION
Should fix an error when checkpointing is enabled after restarting a checkpointed optimisation.