### PR TITLE
Allow Firedrake initialisation of level set

### DIFF
--- a/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
+++ b/demos/multi_material/thermochemical_buoyancy/thermochemical_buoyancy.py
@@ -113,29 +113,17 @@ psi = Function(K, name="Level set")  # Firedrake function for level set
 # from the signed-distance function.
 
 # +
-from numpy import array  # noqa: E402
-
 # Initialise the level-set field according to the conservative level-set approach.
-# First, write out the mathematical description of the material-interface location.
-# Here, only arguments to the G-ADOPT line function are required. Then, use the G-ADOPT
-# API to generate the thickness of the hyperbolic tangent profile and update the
-# level-set field values.
-callable_args = (
-    curve_parameter := array([0.0, lx]),
-    interface_slope := 0,
-    interface_coord_y := 0.025,
-)
-boundary_coordinates = [(lx, ly), (0.0, ly), (0.0, interface_coord_y)]
+# Here, the material interface is a horizontal straight line, and so the conservative
+# level-set field can be simply defined using mesh coordinates. We first express the
+# signed-distance function and then use G-ADOPT's API to generate the thickness of the
+# hyperbolic tangent profile and update the level-set field values.
+x, y = SpatialCoordinate(mesh)  # Extract UFL representation of spatial coordinates
+interface_coord_y = 0.025
+signed_distance = interface_coord_y - y
 
 epsilon = interface_thickness(K)
-assign_level_set_values(
-    psi,
-    epsilon,
-    interface_geometry="curve",
-    interface_callable="line",
-    interface_args=callable_args,
-    boundary_coordinates=boundary_coordinates,
-)
+assign_level_set_values(psi, epsilon, signed_distance)
 # -
 
 # Let us visualise the location of the material interface that we have just initialised.
@@ -168,7 +156,7 @@ Ra = 3e5  # Thermal Rayleigh number
 # Compositional Rayleigh number, defined based on each material value and location
 RaB_dense = 4.5e5
 RaB_reference = 0.0
-RaB = material_field(psi, [RaB_dense, RaB_reference], interface="arithmetic")
+RaB = material_field(psi, [RaB_reference, RaB_dense], interface="arithmetic")
 
 approximation = BoussinesqApproximation(Ra, RaB=RaB)
 # -
@@ -205,19 +193,15 @@ temp_bcs = {boundary.bottom: {"T": 1}, boundary.top: {"T": 0}}
 # We move on to initialising the temperature field.
 
 # +
-X = SpatialCoordinate(mesh)  # Extract UFL representation of spatial coordinates
-
 # Calculate quantities linked to the temperature initial condition using UFL
 u0 = lx ** (7 / 3) / (1 + lx**4) ** (2 / 3) * (Ra / 2 / sqrt(pi)) ** (2 / 3)
 v0 = u0
 Q_ic = 2 * sqrt(lx / pi / u0)
