### PR TITLE
Fix render workflow

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -55,8 +55,6 @@ jobs:
 
       - name: Set up for network namespacing
         run: |
-          sudo sed -i 's/ubuntu/firedrake/' /etc/subuid
-          sudo sed -i 's/ubuntu/firedrake/' /etc/subgid
           sudo apt install -y uidmap iproute2
           . .venv/bin/activate
           jupytext_location="$(which jupytext)"

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -48,9 +48,6 @@ jobs:
           s3cmd --config=$HOME/.s3cfg/config get s3://gadopt/github-actions/Muller_etal_2022_SE_1Ga_Opt_PlateMotionModel_v1.2.zip .
           unzip Muller_etal_2022_SE_1Ga_Opt_PlateMotionModel_v1.2.zip -d demos/mantle_convection/gplates_global
 
-      - name: Fix HOME environment variable
-        run: echo "HOME=/home/firedrake" >> "$GITHUB_ENV"
-
       - name: Install Firedrake kernel
         run: |
           . .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,6 @@ demos = ["assess", "gmsh", "imageio", "jupytext", "openpyxl", "pandas", "pyvista
 optimisation = ["pyroltrilinos"]
 
 [tool.setuptools]
-packages = ["gadopt"]
+packages = ["gadopt", "gadopt.gplates"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
There were a couple of outdated constructs in the render workflow that don't apply with the Firedrake root container. The real issue here is that I _think_ we need to explicitly specify that we have a `gadopt.gplates` subpackage, because we're not using setuptools' automatic package discovery. It's kind of weird that this only sometimes shows up on the render job, and it doesn't ever cause an issue on the testing job. I think this should probably wait for (or be combined with) #213 so that we don't get spurious test failures.