### PR TITLE
Add missing import to thermochemical demo

### DIFF
--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -138,6 +138,7 @@ assign_level_set_values(
 
 # + tags=["active-ipynb"]
 # import matplotlib.pyplot as plt
+# from numpy import linspace
 
 # fig, axes = plt.subplots()
 # axes.set_aspect("equal")


### PR DESCRIPTION
Just a quick fix for the failing demo build. See https://github.com/g-adopt/g-adopt/actions/runs/15436764247 for passing demo run with this branch.