### PR TITLE
Modify tests to use tsp --timeout function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run test
         id: run_tests
         run: |
-          tsp --timeout
+          tsp --timeout -T 7200
           . .venv/bin/activate
           make -j test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           repository: dsroberts/tsp_for_hpc
           path: ./tsp
-          ref: v1.0.0
+          ref: v1.1.0
 
       - name: Build task spooler
         uses: threeal/cmake-action@v2
@@ -118,6 +118,7 @@ jobs:
       - name: Run test
         id: run_tests
         run: |
+          tsp --timeout
           . .venv/bin/activate
           make -j test
         env:

--- a/rules.mk
+++ b/rules.mk
@@ -65,17 +65,7 @@ run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 
 exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS) $(exec_args)
 
-# Execution wrapper
-# -----------------
 #
-# When running in batch mode, we want an additional wrap inside the
-# `timeout` utility to enforce a 2 hour time limit on any given task.
-# This ensures that CI jobs don't exceed the 6 hour time limit on
-# GitHub Actions so they can be torn down gracefully and provide
-# output information.
-
-exec_wrapper = $(if $(BATCH_MODE),timeout 2h $(exec_cmd),$(exec_cmd))
-
 # Canned recipe
 # -------------
 #
@@ -87,7 +77,7 @@ exec_wrapper = $(if $(BATCH_MODE),timeout 2h $(exec_cmd),$(exec_cmd))
 #   	$(run-python)
 
 define run-python =
-@$(call run_cmd,$(exec_wrapper),$(or $(desc),$<))
+@$(call run_cmd,$(exec_cmd),$(or $(desc),$<))
 endef
 
 # Test-related variables


### PR DESCRIPTION
Added 'timeout' functionality to `tsp`. Now we don't need to wrap the tests in the `timeout` command. It shouldn't do anything in this run. However, here are my results from an earlier test with the timeout set to 3 minutes.
<details><summary>Details</summary>

