### PR TITLE
Add unit test for solver parameter consistency

### DIFF
--- a/tests/unit/data/solver_params.py
+++ b/tests/unit/data/solver_params.py
@@ -1,0 +1,39 @@
+from firedrake import *
+from firedrake.adjoint import *
+
+continue_annotation()
+
+solver_parameters = {
+    "snes_type": "newtonls",
+    "snes_converged_reason": None,
+    "snes_max_it": 50,
+    "ksp_type": "cg",
+    "pc_type": "hypre",
+    "ksp_rtol": 1e-9,
+    "ksp_atol": 1e-12,
+    "ksp_max_it": 1000,
+    "ksp_monitor": None,
+    "ksp_converged_reason": None,
+    "gadopt_test": None,
+}
+
+mesh = UnitSquareMesh(1, 1)
+V = FunctionSpace(mesh, "CG", 1)
+R = FunctionSpace(mesh, "R", 0)
+v = TestFunction(V)
+u0 = Function(V)
+u1 = Function(V)
+
+ui = Function(R, val=2.0)
+c = Control(ui)
+u0.assign(ui)
+F = dot(v, (u1 - u0)) * dx - dot(v, u0 * u1) * dx
+problem = NonlinearVariationalProblem(F, u1)
+solver = NonlinearVariationalSolver(problem, solver_parameters=solver_parameters)
+solver.solve()
+u0.assign(u1)
+solver.solve()
+J = assemble(dot(u1, u1) * dx)
+rf = ReducedFunctional(J, c)
+print("BEGIN REDUCEDFUNCTIONAL CALL")
+rf([ui])

--- a/tests/unit/test_solver_parameters.py
+++ b/tests/unit/test_solver_parameters.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+def test_solver_params():
+    unbuffered_env = os.environ.copy()
+    unbuffered_env["PYTHONUNBUFFERED"] = "1"
+
+    test_path = Path(__file__).parent.resolve() / "data/solver_params.py"
+
+    params_output = subprocess.run(
+        [sys.executable, str(test_path), "-options_monitor"],
+        capture_output=True,
+        text=True,
+        env=unbuffered_env,
+    ).stdout.splitlines()
+    mark = params_output.index("BEGIN REDUCEDFUNCTIONAL CALL")
+
+    state = 0  # searching for "setting option" line
+    setting_re = r"Setting option: (.*?)_gadopt_test"
+    solve_re = r"\s+Residual norms for {}"
+    remove_re = r"Removing option: {}_gadopt_test"
+    solve_name = None
+    matches = 0
+
+    for line in params_output[mark + 1:]:
+        if state == 0:
+            if m := re.match(setting_re, line):
+                solve_name = m.group(1)
+                state = 1
+                continue
+
+        if state == 1:
+            if re.match(solve_re.format(solve_name), line):
+                state = 2
+                continue
+
+        if state == 2:
+            if re.match(remove_re.format(solve_name), line):
+                state = 0
+                matches += 1
+                solve_name = None
+                continue
+
+    assert matches > 0


### PR DESCRIPTION
In response to a recent Firedrake regression where solver parameters weren't being passed through to blocks on the tape. This is a bit brute force, but we ensure that our artificial "gadopt_test" option is processed by the options database when we play the tape forward by evaluating the reduced functional.

I think maybe the implementation here is a bit ugly and certainly happy to take a different approach!