### PR TITLE
Add github action to create memory profiling plots

### DIFF
--- a/.github/workflows/memprof_plot.yml
+++ b/.github/workflows/memprof_plot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Install plotter 
         run: |
-          pip3 install git+https://github.com/dsroberts/memprof_plotter.git
+          pip3 install git+https://github.com/g-adopt/memprof_plotter.git
       - name: Make plots
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This action is set to run on completion of the regression tests. It grabs the last 10 `run-log` artefacts and runs this script: https://github.com/dsroberts/memprof_plotter/blob/main/memprof_plotter/plotter.py to create some plots and upload them as an artefact. Note that `workflow_run` triggers only work if the workflow file is on the main branch, so it won't do anything until the PR is merged. Here are my test runs: https://github.com/dsroberts/actions_mess_around/actions.

Once its merged, the graphs won't be particularly useful until more branches are created from after #221 was merged. The python script does handle the case where the `memprof` table is not present in the database. 