```

[dr4292@gadi-cpu-spr-0284 ~]$ TMPDIR=/jobfs/138322102.gadi-pbs/ tsp --list
ID  |      State | ExitStat |   Run Time |    Command
=====================================================
1       finished          0      1:37.418  python3 base_case.py
2       finished        143      3:06.660  python3 implicit_top_bottom_free_surface.py
3       finished          1      1:01.225  python3 gplates_global.py
4       finished          0      1:40.567  python3 compositional_buoyancy.py
5       finished        143      3:06.841  python3 free_surface.py
6       finished          0        54.849  python3 scalar_advection.py
7       finished          0      1:00.444  python3 PDE_constrained_field.py
8       finished          0      1:39.478  python3 helmholtz.py
9       finished        143      3:06.744  python3 2d_cylindrical.py
10      finished          0      1:26.210  python3 base_case.py
11      finished          0      2:16.626  python3 zhong_viscoelastic_free_surface.py --case viscous
12      finished        143      3:06.185  python3 thermochemical_buoyancy.py
13      finished          0        43.400  python3 zhong_viscoelastic_free_surface.py --case elastic
14      finished          0      1:36.427  python3 explicit_free_surface.py
15      finished        143      3:06.052  python3 implicit_free_surface.py
16      finished        143      3:05.782  python3 PDE_constrained_boundary.py
17      finished          0      2:24.655  python3 zhong_viscoelastic_free_surface.py --case viscoelastic
18      finished          1        23.242  mpiexec -np 8 python3 run_benchmark.py benchmarks.trim_2023
19      finished        143      3:04.505  mpiexec -np 4 python3 3d_spherical.py
20      finished        143      3:04.438  mpiexec -np 8 python3 run_benchmark.py benchmarks.schmeling_2008
21      finished        143      3:04.216  mpiexec -np 8 python3 run_benchmark.py benchmarks.van_keken_1997_isothermal
22      finished          0      2:57.228  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 16 8
23      finished          0      1:51.564  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 4 2
24      finished        143      3:09.879  mpiexec -np 16 python3 2d_cylindrical_TALA_DG.py
25      finished          0      1:03.278  mpiexec -np 8 python3 run_benchmark.py benchmarks.robey_2019
26      finished          0      1:51.802  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 4 8
27      finished          0      2:58.614  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 16 2
28      finished          0      1:13.355  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 8 2
29      finished          0      1:03.119  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip_dpc 8 8
30      finished        143      3:04.091  mpiexec -np 2 python3 adjoint_forward.py
31      finished          0        45.937  python3 spiegelman.py 0.0025_1e+23_64_16_50_False
32      finished          0        42.159  python3 spiegelman.py 0.0025_1e+23_64_16_15_False
33      finished          0        54.249  python3 spiegelman.py 0.005_1e+24_64_16_50_True
34      finished          0        54.537  python3 spiegelman.py 0.005_1e+24_64_16_5_False
35      finished          0      1:35.299  python3 spiegelman.py 0.005_1e+24_64_16_15_False
36      finished          0        53.876  python3 spiegelman.py 0.005_1e+24_64_16_15_True
37      finished          0        57.993  python3 spiegelman.py 0.005_1e+24_64_16_0_True
38      finished          0        52.025  python3 spiegelman.py 0.005_1e+24_64_16_25_True
39      finished          0        41.319  python3 spiegelman.py 0.0025_1e+23_64_16_25_True
40      finished          0        37.773  python3 spiegelman.py 0.0025_1e+23_64_16_0_True
41      finished          0        40.664  python3 spiegelman.py 0.0025_1e+23_64_16_15_True
42      finished          0        44.127  python3 spiegelman.py 0.0025_1e+23_64_16_25_False
43      finished        143      3:09.753  mpiexec -np 4 python3 2d_compressible_ALA.py -Stokes_pc_factor_mat_solver_type superlu_dist
44      finished          0        58.933  python3 spiegelman.py 0.005_1e+24_64_16_50_False
45      finished          0        51.823  python3 spiegelman.py 0.005_1e+24_64_16_0_False
46      finished          0        43.370  python3 spiegelman.py 0.0025_1e+23_64_16_50_True
47      finished          0        39.477  python3 spiegelman.py 0.0025_1e+23_64_16_5_True
48      finished          0        39.745  python3 spiegelman.py 0.0025_1e+23_64_16_0_False
49      finished          0        41.159  python3 spiegelman.py 0.0025_1e+23_64_16_5_False
50      finished        143      3:02.170  mpiexec -np 2 python3 ../../demos/mantle_convection/adjoint/adjoint_forward.py
51      finished        143      3:05.406  mpiexec -np 4 python3 viscoplastic_case_DG.py
52      finished          0        53.769  python3 spiegelman.py 0.005_1e+24_64_16_5_True
53      finished          0        52.730  python3 spiegelman.py 0.005_1e+24_64_16_25_False
54      finished        143      3:04.129  mpiexec -np 4 python3 2d_cylindrical.py
55      finished          0        58.496  mpiexec -np 8 python3 run_benchmark.py benchmarks.schmalholz_2011
56      finished          0      1:27.528  mpiexec -np 2 python3 helmholtz.py
57      finished          0        54.367  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 4 2 4
58      finished          0      1:12.854  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 8 2 4
59      finished          0        55.703  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 4 2 1
60      finished          0      1:03.991  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 8 8 4
61      finished          0        57.846  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 8 8 1
62      finished          0      1:08.420  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 8 2 1
63      finished          0      1:08.222  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 4 2 1
64      finished          0      1:05.684  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 4 2 4
65      finished          0        57.865  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 4 8 1
66      finished          0        46.660  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 4 8 4
67      finished          0      1:34.388  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 8 2 4
68      finished        143      3:06.395  mpiexec -np 8 python3 run_benchmark.py benchmarks.tosi_2015
69      finished        143      3:01.475  mpiexec -np 8 python3 implicit_cylindrical_free_surface.py
70      finished          1      3:03.195  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 16 2
71      finished          0      1:34.008  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 8 2 1
72      finished          0        33.302  python3 scalar_advection_diffusion_DH27.py 50.0_True
73      finished          0        32.598  python3 scalar_advection_diffusion_DH27.py 0.25_True
74      finished          0        48.184  python3 scalar_advection_diffusion_DH27.py 0.9_True
75      finished          0      1:09.293  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 8 2
76      finished          0      1:01.314  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 8 2
77      finished          0        47.355  python3 scalar_advection_diffusion_DH27.py 0.25_False
78      finished        143      3:09.962  mpiexec -np 4 python3 3d_cartesian.py
79      finished        143      3:06.372  mpiexec -np 4 python3 2d_compressible_TALA.py -Stokes_pc_factor_mat_solver_type superlu_dist
80      finished          1      3:07.803  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 2 1
81      finished          0        38.996  python3 scalar_advection_diffusion_DH27.py 0.9_False
82      finished        143      3:06.896  mpiexec -np 8 python3 implicit_top_bottom_buoyancy_free_surface.py
83      finished          0        30.243  python3 scalar_advection_diffusion.py
84      finished          0      1:01.282  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 4 2
85      finished          0      1:02.771  python3 scalar_advection_diffusion_DH27.py 50.0_False
86      finished          0      1:50.857  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 16 2
87      finished          0      1:35.501  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 8 2
88      finished          0      1:37.557  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 8 8
89      finished          0      1:30.777  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 8 8 4
90      finished          0        47.729  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 4 2
91      finished          0      1:11.991  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 8 8
92      finished        143      3:10.002  mpiexec -np 4 python3 viscoplastic_case.py
93      finished          0        54.419  mpiexec -np 8 python3 run_benchmark.py benchmarks.gerya_2003
94      finished          0      1:05.385  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 4 8 4
95      finished          1      3:06.142  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 16 8
96      finished          0      2:20.686  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 16 8 4
97      finished          0        58.469  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 4 8
98      finished          0      2:04.877  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 16 8
99      finished          0      1:05.918  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 4 8 1
100     finished          0        22.096  python3 scalar_advection_diffusion_DH219_skew.py
101     finished        143      3:04.884  mpiexec -np 8 python3 run_benchmark.py benchmarks.van_keken_1997_thermochemical
102     finished          1      3:09.830  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 8 4
103     finished          0      2:28.586  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 16 2 1
104     finished          0      1:06.621  mpiexec -np 8 python3 run_benchmark.py benchmarks.crameri_2012
105     finished          0      1:38.142  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 8 8 1
106     finished          0      2:26.875  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 16 2
107     finished          0        53.413  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 4 8
108     finished          0      2:10.096  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 16 8
109     finished          1      3:03.279  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 8 1
110     finished          0      1:08.647  mpiexec -np 16 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip_dpc 8 8
111     finished          1      3:09.555  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 2 4
112     finished          0      2:15.948  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 16 8 1
113     finished          0      1:04.745  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 4 2
114     finished          0      1:53.371  python3 base_case.py
115     finished          0        49.296  mpiexec -np 4 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_freeslip 4 8
116     finished          0      2:30.843  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_freeslip 16 2 4
117     finished          1         9.426  python3 adjoint.py
118     finished          0      1:09.256  mpiexec -np 2 python3 taylor_test.py smoothing
119     finished          0      1:40.413  mpiexec -np 2 python3 taylor_test.py Tobs
120     finished          0      1:17.795  mpiexec -np 2 python3 taylor_test.py uobs
121     finished          0      1:09.238  mpiexec -np 2 python3 taylor_test.py damping

```

