### PR TITLE
Update `setup_solver` in `StokesSolver` to make `nullspace` arguments explicit

### DIFF
--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/2d_cylindrical.py
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/2d_cylindrical.py
@@ -442,10 +442,20 @@ Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, tra
 # along with the approximation, timestep and boundary conditions.
 #
 
-stokes_solver = ViscoelasticStokesSolver(z, stress_old, displacement, approximation,
-                                         dt, bcs=stokes_bcs, constant_jacobian=True,
-                                         nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                         near_nullspace=Z_near_nullspace)
+stokes_solver = ViscoelasticStokesSolver(
+    z,
+    stress_old,
+    displacement,
+    approximation,
+    dt,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 
 # We next set up our output, in VTK format. This format can be read by programs like pyvista and Paraview.
 

--- a/demos/mantle_convection/2d_compressible_ALA/2d_compressible_ALA.py
+++ b/demos/mantle_convection/2d_compressible_ALA/2d_compressible_ALA.py
@@ -138,9 +138,14 @@ gd = GeodynamicalDiagnostics(z, FullT, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace_transpose,
-                             constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # Next initiate the time loop, which runs until a steady-state solution has been attained:

--- a/demos/mantle_convection/2d_compressible_TALA/2d_compressible_TALA.py
+++ b/demos/mantle_convection/2d_compressible_TALA/2d_compressible_TALA.py
@@ -203,9 +203,14 @@ gd = GeodynamicalDiagnostics(z, FullT, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # Next initiate the time loop, which runs until a steady-state solution has been attained:

--- a/demos/mantle_convection/2d_cylindrical/2d_cylindrical.py
+++ b/demos/mantle_convection/2d_cylindrical/2d_cylindrical.py
@@ -161,10 +161,18 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top, quad_degree=6)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 # -
 
 # We now initiate the time loop, which runs until a steady-state solution has been attained.

--- a/demos/mantle_convection/3d_cartesian/3d_cartesian.py
+++ b/demos/mantle_convection/3d_cartesian/3d_cartesian.py
@@ -155,10 +155,18 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 # -
 
 # For all iterative solves, G-ADOPT utilises convergence criterion based on the relative reduction of the

--- a/demos/mantle_convection/3d_spherical/3d_spherical.py
+++ b/demos/mantle_convection/3d_spherical/3d_spherical.py
@@ -137,10 +137,18 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top, quad_degree=6)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 # -
 
 # We now initiate the time loop, which runs until a steady-state solution has been attained.

--- a/demos/mantle_convection/adjoint/adjoint.py
+++ b/demos/mantle_convection/adjoint/adjoint.py
@@ -146,8 +146,14 @@ temp_bcs = {
 
 # Setup Energy and Stokes solver
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace, constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # Specify Problem Length

--- a/demos/mantle_convection/adjoint/adjoint_forward.py
+++ b/demos/mantle_convection/adjoint/adjoint_forward.py
@@ -138,9 +138,8 @@ stokes_solver = StokesSolver(
     T,
     approximation,
     bcs=stokes_bcs,
-    nullspace=Z_nullspace,
-    transpose_nullspace=Z_nullspace,
     constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
 )
 # -
 

--- a/demos/mantle_convection/adjoint_2d_cylindrical/forward.py
+++ b/demos/mantle_convection/adjoint_2d_cylindrical/forward.py
@@ -120,10 +120,12 @@ def run_forward():
         T,
         approximation,
         bcs=stokes_bcs,
-        nullspace=Z_nullspace,
-        transpose_nullspace=Z_nullspace,
-        near_nullspace=Z_near_nullspace,
-        solver_parameters="direct"
+        solver_parameters="direct",
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
     )
 
     # Create output file and select output_frequency

--- a/demos/mantle_convection/adjoint_2d_cylindrical/inverse.py
+++ b/demos/mantle_convection/adjoint_2d_cylindrical/inverse.py
@@ -140,10 +140,12 @@ def inverse(alpha_u, alpha_d, alpha_s):
         T,
         approximation,
         bcs=stokes_bcs,
-        nullspace=Z_nullspace,
-        transpose_nullspace=Z_nullspace,
-        near_nullspace=Z_near_nullspace,
-        solver_parameters="direct"
+        solver_parameters="direct",
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
     )
 
     # Control variable for optimisation

