### PR TITLE
[skip tests] Prototype multi-system extension for parallel_scaling tests

### DIFF
--- a/tests/parallel_scaling/Makefile
+++ b/tests/parallel_scaling/Makefile
@@ -10,7 +10,7 @@ SHELL = /bin/bash
 profile_%.txt: scaling.py stokes_cubed_sphere.py
 	echo "running parallel scaling on level $*"
 	mkdir -p pbs_output
-	python3 scaling.py submit -t "qsub -v GADOPT_CHECKOUT=$(gadopt_checkout),GADOPT_SETUP=$(gadopt_setup) -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2+gdata/fp50,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P $(project) -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}" $*
+	python3 scaling.py submit -H $*
 
 clean:
 	rm -rf pbs_output profile_*.txt level_*.out level_*.err

--- a/tests/parallel_scaling/run_setonix.sh
+++ b/tests/parallel_scaling/run_setonix.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -i
+#SBATCH --exclude=nid00[2024-2055],nid00[2792-2823]
+
+level=$1
+shift
+
+export MY_GADOPT="$GADOPT_CHECKOUT"
+source "$GADOPT_SETUP"
+
+srun $@ -n 1 2> level_${level}_warmup.err > level_${level}_warmup.out
+export PETSC_OPTIONS="-log_view :profile_${level}.txt"
+srun $@ 2> level_${level}_full.err > level_${level}_full.out

--- a/tests/parallel_scaling/scaling.py
+++ b/tests/parallel_scaling/scaling.py
@@ -1,8 +1,10 @@
 import argparse
 import numpy as np
+import os
 import re
 import subprocess
 import sys
+import socket
 from pathlib import Path
 
 cases = {
@@ -27,6 +29,47 @@ cases = {
         "timestep": 6.25e-9,
     },
 }
+
+
+class HPCDetails:
+    batch_templates = {
+        "gadi": "qsub -v GADOPT_CHECKOUT={gadopt_checkout},GADOPT_SETUP={gadopt_setup} -W block=true -N scaling_{level} -l storage=gdata/xd2+scratch/xd2+gdata/fp50,ncpus={cores},walltime=04:00:00,mem={mem}GB,wd,jobfs=200GB -q normalsr -P {project} -o pbs_output/l{level}.out -e pbs_output/l{level}.err -- ./run_gadi.sh {level}",
+        "setonix": "sbatch --export GADOPT_CHECKOUT={gadopt_checkout},GADOPT_SETUP={gadopt_setup} --wait -J scaling_{level} --exclusive --ntasks={cores} --nodes={nodes} -t 4:00:00 -p work -A {project} -o slurm_output/l{level}.out -o slurm_output/l{level}.err -- ./run_setonix.sh {level}",
+    }
+    required_environment = {
+        "gadi": {"gadopt_checkout", "gadopt_setup", "project"},
+        "setonix": {"gadopt_checkout", "gadopt_setup", "project"},
+    }
+
+    @staticmethod
+    def hpc_system_is_gadi():
+        return socket.gethostname().startswith("gadi")
+
+    @staticmethod
+    def hpc_system_is_setonix():
+        if os.path.isfile("/software/pawsey/motd"):
+            with open("/software/pawsey/motd") as f:
+                for line in f.readlines():
+                    if line == "     ___  ___| |_ ___  _ __ (_)_  __           ,########(,,  ...     ,########/,\n":
+                        return True
+            return False
+        else:
+            return False
+
+
+def get_hpc_template():
+    system = None
+    for name in dir(HPCDetails):
+        if name.startswith("hpc_system_is"):
+            if getattr(HPCDetails, name)():
+                system = name.split("_")[-1]
+    if not system:
+        raise KeyError("HPC system requested but could not identify system")
+    # check environment variables
+    for var in HPCDetails.required_environment[system]:
+        if var not in os.environ:
+            raise KeyError(f"{var} is required in environment when running on {system}")
+    return HPCDetails.batch_templates[system], {var: os.environ[var] for var in HPCDetails.required_environment[system]}
 
 
 def get_data(level, base_path=None):
@@ -93,12 +136,17 @@ def run_subcommand(args):
 def submit_subcommand(args):
     config = cases[args.level]
     cores = config.pop("cores")
-    command = args.template.format(cores=cores, mem=4*cores, level=args.level)
-
+    command = args.template.format(
+        cores=cores, mem=4*cores, level=args.level, nodes=max(1, cores//104), **args.extra_format
+    )
     proc = subprocess.Popen(
         [
-            *command.split(), sys.executable, sys.argv[0],
-            "run", str(args.level), *[str(v) for v in config.values()],
+            *command.split(),
+            os.path.basename(sys.executable),
+            sys.argv[0],
+            "run",
+            str(args.level),
+            *[str(v) for v in config.values()],
         ],
     )
     if proc.wait() != 0:
@@ -112,17 +160,29 @@ if __name__ == "__main__":
         description="Run/submit parallel scaling test casse",
     )
     subparsers = parser.add_subparsers(title="subcommands")
-
-    parser_run = subparsers.add_parser("run", help="run a specific configuration of a case (usually not manually invoked)")
+    parser_run = subparsers.add_parser(
+        "run", help="run a specific configuration of a case (usually not manually invoked)"
+    )
     parser_run.add_argument("level", type=int)
     parser_run.add_argument("layers", type=int)
     parser_run.add_argument("timestep", type=float)
     parser_run.add_argument("-n", "--steps", type=int, help="number of timesteps to run")
     parser_run.set_defaults(func=run_subcommand)
     parser_submit = subparsers.add_parser("submit", help="submit a PBS job to run a specific case")
-    parser_submit.add_argument("-t", "--template", default="mpiexec -np {cores}", help="template command for running commands under MPI")
+    group = parser_submit.add_mutually_exclusive_group()
+    group.add_argument(
+        "-t", "--template", default="mpiexec -np {cores}", help="template command for running commands under MPI"
+    )
+    group.add_argument(
+        "-H",
+        "--HPC",
+        help="Detect HPC system and run using known template for batch job submission for that system",
+        action="store_true",
+    )
     parser_submit.add_argument("level", type=int)
     parser_submit.set_defaults(func=submit_subcommand)
 
     args = parser.parse_args()
+    if hasattr(args, "HPC") and args.HPC:
+        args.template, args.extra_format = get_hpc_template()
     args.func(args)


### PR DESCRIPTION
First pass at extending `parallel_tests` to run on multiple HPC systems. Its necessary to move template creation into python as its far too complex to do system detection in a makefile. I'm not convinced that its structured the best way, so any better ideas are very welcome. The location of this machinery in `scaling.py` is temporary as the analytical long tests will need this to, so ideally we'll end up making a `test_utils.py` somewhere that'll have this in it. Running `make` in `parallel_tests` works as expected on both Gadi and Setonix with this branch.