### PR TITLE
Clarify and generalise `assign_level_set_values`

### DIFF
--- a/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
+++ b/demos/multi_material/compositional_buoyancy/compositional_buoyancy.py
@@ -110,6 +110,7 @@ callable_args = (
     perturbation_wavelength := 2 * lx,
     interface_coord_y := 0.2,
 )
+boundary_coordinates = [(lx, ly), (0.0, ly), (0.0, interface_coord_y)]
 
 epsilon = interface_thickness(K)
 assign_level_set_values(
@@ -118,6 +119,7 @@ assign_level_set_values(
     interface_geometry="curve",
     interface_callable="cosine",
     interface_args=(interface_coords_x, *callable_args),
+    boundary_coordinates=boundary_coordinates,
 )
 # -
 

--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -122,6 +122,7 @@ from numpy import array  # noqa: E402
 # level-set field values.
 interface_coords_x = array([0.0, lx])
 callable_args = (interface_slope := 0, interface_coord_y := 0.025)
+boundary_coordinates = [(lx, ly), (0.0, ly), (0.0, interface_coord_y)]
 
 epsilon = interface_thickness(K)
 assign_level_set_values(
@@ -130,6 +131,7 @@ assign_level_set_values(
     interface_geometry="curve",
     interface_callable="line",
     interface_args=(interface_coords_x, *callable_args),
+    boundary_coordinates=boundary_coordinates,
 )
 # -
 

--- a/tests/multi_material/benchmarks/crameri_2012/simulation.py
+++ b/tests/multi_material/benchmarks/crameri_2012/simulation.py
@@ -86,18 +86,22 @@ callable_args = (
     surface_perturbation_wavelength := domain_dims[0],
     surface_coord_y := 7e5,
 )
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, surface_coord_y)]
 surface_signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "cosine",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # Parameters to initialise LAB level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (lab_slope := 0, lab_coord_y := 6e5)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, lab_coord_y)]
 lab_signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/robey_2019/simulation.py
+++ b/tests/multi_material/benchmarks/robey_2019/simulation.py
@@ -113,10 +113,12 @@ level_set_func_space_deg = 2
 # Parameters to initialise level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (interface_slope := 0, interface_coord_y := 0.5)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, interface_coord_y)]
 signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/schmalholz_2011/simulation.py
+++ b/tests/multi_material/benchmarks/schmalholz_2011/simulation.py
@@ -193,7 +193,7 @@ mesh_fine_layer_hor_res = 8e3
 level_set_func_space_deg = 2
 
 # Parameters to initialise level set
