### PR TITLE
Fix `get_boundary_ids` and `test_boundary_detection`

### DIFF
--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -512,13 +512,13 @@ def get_boundary_ids(mesh) -> SimpleNamespace:
     # in its own mesh creation functions.
 
     if mesh.topology_dm.hasLabel("Face Sets"):
-        axis_extremes_order = [["left", "right"], ["bottom", "top"], ["front", "back"]]
+        axis_extremes_order = [["left", "right"], ["bottom", "top"]]
         dim = mesh.geometric_dimension()
         plex_dim = mesh.topology_dm.getCoordinateDim()  # In an extruded mesh, this is different to the
         # firedrake-assigned geometric_dimension
-        if dim == 3 and plex_dim == 2:
-            # For extruded 3D meshes, we label dim[1] (y) as "front", "back" and dim[2] (z) as "bottom","top"
-            axis_extremes_order = [["left", "right"], ["front", "back"], ["bottom", "top"]]
+        if dim == 3:
+            # For 3D meshes, we label dim[1] (y) as "front", "back" and dim[2] (z) as "bottom","top"
+            axis_extremes_order.insert(1,["front", "back"])
         bounding_box = mesh.topology_dm.getBoundingBox()
         boundary_tol = [abs(dim[1] - dim[0]) * 1e-6 for dim in bounding_box]
         if dim > 3:

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -518,7 +518,7 @@ def get_boundary_ids(mesh) -> SimpleNamespace:
         # firedrake-assigned geometric_dimension
         if dim == 3:
             # For 3D meshes, we label dim[1] (y) as "front", "back" and dim[2] (z) as "bottom","top"
-            axis_extremes_order.insert(1,["front", "back"])
+            axis_extremes_order.insert(1, ["front", "back"])
         bounding_box = mesh.topology_dm.getBoundingBox()
         boundary_tol = [abs(dim[1] - dim[0]) * 1e-6 for dim in bounding_box]
         if dim > 3:

--- a/tests/unit/test_boundary_detection.py
+++ b/tests/unit/test_boundary_detection.py
@@ -39,18 +39,16 @@ def test_utility_meshes(mesh_name, ndim, args):
     else:
         assert boundary.left == 1
         assert boundary.right == 2
-        if ndim >= 2:
+        if ndim == 2:
             assert boundary.bottom == 3
             assert boundary.top == 4
-        else:
-            assert not hasattr(boundary, "bottom")
-            assert not hasattr(boundary, "top")
-        if ndim >= 3:
-            assert boundary.front == 5
-            assert boundary.back == 6
-        else:
             assert not hasattr(boundary, "front")
             assert not hasattr(boundary, "back")
+        if ndim == 3:
+            assert boundary.front == 3
+            assert boundary.back == 4
+            assert boundary.bottom == 5
+            assert boundary.top == 6
 
 
 @pytest.mark.parametrize("mesh_name,ndim,args", fd_supported_meshes)
@@ -78,18 +76,16 @@ def test_recover_from_checkpoint(mesh_name, ndim, args):
     else:
         assert boundary.left == 1
         assert boundary.right == 2
-        if ndim >= 2:
+        if ndim == 2:
             assert boundary.bottom == 3
             assert boundary.top == 4
-        else:
-            assert not hasattr(boundary, "bottom")
-            assert not hasattr(boundary, "top")
-        if ndim >= 3:
-            assert boundary.front == 5
-            assert boundary.back == 6
-        else:
             assert not hasattr(boundary, "front")
             assert not hasattr(boundary, "back")
+        if ndim == 3:
+            assert boundary.front == 3
+            assert boundary.back == 4
+            assert boundary.bottom == 5
+            assert boundary.top == 6
 
 
 # Make sure extruded meshes aren't adding subdomains we're not expecting

--- a/tests/unit/test_boundary_detection.py
+++ b/tests/unit/test_boundary_detection.py
@@ -142,7 +142,7 @@ def test_extruded_mesh_cubed_sphere_to_sphere():
     assert not hasattr(boundary, "back")
 
 
-geo_files = (Path(__file__).parents[1] / "multi_material" / "benchmarks").glob("*.geo")
+geo_files = (Path(__file__).parents[1] / "multi_material" / "benchmarks").glob("*/mesh/*.geo")
 
 
 @pytest.mark.parametrize("geo_name", geo_files)


### PR DESCRIPTION
Correct axis convention to z is depth for non-extruded 3D meshes in `get_boundary_ids`. Correct this in `test_boundary_detection` as well. Update paths to `mesh.geo` files in the `multi_material` tests.

Closes #253.