### PR TITLE
Update free surface setup in `StokesSolver` using new `set_equations` and `set_form` methods

### DIFF
--- a/demos/mantle_convection/free_surface/free_surface.py
+++ b/demos/mantle_convection/free_surface/free_surface.py
@@ -128,7 +128,7 @@ Bfs = 10.0  # Free surface buoyancy number
 
 stokes_bcs = {
     boundary.bottom: {"uy": 0},
-    boundary.top: {"free_surface": {"eta_index": 2, "RaFS": Ra * Bfs}},
+    boundary.top: {"free_surface": {"RaFS": Ra * Bfs}},
     boundary.left: {"ux": 0},
     boundary.right: {"ux": 0},
 }

--- a/demos/mantle_convection/free_surface/free_surface.py
+++ b/demos/mantle_convection/free_surface/free_surface.py
@@ -124,11 +124,11 @@ T.interpolate((1.0 - X[1]) + (0.05 * cos(pi * X[0]) * sin(pi * X[1])))
 # Typically, when the exterior density is negligbile compared with the interior density (i.e. air vs rock!) and with $\alpha$ = 3x10$^{-5}$ K$^{-1}$ and $\Delta T$ = 3000 K, $B_{fs}$ is about 10. For dimensional simulations you can specify the density contrast across the free surface with *delta_rho_fs* through the free surface dictionary, as well as providing $\rho_0$ and $g$ through the approximation object in the usual way.
 
 # +
-Bfs = 10.  # Free surface buoyancy number
+Bfs = 10.0  # Free surface buoyancy number
 
 stokes_bcs = {
     boundary.bottom: {"uy": 0},
-    boundary.top: {"free_surface": {"RaFS": Ra*Bfs}},
+    boundary.top: {"free_surface": {"eta_index": 2, "RaFS": Ra * Bfs}},
     boundary.left: {"ux": 0},
     boundary.right: {"ux": 0},
 }
@@ -171,7 +171,7 @@ energy_solver = EnergySolver(
 )
 
 stokes_solver = StokesSolver(
-    z, T, approximation, bcs=stokes_bcs, constant_jacobian=False, free_surface_dt=delta_t
+    z, T, approximation, bcs=stokes_bcs, constant_jacobian=False, coupled_tstep=delta_t
 )
 
 # -

--- a/gadopt/approximations.py
+++ b/gadopt/approximations.py
@@ -241,13 +241,13 @@ class BoussinesqApproximation(BaseApproximation):
         return self.rho * self.H
 
     def free_surface_terms(
-        self, p, T, eta, theta_fs, *, variable_rho_fs=True, RaFS=1, delta_rho_fs=1
+        self, p, T, eta, *, variable_rho_fs=True, RaFS=1, delta_rho_fs=1
     ):
         free_surface_normal_stress = RaFS * delta_rho_fs * self.g * eta
         if variable_rho_fs:
             free_surface_normal_stress -= self.buoyancy(p, T) * eta
 
-        prefactor = -theta_fs * RaFS * delta_rho_fs * self.g
+        prefactor = RaFS * delta_rho_fs * self.g
 
         return free_surface_normal_stress, prefactor
 
@@ -472,7 +472,7 @@ class SmallDisplacementViscoelasticApproximation():
         # accounts for advection of density in the absence of an evolution equation for temperature
         return -self.g * -inner(displacement, grad(self.density))
 
-    def free_surface_terms(self, p, T, eta, theta_fs, *, delta_rho_fs=1):
+    def free_surface_terms(self, p, T, eta, *, delta_rho_fs=1):
         free_surface_normal_stress = delta_rho_fs * self.g * eta
         # prefactor only needed when solving eta as part of mixed system
         return free_surface_normal_stress, None

--- a/gadopt/equations.py
+++ b/gadopt/equations.py
@@ -45,7 +45,7 @@ class Equation:
         quad_degree:
           Integer specifying the quadrature degree. If omitted, it is set to `2p + 1`,
           where p is the polynomial degree of the trial space.
