### PR TITLE
Adapt to Firedrake root containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Put task spooler on PATH
         run: |
-          mv tsp_build/tsp-hpc /home/firedrake/.local/bin/tsp
+          mv tsp_build/tsp-hpc /usr/local/bin/tsp
 
       - name: Install Python dependencies
         run: |
@@ -114,9 +114,6 @@ jobs:
           source create_library.sh
           cp *.so ../../tests/multi_material
         shell: bash
-
-      - name: Fix HOME environment variable
-        run: echo "HOME=/home/firedrake" >> "$GITHUB_ENV"
 
       - name: Run test
         id: run_tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,12 @@ jobs:
         env:
           S3CONFIG: ${{ secrets.S3CONFIG }}
         run: |
-          sudo apt update
-          sudo apt install -y time s3cmd unzip git-lfs gmsh gcc cmake libsqlite3-dev
+          apt update
+          apt install -y time s3cmd unzip git-lfs gmsh gcc cmake libsqlite3-dev
           mkdir -p $HOME/.s3cfg
           echo "${S3CONFIG}" > $HOME/.s3cfg/config
           chmod 600 $HOME/.s3cfg/config
+          git config --global safe.directory '*'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
The Firedrake container now runs as root by default, which makes git complain about safe directories. Set all directories as safe, remove the `$HOME` hack (because Firedrake was installed to `$HOME/.local`, now in `/opt`) and install tsp directly into `/usr/local`. Hopefully gets CI running again...