### PR TITLE
Remove `Material` class from level-set API

### DIFF
--- a/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
+++ b/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
@@ -147,15 +147,9 @@ assign_level_set_values(
 
 
 # +
-buoyant_material = Material(RaB=-1)  # Vertical direction is flipped in the benchmark
-dense_material = Material(RaB=0)
-materials = [buoyant_material, dense_material]
-
 Ra = 0  # Thermal Rayleigh number
-
-RaB = material_field(
-    psi, [material.RaB for material in materials], interface="arithmetic"
-)  # Compositional Rayleigh number, defined based on each material value and location
+# Compositional Rayleigh number, defined based on each material value and location
+RaB = material_field(psi, [RaB_buoyant := 0, RaB_dense := 1], interface="arithmetic")
 
 approximation = BoussinesqApproximation(Ra, RaB=RaB)
 # -

--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -159,15 +159,11 @@ assign_level_set_values(
 # using averaging schemes, such as arithmetic, geometric, and harmonic means.
 
 # +
-dense_material = Material(RaB=4.5e5)
-reference_material = Material(RaB=0)
-materials = [dense_material, reference_material]
-
 Ra = 3e5  # Thermal Rayleigh number
-
+# Compositional Rayleigh number, defined based on each material value and location
 RaB = material_field(
-    psi, [material.RaB for material in materials], interface="arithmetic"
-)  # Compositional Rayleigh number, defined based on each material value and location
+    psi, [RaB_dense := 4.5e5, RaB_reference := 0], interface="arithmetic"
+)
 
 approximation = BoussinesqApproximation(Ra, RaB=RaB)
 # -

--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -11,7 +11,6 @@ from .approximations import (
 from .diagnostics import GeodynamicalDiagnostics
 from .level_set_tools import (
     LevelSetSolver,
-    Material,
     assign_level_set_values,
     interface_thickness,
     material_entrainment,


### PR DESCRIPTION
That specific class was never exactly needed, and it is not Pythonic at all. Its purpose can be achieved explicitly in the simulation script (see updated demos) or through material modules, as will be shown in the next commit for tests.