-        rescale_factor:
+        scaling_factor:
           A constant factor used to rescale mass and residual terms.
 
     """
@@ -59,7 +59,7 @@ class Equation:
     approximation: BaseApproximation | None = None
     bcs: dict[int, dict[str, Any]] = field(default_factory=dict)
     quad_degree: InitVar[int | None] = None
-    rescale_factor: Number | fd.Constant = 1
+    scaling_factor: Number | fd.Constant = 1
 
     def __post_init__(
         self,
@@ -117,14 +117,14 @@ class Equation:
     ) -> fd.Form:
         """Generates the UFL form corresponding to the mass term."""
 
-        return self.rescale_factor * self.mass_term(self, trial)
+        return self.scaling_factor * self.mass_term(self, trial)
 
     def residual(
         self, trial: fd.Argument | fd.ufl.indexed.Indexed | fd.Function
     ) -> fd.Form:
         """Generates the UFL form corresponding to the residual terms."""
 
-        return self.rescale_factor * sum(
+        return self.scaling_factor * sum(
             term(self, trial) for term in self.residual_terms
         )
 

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -8,21 +8,37 @@ from .utility import InteriorBC
 
 
 class FreeSurfaceMassInvPC(fd.MassInvPC):
+    """Version of MassInvPC that includes free surface variables."""
 
-    """Version of MassInvPC that includes free surface variables.
+    def form(
+        self,
+        pc: fd.PETSc.PC,
+        tests: list[fd.Argument | fd.ufl.indexed.Indexed],
+        trials: list[fd.Argument | fd.ufl.indexed.Indexed | fd.Function],
+    ) -> tuple[fd.Form, list[fd.DirichletBC]]:
+        """Sets the form.
 
-    """
-    def form(self, pc, test, trial):
+        Args:
+          pc:
+            PETSc preconditioner
+          tests:
+            List of Firedrake test functions
+          trials:
+            List of Firedrake trial functions
+        """
         appctx = self.get_appctx(pc)
+
+        # N.B. trials[0] is pressure
         mu = appctx.get("mu", 1.0)
-        a = fd.inner(1/mu * trial[0], test[0])*fd.dx
+        a = fd.inner(1 / mu * trials[0], tests[0]) * fd.dx
+
+        ds = appctx["ds"]
         bcs = []
-        ds = appctx['ds']
-        c = 0  # Counter for free surfaces, N.b the first trial[0] is pressure
-        for id in appctx["free_surface_id_list"]:
-            a += fd.inner(1/mu * trial[1+c], test[1+c])*ds(id)
-            bcs.append(InteriorBC(trial.function_space().sub(1+c), 0, id))
-            c += 1
+        for bc_id, eta_ind in appctx["free_surface"].items():
+            a += 1 / mu * fd.inner(trials[eta_ind - 1], tests[eta_ind - 1]) * ds(bc_id)
+
+            bcs.append(InteriorBC(trials.function_space()[eta_ind - 1], 0, bc_id))
+
         return a, bcs
 
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -373,7 +373,6 @@ class StokesSolver:
                 self.solution_split[1],
                 self.T,
                 self.solution_theta_split[eta_ind],
-                self.theta,
                 **params_fs,
             )
         )
@@ -626,7 +625,6 @@ class ViscoelasticStokesSolver(StokesSolver):
             p,
             self.T,
             vertical_component(u + self.displacement),
-            self.theta,
             **params_fs,
         )
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -5,6 +5,7 @@ instantiate the `StokesSolver` class by providing relevant parameters and call t
 
 """
 
+from collections import defaultdict
 from numbers import Number
 from typing import Optional
 
@@ -15,7 +16,15 @@ from .equations import Equation
 from .free_surface_equation import free_surface_term
 from .free_surface_equation import mass_term as mass_term_fs
 from .momentum_equation import residual_terms_stokes
