### PR TITLE
Fix Makefile `all` target preventing tests to run

### DIFF
--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -1,16 +1,18 @@
 include ../../rules.mk
 
 cases := $(wildcard benchmarks/*)
+archive := output_0_reference.npz
+outputs := $(foreach case,$(cases),$(case)/${archive})
 
 .PHONY: all clean check
 
-all: $(cases)
+all: $(outputs)
 
-$(cases) : ncpus := 8
-$(cases) : category := multi_material
-$(cases) : exec_cmd = mpiexec -np $(ncpus) python3 $< $*
-$(cases): desc = $*
-$(cases): %: run_benchmark.py %/simulation.py
+%/${archive} : category := multi_material
+%/${archive} : ncpus := 8
+%/${archive} : exec_cmd = mpiexec -np $(ncpus) python3 $< $(dir $@)
+%/${archive} : desc = $*
+%/${archive}: run_benchmark.py
 	$(run-python)
 
 clean:
@@ -21,5 +23,5 @@ clean:
 	@$(foreach case,$(cases),rm -f $(case)/*.npz;)
 	@$(foreach case,$(cases),rm -f $(case)/mesh/*.msh;)
 
-check: $(cases)
+check: all
 	python3 -m pytest


### PR DESCRIPTION
For some reason, CI gave a green tick, but now nothing runs anymore. Proposed changes should fix the situation