-Tu = erf((1 - X[1]) / 2 * sqrt(u0 / X[0])) / 2
-Tl = 1 - 1 / 2 * erf(X[1] / 2 * sqrt(u0 / (lx - X[0])))
-Tr = 1 / 2 + Q_ic / 2 / sqrt(pi) * sqrt(v0 / (X[1] + 1)) * exp(
-    -(X[0] ** 2) * v0 / (4 * X[1] + 4)
-)
-Ts = 1 / 2 - Q_ic / 2 / sqrt(pi) * sqrt(v0 / (2 - X[1])) * exp(
-    -((lx - X[0]) ** 2) * v0 / (8 - 4 * X[1])
+Tu = erf((1 - y) / 2 * sqrt(u0 / x)) / 2
+Tl = 1 - 1 / 2 * erf(y / 2 * sqrt(u0 / (lx - x)))
+Tr = 1 / 2 + Q_ic / 2 / sqrt(pi) * sqrt(v0 / (y + 1)) * exp(-(x**2) * v0 / (4 * y + 4))
+Ts = 1 / 2 - Q_ic / 2 / sqrt(pi) * sqrt(v0 / (2 - y)) * exp(
+    -((lx - x) ** 2) * v0 / (8 - 4 * y)
 )
 
 # Interpolate temperature initial condition and ensure boundary condition values

--- a/gadopt/level_set_tools.py
+++ b/gadopt/level_set_tools.py
@@ -76,7 +76,8 @@ def assign_level_set_values(
     level_set: fd.Function,
     epsilon: float | fd.Function,
     /,
-    interface_geometry: str,
+    signed_distance: fd.Function | Expr | None = None,
+    interface_geometry: str | None = None,
     *,
     interface: sl.LineString | sl.Polygon | None = None,
     interface_coordinates: list[tuple[float, float]]
@@ -85,7 +86,7 @@ def assign_level_set_values(
     interface_callable: Callable | str | None = None,
     interface_args: tuple[Any, ...] | None = None,
     boundary_coordinates: list[tuple[float, float]] | None = None,
-):
+) -> None:
     """Updates level-set field given interface thickness and signed-distance function.
 
     Generates signed-distance function values at level-set nodes and overwrites
@@ -94,12 +95,18 @@ def assign_level_set_values(
     inside the geometrical object outlined by the interface alone or extended with
     domain boundary segments (to form a closed loop).
 
-    This function uses `Shapely` to generate a geometrical representation of the
-    interface. It handles simple base scenarios for which the interface can be described
-    by a plane curve, a polygonal chain (open or closed), or a circle. In these cases, a
-    mathematical description of the latter geometrical objects is sufficient to generate
-    the interface. For more complex objects, users should set up their own geometrical
-    representation via `Shapely` and provide it to this function.
+    In the most simple case, the signed-distance function can be expressed via Firedrake
+    objects, such as mesh coordinates. When this scenario is possible, providing
+    `signed_distance` as the only optional argument is sufficient to populate the
+    conservative level-set field.
+
+    When the above is not possible, this function uses `Shapely` to generate a
+    geometrical representation of the interface. It handles simple base scenarios for
+    which the interface can be described by a plane curve, a polygonal chain (open or
+    closed), or a circle. In these cases, a mathematical description of the latter
+    geometrical objects is sufficient to generate the interface. For more complex
+    objects, users should set up their own geometrical representation via `Shapely`
+    and provide it to this function.
 
     Currently implemented base scenarios to generate the signed-distance function:
     - The material interface is a plane curve described by a parametric equation of the
@@ -140,6 +147,8 @@ def assign_level_set_values(
         A Firedrake function for the targeted level-set field
       epsilon:
         A float or Firedrake function representing the interface thickness
+      signed_distance:
+        A Firedrake function or UFL expression representing the signed-distance function
       interface_geometry:
         A string specifying the geometry to create
       interface:
@@ -222,6 +231,15 @@ def assign_level_set_values(
             * interface.distance(sl.Point(x, y))
             for x, y in node_coordinates(level_set).dat.data
         ]
+
+    if signed_distance is not None:
+        level_set.interpolate((1 + fd.tanh(signed_distance / 2 / epsilon)) / 2)
+
+        return
+    elif interface_geometry is None:
+        raise ValueError(
+            "Either 'signed_distance' or 'interface_geometry' must be provided"
+        )
 
     if interface is not None and interface_geometry != "shapely":
         raise ValueError(


### PR DESCRIPTION
As pointed out in the last developer meeting, `assign_level_set_values` relies on `Shapely`. However, for extremely simple scenarios where the level set can be initialised via, for example, mesh coordinates, such a reliance should not be enforced. This PR allows the user to bypass `Shapely` in such simple cases. This change allows simplifying the setup of these scenarios (see updated demo) and brings some support to 3-D multi-material simulation in G-ADOPT (provided gh-254 gets merged).