### PR TITLE
Pack boundary conditions and solver options in `StokesSolver` methods

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -295,9 +295,6 @@ class StokesSolver:
 
     def set_boundary_conditions(self) -> None:
         """Sets strong and weak boundary conditions."""
-        self.strong_bcs = []
-        self.weak_bcs = {}
-
         bc_map = {"u": self.solution_space.sub(0)}
         if self.mesh.cartesian:
             bc_map["ux"] = bc_map["u"].sub(0)

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -5,6 +5,7 @@ instantiate the `StokesSolver` class by providing relevant parameters and call t
 
 """
 
+from collections import defaultdict
 from numbers import Number
 from typing import Optional
 
@@ -224,13 +225,15 @@ class StokesSolver:
         free_surface_theta: float = 0.5,
         **kwargs,
     ):
-        self.Z = z.function_space()
-        self.mesh = self.Z.mesh()
-        self.test = fd.TestFunctions(self.Z)
+        self.solution_space = z.function_space()
+        self.mesh = self.solution_space.mesh()
+        self.test = fd.TestFunctions(self.solution_space)
         self.solution = z
         self.T = T
         self.approximation = approximation
+        self.bcs = bcs
         self.quad_degree = quad_degree
+        self.solver_parameters = solver_parameters
 
         self.J = J
         self.constant_jacobian = constant_jacobian
@@ -250,30 +253,7 @@ class StokesSolver:
         self.free_surface_theta = free_surface_theta  # theta = 0.5 gives a second order accurate integration scheme in time
         self.free_surface = False
 
-        for id, bc in bcs.items():
-            weak_bc = {}
-            for bc_type, value in bc.items():
-                if bc_type == 'u':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0), value, id))
-                elif bc_type == 'ux':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(0), value, id))
-                elif bc_type == 'uy':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(1), value, id))
-                elif bc_type == 'uz':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(2), value, id))
-                elif bc_type == 'free_surface':
-                    # N.b. stokes_integrators assumes that the order of the bcs matches the order of the
-                    # free surfaces defined in the mixed space. This is not ideal - python dictionaries
-                    # are ordered by insertion only since recently (since 3.7) - so relying on their order
-                    # is fraught and not considered pythonic. At the moment let's consider having more
-                    # than one free surface a bit of a niche case for now, and leave it as is...
-
-                    # Copy free surface information to a new dictionary
-                    self.free_surface_dict[id] = value
-                    self.free_surface = True
-                else:
-                    weak_bc[bc_type] = value
-            self.weak_bcs[id] = weak_bc
+        self.set_boundary_conditions()
 
         # eta is a list of 0, 1 or multiple free surface fields
         self.u, self.p, *self.eta = fd.split(self.solution)
@@ -286,7 +266,7 @@ class StokesSolver:
             self.equations.append(
                 Equation(
                     self.test[i],
-                    self.Z[i],
+                    self.solution_space[i],
                     terms_eq,
                     eq_attrs=eq_attrs,
                     approximation=self.approximation,
@@ -308,52 +288,102 @@ class StokesSolver:
                 # (N.b. we already have two equations from StokesEquations)
                 self.F += self.equations[2+i].mass((self.eta[i]-self.eta_old[i])/self.free_surface_dt)
 
-        if isinstance(solver_parameters, dict):
-            self.solver_parameters = solver_parameters
-        else:
-            if self.linear:
-                self.solver_parameters = {"snes_type": "ksponly"}
-            else:
-                self.solver_parameters = newton_stokes_solver_parameters.copy()
-
-            if INFO >= log_level:
-                self.solver_parameters["snes_monitor"] = None
-
-            if isinstance(solver_parameters, str):
-                match solver_parameters:
-                    case "direct":
-                        self.solver_parameters.update(direct_stokes_solver_parameters)
-                    case "iterative":
-                        self.solver_parameters.update(
-                            iterative_stokes_solver_parameters
-                        )
-                    case _:
-                        raise ValueError(
-                            f"Solver type '{solver_parameters}' not implemented."
-                        )
-            elif self.mesh.topological_dimension() == 2 and self.mesh.cartesian:
-                self.solver_parameters.update(direct_stokes_solver_parameters)
-            else:
-                self.solver_parameters.update(iterative_stokes_solver_parameters)
-
-            if self.solver_parameters.get("pc_type") == "fieldsplit":
-                # extra options for iterative solvers
-                if DEBUG >= log_level:
-                    self.solver_parameters['fieldsplit_0']['ksp_converged_reason'] = None
-                    self.solver_parameters['fieldsplit_1']['ksp_monitor'] = None
-                elif INFO >= log_level:
-                    self.solver_parameters['fieldsplit_1']['ksp_converged_reason'] = None
-
-                if self.free_surface:
-                    # merge free surface fields with pressure field for Schur complement solve
-                    self.solver_parameters.update({"pc_fieldsplit_0_fields": '0',
-                                                   "pc_fieldsplit_1_fields": '1,'+','.join(str(2+i) for i in range(len(self.eta)))})
-
-                    # update keys for GADOPT's free surface mass inverse preconditioner
-                    self.solver_parameters["fieldsplit_1"].update({"pc_python_type": "gadopt.FreeSurfaceMassInvPC"})
+        self.set_solver_options()
 
         # solver object is set up later to permit editing default solver parameters specified above
         self._solver_setup = False
+
+    def set_boundary_conditions(self) -> None:
+        """Sets strong and weak boundary conditions."""
+        self.strong_bcs = []
+        self.weak_bcs = {}
+
+        bc_map = {"u": self.solution_space.sub(0)}
+        if self.mesh.cartesian:
+            bc_map["ux"] = bc_map["u"].sub(0)
+            bc_map["uy"] = bc_map["u"].sub(1)
+            if self.mesh.geometric_dimension == 3:
+                bc_map["uz"] = bc_map["u"].sub(2)
+
+        for bc_id, bc in self.bcs.items():
+            weak_bc = defaultdict(float)
+
+            for bc_type, val in bc.items():
+                match bc_type:
+                    case "u" | "ux" | "uy" | "uz":
+                        self.strong_bcs.append(
+                            fd.DirichletBC(bc_map[bc_type], val, bc_id)
+                        )
+                    case "free_surface":
+                        # N.B. stokes_integrators assumes that the order of the bcs
+                        # matches the order of the free surfaces defined in the mixed
+                        # space. This is not ideal - Python dictionaries are ordered by
+                        # insertion only since recently (since 3.7) - so relying on
+                        # their order is fraught and not considered pythonic. At the
+                        # moment let's consider having more than one free surface a bit
+                        # of a niche case for now, and leave it as is...
+
+                        # Copy free surface information to a new dictionary
+                        self.free_surface_dict[bc_id] = val
+                        self.free_surface = True
+                    case _:
+                        weak_bc[bc_type] += val
+
+            self.weak_bcs[bc_id] = weak_bc
+
+    def set_solver_options(self) -> None:
+        """Sets PETSc solver parameters."""
+        # Application context for the inverse mass matrix preconditioner
+        self.appctx = {
+            "mu": self.approximation.mu / self.approximation.rho_continuity()
+        }
+
+        if isinstance(solver_preset := self.solver_parameters, dict):
+            return
+
+        if not depends_on(self.approximation.mu, self.solution):
+            self.solver_parameters = {"snes_type": "ksponly"}
+        else:
+            self.solver_parameters = newton_stokes_solver_parameters.copy()
+
+        if INFO >= log_level:
+            self.solver_parameters["snes_monitor"] = None
+
+        if solver_preset is not None:
+            match solver_preset:
+                case "direct":
+                    self.solver_parameters.update(direct_stokes_solver_parameters)
+                case "iterative":
+                    self.solver_parameters.update(iterative_stokes_solver_parameters)
+                case _:
+                    raise ValueError("Solver type must be 'direct' or 'iterative'.")
+        elif self.mesh.topological_dimension() == 2 and self.mesh.cartesian:
+            self.solver_parameters.update(direct_stokes_solver_parameters)
+        else:
+            self.solver_parameters.update(iterative_stokes_solver_parameters)
+
+        # Extra options for iterative solvers
+        if self.solver_parameters.get("pc_type") == "fieldsplit":
+            if DEBUG >= log_level:
+                self.solver_parameters["fieldsplit_0"]["ksp_converged_reason"] = None
+                self.solver_parameters["fieldsplit_1"]["ksp_monitor"] = None
+            elif INFO >= log_level:
+                self.solver_parameters["fieldsplit_1"]["ksp_converged_reason"] = None
+
+            if self.free_surface:
+                # Gather pressure and free surface fields for Schur complement solve
+                fields_ind = ",".join(map(str, range(1, len(self.solution_split))))
+                self.solver_parameters.update(
+                    {
+                        "pc_fieldsplit_0_fields": "0",
+                        "pc_fieldsplit_1_fields": fields_ind,
+                    }
+                )
+
+                # Update mass inverse preconditioner
+                self.solver_parameters["fieldsplit_1"].update(
+                    {"pc_python_type": "gadopt.FreeSurfaceMassInvPC"}
+                )
 
     def setup_equation_attributes(self):
         stress = self.approximation.stress(self.u)
@@ -413,7 +443,7 @@ class StokesSolver:
             self.equations.append(
                 Equation(
                     self.test[2 + c],
-                    self.Z[2 + c],
+                    self.solution_space[2 + c],
                     free_surface_term,
                     mass_term=mass_term_fs,
                     eq_attrs=eq_attrs,
@@ -423,7 +453,7 @@ class StokesSolver:
 
             # Set internal dofs to zero to prevent singular matrix for free surface equation
             self.strong_bcs.append(
-                InteriorBC(self.Z.sub(2 + c), 0, free_surface_id)
+                InteriorBC(self.solution_space.sub(2 + c), 0, free_surface_id)
             )
 
             self.free_surface_id_list.append(free_surface_id)
@@ -432,17 +462,15 @@ class StokesSolver:
 
     def setup_solver(self):
         """Sets up the solver."""
-        # mu used in MassInvPC:
-        appctx = {"mu": self.approximation.mu / self.approximation.rho_continuity()}
-
         if self.free_surface:
-            appctx["free_surface_id_list"] = self.free_surface_id_list
-            appctx["ds"] = self.equations[2].ds
+            self.appctx["free_surface_id_list"] = self.free_surface_id_list
+            self.appctx["ds"] = self.equations[2].ds
 
         if self.constant_jacobian:
-            z_tri = fd.TrialFunction(self.Z)
-            F_stokes_lin = fd.replace(self.F, {self.solution: z_tri})
-            a, L = fd.lhs(F_stokes_lin), fd.rhs(F_stokes_lin)
+            trial = fd.TrialFunction(self.solution_space)
+            F = fd.replace(self.F, {self.solution: trial})
+            a, L = fd.lhs(F), fd.rhs(F)
+
             self.problem = fd.LinearVariationalProblem(
                 a, L, self.solution, bcs=self.strong_bcs, constant_jacobian=True
             )
@@ -450,7 +478,7 @@ class StokesSolver:
                 self.problem,
                 solver_parameters=self.solver_parameters,
                 options_prefix=self.name,
-                appctx=appctx,
+                appctx=self.appctx,
                 **self.solver_kwargs,
             )
         else:
@@ -461,7 +489,7 @@ class StokesSolver:
                 self.problem,
                 solver_parameters=self.solver_parameters,
                 options_prefix=self.name,
-                appctx=appctx,
+                appctx=self.appctx,
                 **self.solver_kwargs,
             )
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -372,7 +372,7 @@ class StokesSolver:
 
             if self.free_surface:
                 # Gather pressure and free surface fields for Schur complement solve
-                fields_ind = ",".join(map(str, range(1, len(self.solution_split))))
+                fields_ind = ",".join(map(str, range(1, len(self.solution_space))))
                 self.solver_parameters.update(
                     {
                         "pc_fieldsplit_0_fields": "0",


### PR DESCRIPTION
This PR contains the first set of changes transitioning the current Stokes integrators module towards the one proposed in gh-158. The end goal is to inherit solver classes from an abstract base class, and the methods defined here will become part of the abstract base class.