### PR TITLE
Pin VTK for pyvista compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
   "pandas",
   "shapely",
-  "vtk>=9.0.1",
+  "vtk<9.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We can unpin when https://github.com/pyvista/pyvista/issues/7587 is closed (which should be pretty soon really). Should allow render jobs to complete again.