--- a/demos/mantle_convection/adjoint_2d_cylindrical/taylor_test.py
+++ b/demos/mantle_convection/adjoint_2d_cylindrical/taylor_test.py
@@ -142,10 +142,12 @@ def annulus_taylor_test(case):
         T,
         approximation,
         bcs=stokes_bcs,
-        nullspace=Z_nullspace,
-        transpose_nullspace=Z_nullspace,
-        near_nullspace=Z_near_nullspace,
-        solver_parameters="direct"
+        solver_parameters="direct",
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
     )
 
     # Control variable for optimisation

--- a/demos/mantle_convection/base_case/base_case.py
+++ b/demos/mantle_convection/base_case/base_case.py
@@ -330,9 +330,14 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # We can now initiate the time-loop, with the Stokes and energy

--- a/demos/mantle_convection/gplates_global/gplates_global.py
+++ b/demos/mantle_convection/gplates_global/gplates_global.py
@@ -274,10 +274,18 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top, quad_degree=6)
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             constant_jacobian=True,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 # -
 
 # Before we begin with the time-stepping, we need to know when to

--- a/demos/mantle_convection/viscoplastic_case/viscoplastic_case.py
+++ b/demos/mantle_convection/viscoplastic_case/viscoplastic_case.py
@@ -147,8 +147,13 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # Next, we initiate the time loop, which runs until a steady-state solution has been attained.

--- a/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
+++ b/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
@@ -219,8 +219,7 @@ stokes_solver = StokesSolver(
     T,
     approximation,
     bcs=stokes_bcs,
-    nullspace=Z_nullspace,
-    transpose_nullspace=Z_nullspace,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
 )
 
 subcycles = 1  # Number of advection solves to perform within one time step

--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -263,8 +263,7 @@ stokes_solver = StokesSolver(
     T,
     approximation,
     bcs=stokes_bcs,
-    nullspace=Z_nullspace,
-    transpose_nullspace=Z_nullspace,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
 )
 
 subcycles = 1  # Number of advection solves to perform within one time step

--- a/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
+++ b/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
@@ -202,9 +202,17 @@ gd = GeodynamicalDiagnostics(z, FullT, boundary.bottom, boundary.top, quad_degre
 
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             near_nullspace=Z_near_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    nullspace={
+        "nullspace": Z_nullspace,
+        "transpose_nullspace": Z_nullspace,
+        "near_nullspace": Z_near_nullspace,
+    },
+)
 stokes_solver.solver_parameters["fieldsplit_0"]["ksp_converged_reason"] = None
 stokes_solver.solver_parameters["fieldsplit_1"]["ksp_converged_reason"] = None
 

--- a/tests/adjoint/taylor_test.py
+++ b/tests/adjoint/taylor_test.py
@@ -88,9 +88,14 @@ def rectangle_taylor_test(case):
 
     # Setup Energy and Stokes solver
     energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 constant_jacobian=True)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        constant_jacobian=True,