-interface_coords = [
+interface_coordinates = [
     (0, 5.8e5),
     (4.6e5, 5.8e5),
     (4.6e5, 3.3e5),
@@ -202,7 +202,7 @@ interface_coords = [
     (domain_dims[0], 5.8e5),
 ]
 
-boundary_coords = [
+boundary_coordinates = [
     (domain_dims[0], domain_dims[1]),
     (0, domain_dims[1]),
     (0, 5.8e5),
@@ -210,8 +210,8 @@ boundary_coords = [
 # Keyword arguments to define the signed-distance function
 signed_distance_kwargs = {
     "interface_geometry": "polygon",
-    "interface_coordinates": interface_coords,
-    "boundary_coordinates": boundary_coords,
+    "interface_coordinates": interface_coordinates,
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/schmeling_2008/simulation.py
+++ b/tests/multi_material/benchmarks/schmeling_2008/simulation.py
@@ -122,10 +122,12 @@ level_set_func_space_deg = 2
 # Parameters to initialise surface level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (surface_slope := 0, surface_coord_y := 7e5)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, surface_coord_y)]
 surface_signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # Parameters to initialise slab level set
 slab_interface_coords = [

--- a/tests/multi_material/benchmarks/tosi_2015/simulation.py
+++ b/tests/multi_material/benchmarks/tosi_2015/simulation.py
@@ -88,10 +88,12 @@ level_set_func_space_deg = 2
 # Parameters to initialise level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (interface_slope := 0, interface_coord_y := 0.5)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, interface_coord_y)]
 signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/trim_2023/simulation.py
+++ b/tests/multi_material/benchmarks/trim_2023/simulation.py
@@ -131,10 +131,12 @@ level_set_func_space_deg = 2
 # Parameters to initialise level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (interface_slope := 0, interface_coord_y := 0.5)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, interface_coord_y)]
 signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/van_keken_1997_isothermal/simulation.py
+++ b/tests/multi_material/benchmarks/van_keken_1997_isothermal/simulation.py
@@ -110,10 +110,12 @@ callable_args = (
     perturbation_wavelength := 2 * domain_dims[0],
     interface_coord_y := 0.2,
 )
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, interface_coord_y)]
 signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "cosine",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array

--- a/tests/multi_material/benchmarks/van_keken_1997_thermochemical/simulation.py
+++ b/tests/multi_material/benchmarks/van_keken_1997_thermochemical/simulation.py
@@ -169,10 +169,12 @@ level_set_func_space_deg = 2
 # Parameters to initialise level set
 interface_coords_x = np.array([0.0, domain_dims[0]])
 callable_args = (interface_slope := 0, interface_coord_y := 0.025)
+boundary_coordinates = [domain_dims, (0.0, domain_dims[1]), (0.0, interface_coord_y)]
 signed_distance_kwargs = {
     "interface_geometry": "curve",
     "interface_callable": "line",
     "interface_args": (interface_coords_x, *callable_args),
+    "boundary_coordinates": boundary_coordinates,
 }
 # The following list must be ordered such that, unpacking from the end, each dictionary
 # contains the keyword arguments required to initialise the signed-distance array


### PR DESCRIPTION
Through interacting with Fanny, who has started to use `G-ADOPT` to implement multi-material, thermomechanical subduction models, I realised that some items of the recently updated level-set API were not satisfactory. This PR deals with `assign_level_set_values`. The first item of interest is the function's documentation, which was either incomplete or unclear. The second item is the way level-set values (essentially, 0 or 1) are assigned, particularly for interfaces represented as curves. The current behaviour only allows for mathematical functions, but implicit curve equations should be handled. Finally, the whole idea behind  `assign_level_set_values` was to hide the `Shapely` API from the user. However, there are cases for which the simple scenarios currently implemented are not sufficient to generate the desired interface. In these cases, the user has to interact with `Shapely` directly and should be able to provide their `Shapely` object to `G-ADOPT`'s API. Such a scenario is not currently handled, and this PR addresses this gap.

For reference, this is the code Fanny and I wrote for the subduction case:
```python
# Material interface
plate_extremity_coords = (0.0, domain_dims[1])
trench_coords = (domain_dims[0] / 2, domain_dims[1])
weak_layer_thickness = 2e4
ann_outer_radius = 2.5e5
ann_centre = (trench_coords[0], trench_coords[1] - ann_outer_radius)
slab_tip_angle = np.deg2rad(77.0)

surface_plate_coords = [
    plate_extremity_coords,
    trench_coords,
    (trench_coords[0], trench_coords[1] - weak_layer_thickness),
    (plate_extremity_coords[0], plate_extremity_coords[1] - weak_layer_thickness),
    plate_extremity_coords,
]
surface_plate = sl.Polygon(surface_plate_coords)

ann_outer_circle = sl.Point(ann_centre).buffer(ann_outer_radius)
ann_inner_circle = sl.Point(ann_centre).buffer(ann_outer_radius - weak_layer_thickness)
annulus = ann_outer_circle.difference(ann_inner_circle)

slab_tip_triangle_coords = [
    trench_coords,
    (trench_coords[0] + ann_outer_radius * np.tan(slab_tip_angle), trench_coords[1]),
    ann_centre,
    trench_coords,
]
slab_tip_triangle = sl.Polygon(slab_tip_triangle_coords)

weak_layer_polygon = surface_plate.union(annulus.intersection(slab_tip_triangle))
weak_layer_polygon_coords = weak_layer_polygon.exterior.coords._coords
([plate_extremity_index],) = np.all(
    weak_layer_polygon_coords == plate_extremity_coords, axis=1
).nonzero()
weak_layer_interface_coords = weak_layer_polygon_coords[:plate_extremity_index]
weak_layer_interface = sl.LineString(weak_layer_interface_coords)

# Initialise level set
epsilon = interface_thickness(K)
assign_level_set_values(
    psi,
    epsilon,
    interface_geometry="shapely",
    interface=weak_layer_interface,
    boundary_coordinates=weak_layer_polygon_coords[plate_extremity_index:],
)
```