-from .utility import DEBUG, INFO, InteriorBC, depends_on, log_level, upward_normal
+from .utility import (
+    DEBUG,
+    INFO,
+    InteriorBC,
+    depends_on,
+    log_level,
+    upward_normal,
+    vertical_component,
+)
 
 iterative_stokes_solver_parameters = {
     "mat_type": "matfree",
@@ -191,7 +200,7 @@ class StokesSolver:
     """Solves the Stokes system in place.
 
     Arguments:
-      z: Firedrake function representing mixed Stokes system
+      solution: Firedrake function representing mixed Stokes system
       T: Firedrake function representing temperature
       approximation: Approximation describing system of equations
       bcs: Dictionary of identifier-value pairs specifying boundary conditions
@@ -201,10 +210,10 @@ class StokesSolver:
                          specifying a default set of parameters defined in G-ADOPT
       J: Firedrake function representing the Jacobian of the system
       constant_jacobian: Whether the Jacobian of the system is constant
-      free_surface_dt: Timestep for advancing free surface equation
-      free_surface_theta: Timestepping prefactor for free surface equation, where
-                          theta = 0: Forward Euler, theta = 0.5: Crank-Nicolson (default),
-                          or theta = 1: Backward Euler
+      coupled_tstep: Timestep for advancing free surface equation
+      theta: Timestepping prefactor for free surface equation, where
+             theta = 0: Forward Euler, theta = 0.5: Crank-Nicolson (default),
+             or theta = 1: Backward Euler
 
     """
 
@@ -212,7 +221,7 @@ class StokesSolver:
 
     def __init__(
         self,
-        z: fd.Function,
+        solution: fd.Function,
         T: fd.Function,
         approximation: BaseApproximation,
         bcs: dict[int, dict[str, Number]] = {},
@@ -220,17 +229,27 @@ class StokesSolver:
         solver_parameters: Optional[dict[str, str | Number] | str] = None,
         J: Optional[fd.Function] = None,
         constant_jacobian: bool = False,
-        free_surface_dt: Optional[float] = None,
-        free_surface_theta: float = 0.5,
+        coupled_tstep: Optional[float] = None,
+        theta: float = 0.5,
         **kwargs,
     ):
-        self.Z = z.function_space()
-        self.mesh = self.Z.mesh()
-        self.test = fd.TestFunctions(self.Z)
-        self.solution = z
+        self.solution_space = solution.function_space()
+        self.mesh = self.solution_space.mesh()
+        self.tests = fd.TestFunctions(self.solution_space)
+        self.solution = solution
         self.T = T
         self.approximation = approximation
         self.quad_degree = quad_degree
+        self.coupled_tstep = coupled_tstep
+        self.theta = theta
+
+        self.solution_old = solution.copy(deepcopy=True)
+        self.solution_split = fd.split(solution)
+        self.solution_old_split = fd.split(self.solution_old)
+        self.solution_theta_split = [
+            theta * sol + (1 - theta) * sol_old
+            for sol, sol_old in zip(self.solution_split, self.solution_old_split)
+        ]
 
         self.J = J
         self.constant_jacobian = constant_jacobian
@@ -245,68 +264,46 @@ class StokesSolver:
         self.strong_bcs = []
 
         # Free surface parameters
-        self.free_surface_dict = {}
-        self.free_surface_dt = free_surface_dt
-        self.free_surface_theta = free_surface_theta  # theta = 0.5 gives a second order accurate integration scheme in time
-        self.free_surface = False
+        self.free_surface_map = {}
+        self.buoyancy_fs = [None] * len(self.solution_split)
 
-        for id, bc in bcs.items():
-            weak_bc = {}
+        for bc_id, bc in bcs.items():
+            weak_bc = defaultdict(float)
             for bc_type, value in bc.items():
                 if bc_type == 'u':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0), value, id))
+                    self.strong_bcs.append(
+                        fd.DirichletBC(self.solution_space.sub(0), value, bc_id)
+                    )
                 elif bc_type == 'ux':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(0), value, id))
+                    self.strong_bcs.append(
+                        fd.DirichletBC(self.solution_space.sub(0).sub(0), value, bc_id)
+                    )
                 elif bc_type == 'uy':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(1), value, id))
+                    self.strong_bcs.append(
+                        fd.DirichletBC(self.solution_space.sub(0).sub(1), value, bc_id)
+                    )
                 elif bc_type == 'uz':
-                    self.strong_bcs.append(fd.DirichletBC(self.Z.sub(0).sub(2), value, id))
+                    self.strong_bcs.append(
+                        fd.DirichletBC(self.solution_space.sub(0).sub(2), value, bc_id)
+                    )
                 elif bc_type == 'free_surface':
-                    # N.b. stokes_integrators assumes that the order of the bcs matches the order of the
-                    # free surfaces defined in the mixed space. This is not ideal - python dictionaries
-                    # are ordered by insertion only since recently (since 3.7) - so relying on their order
-                    # is fraught and not considered pythonic. At the moment let's consider having more
-                    # than one free surface a bit of a niche case for now, and leave it as is...
-
-                    # Copy free surface information to a new dictionary
-                    self.free_surface_dict[id] = value
-                    self.free_surface = True
+                    weak_bc["normal_stress"] += self.set_free_surface_boundary(
+                        value, bc_id
+                    )
                 else:
-                    weak_bc[bc_type] = value
-            self.weak_bcs[id] = weak_bc
+                    weak_bc[bc_type] += value
+            self.weak_bcs[bc_id] = weak_bc
 
         # eta is a list of 0, 1 or multiple free surface fields
         self.u, self.p, *self.eta = fd.split(self.solution)
 
         self.rho_mass = self.approximation.rho_continuity()
-        self.setup_equation_attributes()
 
         self.equations = []
-        for i, (terms_eq, eq_attrs) in enumerate(zip(residual_terms_stokes, self.eqs_attrs)):
-            self.equations.append(
-                Equation(
-                    self.test[i],
-                    self.Z[i],
-                    terms_eq,
-                    eq_attrs=eq_attrs,
-                    approximation=self.approximation,
-                    bcs=self.weak_bcs,
-                    quad_degree=quad_degree,
-                )
-            )
+        self.F = 0.0  # Weak form of the system
 
-        if self.free_surface:
-            self.setup_free_surface()
-
-        self.F = 0
-        for eq, trial in zip(self.equations, fd.split(self.solution)):
-            self.F -= eq.residual(trial)
-
-        if self.free_surface:
-            for i in range(len(self.eta)):
-                # Add free surface time derivative term
-                # (N.b. we already have two equations from StokesEquations)
-                self.F += self.equations[2+i].mass((self.eta[i]-self.eta_old[i])/self.free_surface_dt)
+        self.set_equations()
+        self.set_form()
 
         if isinstance(solver_parameters, dict):
             self.solver_parameters = solver_parameters
