### PR TITLE
Remove unnecessary global scope from test_spiegelman

### DIFF
--- a/tests/Drucker-Prager_rheology/test_spiegelman.py
+++ b/tests/Drucker-Prager_rheology/test_spiegelman.py
@@ -30,8 +30,6 @@ def residual(ui, mui, nx, ny, picard_iterations, stabilisation):
 
 
 def test_spiegelman_1e23():
-    global conf
-
     test_conf = conf.copy()
     ui, mui = test_conf.pop("ui-mui")[0]
     del test_conf["picard"][0]  # drop picard-only
@@ -51,8 +49,6 @@ def test_spiegelman_1e23():
 
 
 def test_spiegelman_1e24():
-    global conf
-
     test_conf = conf.copy()
     ui, mui = test_conf.pop("ui-mui")[1]
     del test_conf["picard"][0]  # drop picard-only


### PR DESCRIPTION
The conf dictionary is always copied before modification, so it doesn't need to be global in the test scope. Will fix our newly developed lint failure.