### PR TITLE
Silence memory binding warnings in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           make -j test
         env:
           GADOPT_LOGLEVEL: INFO
+          OMPI_MCA_hwloc_base_mem_bind_failure_action: silent
           BATCH_MODE: 1
 
       - name: Pytest


### PR DESCRIPTION
These warnings are meaningless as a) no memory binding policy is set, so as far as I can tell its failing to not set memory binding and b) memory binding is useless on this system as it only has a single NUMA node. The warning is spurious and therefore can be safely silenced.