### PR TITLE
Tests for adjoint with changing Dirichlet boundary condition

### DIFF
--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -1,7 +1,7 @@
 include ../../rules.mk
 
-cases := damping smoothing Tobs uobs
-scheduler := fullmemory
+cases := damping smoothing Tobs uobs uimposed
+scheduler := noscheduler fullmemory fullstorage
 
 cases_schedulers := $(foreach case,$(cases),$(foreach sched,$(scheduler),$(case)_$(sched)))
 

--- a/tests/adjoint/cases.py
+++ b/tests/adjoint/cases.py
@@ -1,4 +1,14 @@
-from checkpoint_schedules import SingleMemoryStorageSchedule
+from checkpoint_schedules import SingleMemoryStorageSchedule, SingleDiskStorageSchedule
 
-cases = ["damping", "smoothing", "Tobs", "uobs"]
-schedules = {"fullmemory": SingleMemoryStorageSchedule()}
+cases = [
+    "damping",  # Taylor test on the damping term only  $$ (Tic - T_ave) ** 2 dx $$
+    "smoothing",  # Taylor test on smoothing only  $$ \nabla (T_ic - T_ave) ** 2 dx$$
+    "Tobs",  # Taylor test on temperature misfit only  $$ (T - T_obs) ** 2 dx $$
+    "uobs",  # Taylor test on uobs only $$ (u - uobs) ** 2 ds_t $$
+    "uimposed",  # Taylor test on temperature misfit, but with imposed velocity $$ (T - T_obs) ** 2 dx $$
+]
+schedules = {
+    "noscheduler": None,  # No scheduler used
+    "fullmemory": SingleMemoryStorageSchedule(),  # Store all data in memory
+    "fullstorage": SingleDiskStorageSchedule(),  # Store all data on disk
+}


### PR DESCRIPTION
This introduces a changing BC test to the adjoint test in a box. In addition we also introduce a None scheduler (not using any scheduling in adjoint) and disk storage scheduling for the same case (going from 4cases x 1scheduler = 4total to  5cases x 3scheduler=15total cases). 

**Note** With the current bug in pyadjoint, the additional tests should fail on firedrake 2025.04.post0