@@ -344,103 +341,107 @@ class StokesSolver:
                 elif INFO >= log_level:
                     self.solver_parameters['fieldsplit_1']['ksp_converged_reason'] = None
 
-                if self.free_surface:
-                    # merge free surface fields with pressure field for Schur complement solve
-                    self.solver_parameters.update({"pc_fieldsplit_0_fields": '0',
-                                                   "pc_fieldsplit_1_fields": '1,'+','.join(str(2+i) for i in range(len(self.eta)))})
-
-                    # update keys for GADOPT's free surface mass inverse preconditioner
-                    self.solver_parameters["fieldsplit_1"].update({"pc_python_type": "gadopt.FreeSurfaceMassInvPC"})
+                if self.free_surface_map:
+                    # Gather pressure and free surface fields for Schur complement solve
+                    fields_ind = ",".join(map(str, range(1, len(self.solution_split))))
+                    self.solver_parameters.update(
+                        {
+                            "pc_fieldsplit_0_fields": "0",
+                            "pc_fieldsplit_1_fields": fields_ind,
+                        }
+                    )
+                    # Update mass inverse preconditioner
+                    self.solver_parameters["fieldsplit_1"].update(
+                        {"pc_python_type": "gadopt.FreeSurfaceMassInvPC"}
+                    )
 
         # solver object is set up later to permit editing default solver parameters specified above
         self._solver_setup = False
 
-    def setup_equation_attributes(self):
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> fd.ufl.algebra.Product | fd.ufl.algebra.Sum:
+        # Extract the free-surface index and associate it with the boundary id
+        eta_ind = params_fs.pop("eta_index")
+        self.free_surface_map[bc_id] = eta_ind
+
+        # Set internal degrees of freedom to zero to prevent singular matrix
+        self.strong_bcs.append(InteriorBC(self.solution_space[eta_ind], 0, bc_id))
+
+        normal_stress, self.buoyancy_fs[eta_ind] = (
+            self.approximation.free_surface_terms(
+                self.solution_split[1],
+                self.T,
+                self.solution_theta_split[eta_ind],
+                self.theta,
+                **params_fs,
+            )
+        )
+
+        return normal_stress
+
+    def set_equations(self) -> None:
+        u, p = self.solution_split[:2]
         stress = self.approximation.stress(self.u)
         source = self.approximation.buoyancy(self.p, self.T) * self.k
-        self.eqs_attrs = [{"p": self.p, "stress": stress, "source": source}, {"u": self.u, "rho_mass": self.rho_mass}]
+        eqs_attrs = [
+            {"p": p, "stress": stress, "source": source},
+            {"u": u, "rho_mass": self.approximation.rho_continuity()},
+        ]
 
-    def setup_free_surface(self):
-        if self.free_surface_dt is None:
-            raise TypeError(
-                "Please provide a timestep to advance the free surface, currently free_surface_dt=None."
-            )
-
-        u_, p_, *self.eta_ = self.solution.subfunctions
-        self.eta_old = []
-        self.eta_theta = []
-        self.free_surface_id_list = []
-
-        c = 0  # Counter for free surfaces (N.b. we already have two equations from StokesEquations)
-        for free_surface_id, free_surface_params in self.free_surface_dict.items():
-            # Define free surface variables for timestepping
-            self.eta_old.append(fd.Function(self.eta_[c]))
-            self.eta_theta.append(
-                (1 - self.free_surface_theta) * self.eta_old[c]
-                + self.free_surface_theta * self.eta[c]
-            )
-
-            # Normal stress #
-            # Depending on variable_free_surface_density flag provided to approximation the
-            # interior density below the free surface is either set to a constant density or
-            # varies spatially according to the buoyancy field
-            # N.b. constant reference density is needed for analytical cylindrical cases
-            # Prefactor #
-            # To ensure the top right and bottom left corners of the block matrix remains symmetric we need to
-            # multiply the free surface equation (kinematic bc) with -theta * delta_rho * g. This is similar
-            # to rescaling eta -> eta_tilde in Kramer et al. 2012 (e.g. see block matrix shown in Eq 23)
-            # N.b. in the case where the density contrast across the free surface is spatially variant due to
-            # interior buoyancy changes then the matrix will not be exactly symmetric.
-            normal_stress, prefactor = self.approximation.free_surface_terms(
-                self.p, self.T, self.eta_theta[c], self.free_surface_theta, **free_surface_params
-            )
-
-            # Add free surface stress term
-            if 'normal_stress' in self.weak_bcs[free_surface_id]:
-                # Usually there will be also an ice/water loadi acting as a normal stress in the GIA problem
-                existing_value = self.weak_bcs[free_surface_id]['normal_stress']
-                self.weak_bcs[free_surface_id]['normal_stress'] = existing_value + normal_stress
-            else:
-                self.weak_bcs[free_surface_id] = {'normal_stress': normal_stress}
-
-            eq_attrs = {
-                "boundary_id": free_surface_id,
-                "buoyancy_scale": prefactor,
-                "u": self.u,
-            }
-
-            # Add the free surface equation
+        for i in range(len(residual_terms_stokes)):
             self.equations.append(
                 Equation(
-                    self.test[2 + c],
-                    self.Z[2 + c],
-                    free_surface_term,
-                    mass_term=mass_term_fs,
-                    eq_attrs=eq_attrs,
+                    self.tests[i],
+                    self.solution_space[i],
+                    residual_terms_stokes[i],
+                    eq_attrs=eqs_attrs[i],
+                    approximation=self.approximation,
+                    bcs=self.weak_bcs,
                     quad_degree=self.quad_degree,
                 )
             )
 
