### PR TITLE
Code improvements/fixes identified whilst testing 3-D level set

### DIFF
--- a/gadopt/equations.py
+++ b/gadopt/equations.py
@@ -137,22 +137,22 @@ def cell_edge_integral_ratio(mesh: fd.MeshGeometry, p: int) -> int:
     See Equation (3.7), Table 3.1, and Appendix C from Hillewaert's thesis:
     https://www.researchgate.net/publication/260085826
     """
-    cell_type = mesh.ufl_cell().cellname()
-    if cell_type == "triangle":
-        return (p + 1) * (p + 2) / 2.0
-    elif cell_type == "quadrilateral" or cell_type == "interval * interval":
-        return (p + 1) ** 2
-    elif cell_type == "triangle * interval":
-        return (p + 1) ** 2
-    elif cell_type == "quadrilateral * interval":
-        # if e is a wedge and f is a triangle: (p+1)**2
-        # if e is a wedge and f is a quad: (p+1)*(p+2)/2
-        # here we just return the largest of the the two (for p>=0)
-        return (p + 1) ** 2
-    elif cell_type == "tetrahedron":
-        return (p + 1) * (p + 3) / 3
-    else:
-        raise NotImplementedError("Unknown cell type in mesh: {}".format(cell_type))
+    match cell_type := mesh.ufl_cell().cellname():
+        case "triangle":
+            return (p + 1) * (p + 2) / 2.0
+        case "quadrilateral" | "interval * interval":
+            return (p + 1) ** 2
+        case "triangle * interval":
+            return (p + 1) ** 2
+        case "quadrilateral * interval" | "hexahedron":
+            # if e is a wedge and f is a triangle: (p+1)**2
+            # if e is a wedge and f is a quad: (p+1)*(p+2)/2
+            # here we just return the largest of the the two (for p>=0)
+            return (p + 1) ** 2
+        case "tetrahedron":
+            return (p + 1) * (p + 3) / 3
+        case _:
+            raise NotImplementedError(f"Unknown cell type in mesh: {cell_type}")
 
 
 def interior_penalty_factor(eq: Equation, *, shift: int = 0) -> float:

--- a/gadopt/level_set_tools.py
+++ b/gadopt/level_set_tools.py
@@ -473,7 +473,7 @@ class LevelSetSolver:
             grad_name += number_match.group()
 
         gradient_space = fd.VectorFunctionSpace(
-            self.mesh, "Q", self.solution.ufl_element().degree()
+            self.mesh, "CG", self.solution.ufl_element().degree()
         )
         self.solution_grad = fd.Function(gradient_space, name=grad_name)
 
@@ -766,7 +766,7 @@ def min_max_height(
       side:
         An integer (`0` or `1`) denoting the level-set value on the target material side
       mode:
-        A string ("min" or "max") specifying which extremum height is sought
+        A string (`"min"` or `"max"`) specifying which extremum height is sought
 
     Returns:
       A float corresponding to the material interface extremum height
@@ -799,7 +799,7 @@ def min_max_height(
     coords = node_coordinates(level_set)
 
     coords_data = coords.dat.data_ro
-    ls_data = level_set.dat.data_ro
+    ls_data = level_set.dat.data_ro.clip(1e-6, 1.0 - 1e-6)
     if isinstance(epsilon, float):
         eps_data = epsilon * np.ones_like(ls_data)
     else:
@@ -832,14 +832,14 @@ def min_max_height(
 
             ls_inside = ls_data[mask_ls][ind_inside]
             eps_inside = eps_data[mask_ls][ind_inside]
-            sdls_inside = eps_inside * np.log(ls_inside / (1 - ls_inside))
+            sdls_inside = eps_inside * np.log(ls_inside / (1.0 - ls_inside))
 
             ls_outside = ls_data[~mask_ls][mask_hor_coords][ind_outside]
             eps_outside = eps_data[~mask_ls][mask_hor_coords][ind_outside]
-            sdls_outside = eps_outside * np.log(ls_outside / (1 - ls_outside))
+            sdls_outside = eps_outside * np.log(ls_outside / (1.0 - ls_outside))
 
             sdls_dist = sdls_outside / (sdls_outside - sdls_inside)
-            height = sdls_dist * height_inside + (1 - sdls_dist) * height_outside
+            height = sdls_dist * height_inside + (1.0 - sdls_dist) * height_outside
         else:
             height = height_inside
     else:

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -309,7 +309,7 @@ class StokesSolver:
         if self.mesh.cartesian:
             bc_map["ux"] = bc_map["u"].sub(0)
             bc_map["uy"] = bc_map["u"].sub(1)
-            if self.mesh.geometric_dimension == 3:
+            if self.mesh.geometric_dimension() == 3:
                 bc_map["uz"] = bc_map["u"].sub(2)
 
         for bc_id, bc in self.bcs.items():


### PR DESCRIPTION
A few changes/improvements I had to make/spotted whilst looking at a 3-D level-set simulation. 

- `cell_edge_integral_ratio` is missing `hexahedron`. I checked the document linked in the docstring and concluded `hexahedron` probably falls in the same category as `quadrilateral * interval`. Moreover, I rewrote the function's logic using `match/case` and converted the error message to an f-string to make things look cleaner.
-  `gradient_space` in `set_gradient_solver` should be defined on `CG` to allow for both simplex and quad support.
- `ls_data` in `min_max_height` needs to be clipped away from 0.0 and 1.0 to avoid issues in `numpy.log` calls. Such issues are likely to arise for coarser meshes (and unreasonable interface-thickness values).
- `geometric_dimension` in `set_boundary_conditions` is a Callable (silly me).