</details>
 
And here is the `tsp --list-failed` output.

<details><summary>Details</summary>

```
ID  |      State | ExitStat |   Run Time |    Command
=====================================================
2       finished        143      3:06.660  python3 implicit_top_bottom_free_surface.py
3       finished          1      1:01.225  python3 gplates_global.py
5       finished        143      3:06.841  python3 free_surface.py
9       finished        143      3:06.744  python3 2d_cylindrical.py
12      finished        143      3:06.185  python3 thermochemical_buoyancy.py
15      finished        143      3:06.052  python3 implicit_free_surface.py
16      finished        143      3:05.782  python3 PDE_constrained_boundary.py
18      finished          1        23.242  mpiexec -np 8 python3 run_benchmark.py benchmarks.trim_2023
19      finished        143      3:04.505  mpiexec -np 4 python3 3d_spherical.py
20      finished        143      3:04.438  mpiexec -np 8 python3 run_benchmark.py benchmarks.schmeling_2008
21      finished        143      3:04.216  mpiexec -np 8 python3 run_benchmark.py benchmarks.van_keken_1997_isothermal
24      finished        143      3:09.879  mpiexec -np 16 python3 2d_cylindrical_TALA_DG.py
30      finished        143      3:04.091  mpiexec -np 2 python3 adjoint_forward.py
43      finished        143      3:09.753  mpiexec -np 4 python3 2d_compressible_ALA.py -Stokes_pc_factor_mat_solver_type superlu_dist
50      finished        143      3:02.170  mpiexec -np 2 python3 ../../demos/mantle_convection/adjoint/adjoint_forward.py
51      finished        143      3:05.406  mpiexec -np 4 python3 viscoplastic_case_DG.py
54      finished        143      3:04.129  mpiexec -np 4 python3 2d_cylindrical.py
68      finished        143      3:06.395  mpiexec -np 8 python3 run_benchmark.py benchmarks.tosi_2015
69      finished        143      3:01.475  mpiexec -np 8 python3 implicit_cylindrical_free_surface.py
70      finished          1      3:03.195  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 16 2
78      finished        143      3:09.962  mpiexec -np 4 python3 3d_cartesian.py
79      finished        143      3:06.372  mpiexec -np 4 python3 2d_compressible_TALA.py -Stokes_pc_factor_mat_solver_type superlu_dist
80      finished          1      3:07.803  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 2 1
82      finished        143      3:06.896  mpiexec -np 8 python3 implicit_top_bottom_buoyancy_free_surface.py
92      finished        143      3:10.002  mpiexec -np 4 python3 viscoplastic_case.py
95      finished          1      3:06.142  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run delta_cylindrical_zeroslip 16 8
101     finished        143      3:04.884  mpiexec -np 8 python3 run_benchmark.py benchmarks.van_keken_1997_thermochemical
102     finished          1      3:09.830  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 8 4
109     finished          1      3:03.279  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 8 1
111     finished          1      3:09.555  mpiexec -np 24 /g/data/fp50/apps/firedrake/20250326/venv/bin/python3 analytical.py run smooth_cylindrical_zeroslip 16 2 4
117     finished          1         9.426  python3 adjoint.py

```
</details>

The timeout works by polling, so jobs may run up to 1 polling interval (default is 10 seconds) longer than the designated timeout (2 hours by default). Timed out jobs are fairly obvious. The exit status may not be entirely consistent due to whatever the program decides to do with a SIGTERM, but a job that has been timed out will never succeed. Convention for exit status follows PBS where a status over 128 indicated that the controlling program (i.e. `tsp`) was signalled. When in timeout mode, `tsp` will exit if it detects no running jobs for some amount of time (default is 30 seconds).