-            # Set internal dofs to zero to prevent singular matrix for free surface equation
-            self.strong_bcs.append(
-                InteriorBC(self.Z.sub(2 + c), 0, free_surface_id)
+        for bc_id, eta_ind in self.free_surface_map.items():
+            eq_attrs = {
+                "boundary_id": bc_id,
+                "buoyancy_scale": self.buoyancy_fs[eta_ind],
+                "u": u,
+            }
+
+            self.equations.append(
+                Equation(
+                    self.tests[eta_ind],
+                    self.solution_space[eta_ind],
+                    free_surface_term,
+                    mass_term=mass_term_fs,
+                    eq_attrs=eq_attrs,
+                    quad_degree=self.quad_degree,
+                    scaling_factor=-self.theta,
+                )
             )
 
-            self.free_surface_id_list.append(free_surface_id)
-
-            c += 1
+    def set_form(self) -> None:
+        """Sets the weak form including linear and bilinear terms."""
+        for equation, solution, solution_old in zip(
+            self.equations, self.solution_split, self.solution_old_split
+        ):
+            if equation.mass_term:
+                assert equation.scaling_factor == -self.theta
+                self.F += equation.mass((solution - solution_old) / self.coupled_tstep)
+            self.F -= equation.residual(solution)
 
     def setup_solver(self):
         """Sets up the solver."""
         # mu used in MassInvPC:
         appctx = {"mu": self.approximation.mu / self.approximation.rho_continuity()}
 
-        if self.free_surface:
-            appctx["free_surface_id_list"] = self.free_surface_id_list
-            appctx["ds"] = self.equations[2].ds
+        if self.free_surface_map:
+            appctx["free_surface"] = self.free_surface_map
+            appctx["ds"] = self.equations[-1].ds
 
         if self.constant_jacobian:
-            z_tri = fd.TrialFunction(self.Z)
+            z_tri = fd.TrialFunction(self.solution_space)
             F_stokes_lin = fd.replace(self.F, {self.solution: z_tri})
             a, L = fd.lhs(F_stokes_lin), fd.rhs(F_stokes_lin)
             self.problem = fd.LinearVariationalProblem(
@@ -472,12 +473,9 @@ class StokesSolver:
         if not self._solver_setup:
             self.setup_solver()
 
-        # Need to update old free surface height for implicit free surface
-        if self.free_surface:
-            for i in range(len(self.eta_)):
-                self.eta_old[i].assign(self.eta_[i])
-
         self.solver.solve()
+
+        self.solution_old.assign(self.solution)
 
 
 def ala_right_nullspace(
@@ -600,40 +598,62 @@ class ViscoelasticStokesSolver(StokesSolver):
         # This isn't used in the viscoelastic code but StokesSolver currently assumes temperature is required as an argument
         T_placeholder = fd.Constant(0)
 
-        super().__init__(z, T_placeholder, approximation, bcs=bcs,
-                         quad_degree=quad_degree, solver_parameters=solver_parameters,
-                         J=J, constant_jacobian=constant_jacobian, free_surface_dt=self.dt,
-                         **kwargs)
+        super().__init__(
+            z,
+            T_placeholder,
+            approximation,
+            bcs=bcs,
+            quad_degree=quad_degree,
+            solver_parameters=solver_parameters,
+            J=J,
+            constant_jacobian=constant_jacobian,
+            coupled_tstep=self.dt,
+            **kwargs,
+        )
 
         scale_mu = fd.Constant(1e10)  # this is a scaling factor roughly size of mantle maxwell time to make sure that solve converges with strong bcs in parallel...
         self.F = (1 / scale_mu)*self.F
 
-    def setup_equation_attributes(self):
-        stress = self.approximation.stress(self.u, self.stress_old, self.dt)
+    def set_free_surface_boundary(
+        self, params_fs: dict[str, int | bool], bc_id: int
+    ) -> fd.ufl.algebra.Product | fd.ufl.algebra.Sum:
+        # First, make the displacement term implicit by incorporating the unknown
+        # `incremental displacement' (u) that we are solving for. Then, calculate the
+        # free surface stress term. This is also referred to as the Hydrostatic
+        # Prestress advection term in the GIA literature.
+        u, p = self.solution_split[:2]
+        normal_stress, _ = self.approximation.free_surface_terms(
+            p,
+            self.T,
+            vertical_component(u + self.displacement),
+            self.theta,
+            **params_fs,
+        )
+
+        return normal_stress
+
+    def set_equations(self) -> None:
+        """Sets up UFL forms for the viscoelastic Stokes equations residual."""
+        u, p = self.solution_split
+        stress = self.approximation.stress(u, self.stress_old, self.dt)
         source = self.approximation.buoyancy(self.displacement) * self.k
-        self.eqs_attrs = [{"p": self.p, "stress": stress, "source": source}, {"u": self.u, "rho_mass": self.rho_mass}]
+        eqs_attrs = [
+            {"p": p, "stress": stress, "source": source},
+            {"u": u, "rho_mass": self.rho_mass},
+        ]
 
-    def setup_free_surface(self):
-        # Overload method
-        for free_surface_id, free_surface_params in self.free_surface_dict.items():
-            # First, make the displacement term implicit by incorporating
-            # the unknown `incremental displacement' (u) that
-            # we are solving for
-            implicit_displacement = self.u + self.displacement
-            implicit_displacement_up = fd.dot(implicit_displacement, self.k)
-            # Add free surface stress term. This is also referred to as the Hydrostatic Prestress advection term in the GIA literature.
-            normal_stress, _ = self.approximation.free_surface_terms(
-                self.p, self.T, implicit_displacement_up, self.free_surface_theta, **free_surface_params
+        for i in range(len(residual_terms_stokes)):
+            self.equations.append(
+                Equation(
+                    self.tests[i],
+                    self.solution_space[i],
+                    residual_terms_stokes[i],
+                    eq_attrs=eqs_attrs[i],
+                    approximation=self.approximation,
+                    bcs=self.weak_bcs,
+                    quad_degree=self.quad_degree,
+                )
             )
-            if 'normal_stress' in self.weak_bcs[free_surface_id]:
-                # Usually there will be also an ice/water loadi acting as a normal stress in the GIA problem
-                existing_value = self.weak_bcs[free_surface_id]['normal_stress']
-                self.weak_bcs[free_surface_id]['normal_stress'] = existing_value + normal_stress
-            else:
-                self.weak_bcs[free_surface_id] = {'normal_stress': normal_stress}
-
-        # Turn off free surface flag because the viscoelastic free surface (for the small displacement approximation) is now setup
-        self.free_surface = False
 
     def solve(self):
         super().solve()

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -488,64 +488,64 @@ class StokesSolver:
 
 
 def ala_right_nullspace(
-    W: fd.functionspaceimpl.WithGeometry,
-    approximation: AnelasticLiquidApproximation,
+        W: fd.functionspaceimpl.WithGeometry,
+        approximation: AnelasticLiquidApproximation,
         top_subdomain_id: str | int):
     r"""Compute pressure nullspace for Anelastic Liquid Approximation.
 
-    Arguments:
-      W: pressure function space
-      approximation: AnelasticLiquidApproximation with equation parameters
-      top_subdomain_id: boundary id of top surface
+        Arguments:
+          W: pressure function space
+          approximation: AnelasticLiquidApproximation with equation parameters
+          top_subdomain_id: boundary id of top surface
 
-    Returns:
-      pressure nullspace solution
+        Returns:
+          pressure nullspace solution
 
-    To obtain the pressure nullspace solution for the Stokes equation in Anelastic Liquid Approximation,
-    which includes a pressure-dependent buoyancy term, we try to solve the equation:
+        To obtain the pressure nullspace solution for the Stokes equation in Anelastic Liquid Approximation,
+        which includes a pressure-dependent buoyancy term, we try to solve the equation:
 
-    $$
-      -nabla p + g "Di" rho chi c_p/(c_v gamma) hatk p = 0
-    $$
+        $$
+          -nabla p + g "Di" rho chi c_p/(c_v gamma) hatk p = 0
+        $$
 
-    Taking the divergence:
+        Taking the divergence:
 
-    $$
-      -nabla * nabla p + nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) = 0,
-    $$
+        $$
+          -nabla * nabla p + nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) = 0,
+        $$
 
-    then testing it with q:
+        then testing it with q:
 
-    $$
-        int_Omega -q nabla * nabla p dx + int_Omega q nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) dx = 0
-    $$
+        $$
+            int_Omega -q nabla * nabla p dx + int_Omega q nabla * (g "Di" rho chi c_p/(c_v gamma) hatk p) dx = 0
+        $$
 
-    followed by integration by parts:
+        followed by integration by parts:
 
-    $$
-        int_Gamma -bb n * q nabla p ds + int_Omega nabla q cdot nabla p dx +
-        int_Gamma bb n * hatk q g "Di" rho chi c_p/(c_v gamma) p dx -
-        int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0
-    $$
+        $$
+            int_Gamma -bb n * q nabla p ds + int_Omega nabla q cdot nabla p dx +
+            int_Gamma bb n * hatk q g "Di" rho chi c_p/(c_v gamma) p dx -
+            int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0
+        $$
 
-    This elliptic equation can be solved with natural boundary conditions by imposing our original equation above, which eliminates
-    all boundary terms:
+        This elliptic equation can be solved with natural boundary conditions by imposing our original equation above, which eliminates
+        all boundary terms:
 
-    $$
-      int_Omega nabla q * nabla p dx - int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0.
-    $$
+        $$
+          int_Omega nabla q * nabla p dx - int_Omega nabla q * hatk g "Di" rho chi c_p/(c_v gamma) p dx = 0.
+        $$
 
-    However, if we do so on all boundaries we end up with a system that has the same nullspace, as the one we are after (note that
-    we ended up merely testing the original equation with $nabla q$). Instead we use the fact that the gradient of the null mode
-    is always vertical, and thus the null mode is constant at any horizontal level (geoid), specifically the top surface. Choosing
-    any nonzero constant for this surface fixes the arbitrary scalar multiplier of the null mode. We choose the value of one
-    and apply it as a Dirichlet boundary condition.
+        However, if we do so on all boundaries we end up with a system that has the same nullspace, as the one we are after (note that
+        we ended up merely testing the original equation with $nabla q$). Instead we use the fact that the gradient of the null mode
+        is always vertical, and thus the null mode is constant at any horizontal level (geoid), specifically the top surface. Choosing
+        any nonzero constant for this surface fixes the arbitrary scalar multiplier of the null mode. We choose the value of one
+        and apply it as a Dirichlet boundary condition.
 
-    Note that this procedure does not necessarily compute the exact nullspace of the *discretised* Stokes system. In particular,
-    since not every test function $v in V$, the velocity test space, can be written as $v=nabla q$ with $q in W$, the
-    pressure test space, the two terms do not necessarily exactly cancel when tested with $v$ instead of $nabla q$ as in our
-    final equation. However, in practice the discrete error appears to be small enough, and providing this nullspace gives
-    an improved convergence of the iterative Stokes solver.
+        Note that this procedure does not necessarily compute the exact nullspace of the *discretised* Stokes system. In particular,
+        since not every test function $v in V$, the velocity test space, can be written as $v=nabla q$ with $q in W$, the
+        pressure test space, the two terms do not necessarily exactly cancel when tested with $v$ instead of $nabla q$ as in our
+        final equation. However, in practice the discrete error appears to be small enough, and providing this nullspace gives
+        an improved convergence of the iterative Stokes solver.
     """
     W = fd.FunctionSpace(mesh=W.mesh(), family=W.ufl_element())
     q = fd.TestFunction(W)

--- a/tests/free_surface/implicit_cylindrical_free_surface.py
+++ b/tests/free_surface/implicit_cylindrical_free_surface.py
@@ -42,7 +42,7 @@ class CylindricalImplicitFreeSurfaceModel(ImplicitFreeSurfaceModel):
 
     def setup_bcs(self):
         self.stokes_bcs = {
-            self.boundary.top: {"free_surface": {"eta_index": 2, "RaFS": 1}},
+            self.boundary.top: {"free_surface": {"RaFS": 1}},
             self.boundary.bottom: {"un": 0},
         }
 

--- a/tests/free_surface/implicit_cylindrical_free_surface.py
+++ b/tests/free_surface/implicit_cylindrical_free_surface.py
@@ -42,8 +42,8 @@ class CylindricalImplicitFreeSurfaceModel(ImplicitFreeSurfaceModel):
 
     def setup_bcs(self):
         self.stokes_bcs = {
-            self.boundary.top: {'free_surface': {}},  # Free surface boundary conditions are applied automatically in stokes_integrators and momentum_equation for implicit free surface coupling
-            self.boundary.bottom: {'un': 0}
+            self.boundary.top: {"free_surface": {"eta_index": 2, "RaFS": 1}},
+            self.boundary.bottom: {"un": 0},
         }
 
     def setup_nullspaces(self):

--- a/tests/free_surface/implicit_free_surface.py
+++ b/tests/free_surface/implicit_free_surface.py
@@ -37,16 +37,25 @@ class ImplicitFreeSurfaceModel(ExplicitFreeSurfaceModel):
     def setup_bcs(self):
         # No normal flow except on the free surface
         self.stokes_bcs = {
-            self.boundary.top: {'free_surface': {}},  # Free surface boundary conditions are applied automatically in stokes_integrators and momentum_equation for implicit free surface coupling
-            self.boundary.bottom: {'un': 0},
-            self.boundary.left: {'un': 0},
-            self.boundary.right: {'un': 0},
+            self.boundary.top: {"free_surface": {"eta_index": 2, "RaFS": 1}},
+            self.boundary.bottom: {"un": 0},
+            self.boundary.left: {"un": 0},
+            self.boundary.right: {"un": 0},
         }
 
     def setup_solver(self):
-        self.stokes_solver = StokesSolver(self.z, self.T, self.approximation, bcs=self.stokes_bcs,
-                                          free_surface_dt=self.dt, solver_parameters=self.solver_parameters, nullspace=self.Z_nullspace,
-                                          transpose_nullspace=self.Z_nullspace, near_nullspace=self.Z_near_nullspace)
+        self.stokes_solver = StokesSolver(
+            self.z,
+            self.T,
+            self.approximation,
+            coupled_tstep=self.dt,
+            theta=0.5,
+            bcs=self.stokes_bcs,
+            solver_parameters=self.solver_parameters,
+            nullspace=self.Z_nullspace,
+            transpose_nullspace=self.Z_nullspace,
+            near_nullspace=self.Z_near_nullspace,
+        )
 
     def calculate_error(self):
         local_error = assemble(pow(self.stokes_vars[2]-self.eta_analytical, 2)*self.ds(self.boundary.top))

--- a/tests/free_surface/implicit_free_surface.py
+++ b/tests/free_surface/implicit_free_surface.py
@@ -37,7 +37,7 @@ class ImplicitFreeSurfaceModel(ExplicitFreeSurfaceModel):
     def setup_bcs(self):
         # No normal flow except on the free surface
         self.stokes_bcs = {
-            self.boundary.top: {"free_surface": {"eta_index": 2, "RaFS": 1}},
+            self.boundary.top: {"free_surface": {"RaFS": 1}},
             self.boundary.bottom: {"un": 0},
             self.boundary.left: {"un": 0},
             self.boundary.right: {"un": 0},

--- a/tests/free_surface/implicit_top_bottom_free_surface.py
+++ b/tests/free_surface/implicit_top_bottom_free_surface.py
@@ -49,9 +49,7 @@ class TopBottomImplicitFreeSurfaceModel(ImplicitFreeSurfaceModel):
         # This is not ideal - python dictionaries are ordered by insertion only since recently (since 3.7) - so relying on
         # their order is fraught and not considered pythonic. At the moment let's consider having more than one free surface
         # a bit of a niche case for now, and leave it as is...
-        self.stokes_bcs[self.boundary.bottom] = {
-            "free_surface": {"eta_index": 3, "RaFS": -1}
-        }
+        self.stokes_bcs[self.boundary.bottom] = {"free_surface": {"RaFS": -1}}
 
     def update_analytical_free_surfaces(self):
         super().update_analytical_free_surfaces()

--- a/tests/free_surface/implicit_top_bottom_free_surface.py
+++ b/tests/free_surface/implicit_top_bottom_free_surface.py
@@ -22,7 +22,12 @@ class TopBottomImplicitFreeSurfaceModel(ImplicitFreeSurfaceModel):
             # Adding a small absorption term bringing the vertical velocity to zero removes this nullspace
             # and does not affect convergence provided that this term is small compared with the overall numerical error.
             self.absorption_penalty(dt_factor)
-            self.stokes_solver.F += self.penalty * self.stokes_solver.test[0][1] * (self.stokes_solver.solution[1] - 0)*dx
+            self.stokes_solver.F += (
+                self.penalty
+                * self.stokes_solver.tests[0][1]
+                * (self.stokes_solver.solution[1] - 0)
+                * dx
+            )
 
     def setup_function_space(self):
         self.Z = MixedFunctionSpace([self.V, self.W, self.W, self.W])  # Mixed function space with bottom free surface.
@@ -44,7 +49,9 @@ class TopBottomImplicitFreeSurfaceModel(ImplicitFreeSurfaceModel):
         # This is not ideal - python dictionaries are ordered by insertion only since recently (since 3.7) - so relying on
         # their order is fraught and not considered pythonic. At the moment let's consider having more than one free surface
         # a bit of a niche case for now, and leave it as is...
-        self.stokes_bcs[self.boundary.bottom] = {"free_surface": {"RaFS": -1}}
+        self.stokes_bcs[self.boundary.bottom] = {
+            "free_surface": {"eta_index": 3, "RaFS": -1}
+        }
 
     def update_analytical_free_surfaces(self):
         super().update_analytical_free_surfaces()


### PR DESCRIPTION
This PR attempts to streamline the free surface implementation in `StokesSolver`. In doing so, it introduces two new methods (`set_equations` and `set_form`) that deal with setting up `Equation` instances and calculating the weak form based on the theta scheme.