+        nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+    )
 
     initial_timestep = 0
 

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -70,9 +70,17 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -70,9 +70,17 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -70,9 +70,17 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -70,9 +70,17 @@ def model(level, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -69,9 +69,17 @@ def model(level, k, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
@@ -104,9 +104,18 @@ def model(level, k, nn, do_write=False):
     dt = Constant(tau0)  # timestep (dimensionless)
     log("dt (dimensionless)", dt)
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs, free_surface_dt=dt,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        free_surface_dt=dt,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
 
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13

--- a/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -69,9 +69,17 @@ def model(level, k, nn, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-13
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-11

--- a/tests/analytical_comparisons/smooth_spherical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_freeslip.py
@@ -75,9 +75,17 @@ def model(level, l, mm, k, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=True)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9

--- a/tests/analytical_comparisons/smooth_spherical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_spherical_zeroslip.py
@@ -75,9 +75,17 @@ def model(level, l, mm, k, do_write=False):
     Z_nullspace = create_stokes_nullspace(Z, closed=True, rotational=False)
     Z_near_nullspace = create_stokes_nullspace(Z, closed=False, rotational=True, translations=[0, 1])
 
-    stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                                 nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                                 near_nullspace=Z_near_nullspace)
+    stokes_solver = StokesSolver(
+        z,
+        T,
+        approximation,
+        bcs=stokes_bcs,
+        nullspace={
+            "nullspace": Z_nullspace,
+            "transpose_nullspace": Z_nullspace,
+            "near_nullspace": Z_near_nullspace,
+        },
+    )
     # use tighter tolerances than default to ensure convergence:
     stokes_solver.solver_parameters['fieldsplit_0']['ksp_rtol'] = 1e-10
     stokes_solver.solver_parameters['fieldsplit_1']['ksp_rtol'] = 1e-9

--- a/tests/base_gmsh/base_case.py
+++ b/tests/base_gmsh/base_case.py
@@ -187,9 +187,14 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace,
-                             constant_jacobian=True)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    constant_jacobian=True,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # We can now initiate the time-loop, with the Stokes and energy

--- a/tests/free_surface/implicit_free_surface.py
+++ b/tests/free_surface/implicit_free_surface.py
@@ -44,9 +44,19 @@ class ImplicitFreeSurfaceModel(ExplicitFreeSurfaceModel):
         }
 
     def setup_solver(self):
-        self.stokes_solver = StokesSolver(self.z, self.T, self.approximation, bcs=self.stokes_bcs,
-                                          free_surface_dt=self.dt, solver_parameters=self.solver_parameters, nullspace=self.Z_nullspace,
-                                          transpose_nullspace=self.Z_nullspace, near_nullspace=self.Z_near_nullspace)
+        self.stokes_solver = StokesSolver(
+            self.z,
+            self.T,
+            self.approximation,
+            bcs=self.stokes_bcs,
+            free_surface_dt=self.dt,
+            solver_parameters=self.solver_parameters,
+            nullspace={
+                "nullspace": self.Z_nullspace,
+                "transpose_nullspace": self.Z_nullspace,
+                "near_nullspace": self.Z_near_nullspace,
+            },
+        )
 
     def calculate_error(self):
         local_error = assemble(pow(self.stokes_vars[2]-self.eta_analytical, 2)*self.ds(self.boundary.top))

--- a/tests/multi_material/run_benchmark.py
+++ b/tests/multi_material/run_benchmark.py
@@ -223,8 +223,7 @@ stokes_solver = ga.StokesSolver(
     bcs=Simulation.stokes_bcs,
     quad_degree=None,
     solver_parameters=Simulation.stokes_solver_params,
-    nullspace=stokes_nullspace,
-    transpose_nullspace=stokes_nullspace,
+    nullspace={"nullspace": stokes_nullspace, "transpose_nullspace": stokes_nullspace},
 )
 
 # Solve initial Stokes system

--- a/tests/viscoplastic_case_DG/viscoplastic_case_DG.py
+++ b/tests/viscoplastic_case_DG/viscoplastic_case_DG.py
@@ -145,8 +145,13 @@ gd = GeodynamicalDiagnostics(z, T, boundary.bottom, boundary.top)
 # +
 energy_solver = EnergySolver(T, u, approximation, delta_t, ImplicitMidpoint, bcs=temp_bcs)
 
-stokes_solver = StokesSolver(z, T, approximation, bcs=stokes_bcs,
-                             nullspace=Z_nullspace, transpose_nullspace=Z_nullspace)
+stokes_solver = StokesSolver(
+    z,
+    T,
+    approximation,
+    bcs=stokes_bcs,
+    nullspace={"nullspace": Z_nullspace, "transpose_nullspace": Z_nullspace},
+)
 # -
 
 # Next, we initiate the time loop, which runs until a steady-state solution has been attained.


### PR DESCRIPTION
This PR makes nullspace arguments to variational solvers explicit in `StokesSolver`, i.e. they are now their own documented argument instead of being silently injected through `kwargs`.