### PR TITLE
Update memprof plot action to use updated memprof_plotter

### DIFF
--- a/.github/workflows/memprof_plot.yml
+++ b/.github/workflows/memprof_plot.yml
@@ -19,15 +19,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           NRUNS: 10
         run: |
-          export JSON=$( gh run list -R g-adopt/g-adopt -w test.yml -s success -L "${NRUNS}" --json databaseId,number )
-          declare -a RUNIDS=( $( jq --jsonargs '.[].databaseId' <<<"${JSON}" ) )
-          declare -a RUNNOS=( $( jq --jsonargs '.[].number' <<<"${JSON}") )
-
-          for (( i=0; i<${NRUNS}; i++ )); do
-              gh run download -R g-adopt/g-adopt -D "${RUNNOS[$i]}" -n run-log "${RUNIDS[$i]}"
-          done
-
-          memprof_plotter "${RUNNOS[@]}"
+          memprof_plotter -n "${NRUNS}"
       - name: Upload plots
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I've updated memprof_plotter to use `PyGithub`. Its a bit smarter now, it picks the `n` most recent successful runs that have artefacts. Since it doesn't use `gh` at all any more, the action here needs to be updated. There is also a test action over at g-adopt/memprof_plotter, we should all be able to see the artefacts from that action.