### PR TITLE
Use correct type for optimisation parameters

### DIFF
--- a/gadopt/inverse.py
+++ b/gadopt/inverse.py
@@ -354,11 +354,11 @@ minimisation_parameters = {
             "Radius Shrinking Rate (Positive rho)": 0.25,
             "Radius Growing Rate": 10.0,
             "Sufficient Decrease Parameter": 1e-2,
-            "Safeguard Size": 100,
+            "Safeguard Size": 100.0,
         },
     },
     "Status Test": {
-        "Gradient Tolerance": 0,
+        "Gradient Tolerance": 0.0,
         "Iteration Limit": 100,
     },
 }


### PR DESCRIPTION
The "Safeguard Size" and "Gradient Tolerance" parameters that are present in the minimisation defaults are actually floats, but they are written as ints. With a default build of ROL using boost::property_list, this doesn't cause any issues. However, it's possible to build ROL using Teuchos to manage the parameter lists, and it'll complain about type issues.