### PR TITLE
Fix warnings produced through unit tests

### DIFF
--- a/tests/unit/test_continuity.py
+++ b/tests/unit/test_continuity.py
@@ -21,22 +21,25 @@ def assert_normal_continuity(V, expected=True):
 
 
 def test_continuity():
-    """Test is_continuous and normal_is_continuous for functionspaces that we use
+    """Test is_continuous and normal_is_continuous for function spaces that we use
 
-    Should add tests here if we end up using more exotic functionspaces."""
+    Should add tests here if we end up using more exotic function spaces."""
     mesh1d = fd.UnitIntervalMesh(1)
     meshes = [
         fd.UnitSquareMesh(1, 1, quadrilateral=True),
         fd.UnitSquareMesh(1, 1, quadrilateral=False),
-        fd.ExtrudedMesh(mesh1d, 1)
+        fd.ExtrudedMesh(mesh1d, 1),
     ]
 
     for mesh in meshes:
+        mesh_cell = mesh.ufl_cell()
+        discontinuous_element = "DG" if mesh_cell == ufl.triangle else "DQ"
+
         P1 = fd.FunctionSpace(mesh, "CG", 1)
-        P1DG = fd.FunctionSpace(mesh, "DG", 1)
+        P1DG = fd.FunctionSpace(mesh, discontinuous_element, 1)
         assert_continuity(P1)
         assert_continuity(P1DG, expected=False)
-        if mesh.ufl_cell() == ufl.triangle:
+        if mesh_cell == ufl.triangle:
             RT1 = fd.FunctionSpace(mesh, "RT", 1)
             assert_continuity(RT1, expected=False)
             assert_normal_continuity(RT1)
@@ -46,11 +49,11 @@ def test_continuity():
         VP1 = fd.VectorFunctionSpace(mesh, "CG", 1)
         assert_continuity(VP1)
         assert_normal_continuity(VP1)
-        VDG1 = fd.VectorFunctionSpace(mesh, "DG", 1)
+        VDG1 = fd.VectorFunctionSpace(mesh, discontinuous_element, 1)
         assert_continuity(VDG1, expected=False)
         assert_normal_continuity(VDG1, expected=False)
 
-        if not isinstance(mesh.ufl_cell(), ufl.cell.TensorProductCell):
+        if not isinstance(mesh_cell, ufl.cell.TensorProductCell):
             mesh3d = fd.ExtrudedMesh(mesh, 1)
             V = get_functionspace(mesh3d, "CG", 1, "CG", 1)
             assert_continuity(V)
@@ -58,13 +61,13 @@ def test_continuity():
             V = get_functionspace(mesh3d, "CG", 1, "DG", 1)
             assert_continuity(V, expected=False)
             assert_normal_continuity(V, expected=False)
-            if mesh.ufl_cell() == ufl.triangle:
+            if mesh_cell == ufl.triangle:
                 N2_1 = fd.FiniteElement("N2curl", fd.triangle, 1, variant="integral")
                 CG_2 = fd.FiniteElement("CG", fd.interval, 2)
                 N2CG = fd.TensorProductElement(N2_1, CG_2)
                 Ned_horiz = fd.HCurlElement(N2CG)
                 P2tr = fd.FiniteElement("CG", fd.triangle, 2)
-                P1dg = fd.FiniteElement("DG", fd.interval, 1)
+                P1dg = fd.FiniteElement(discontinuous_element, fd.interval, 1)
                 P2P1 = fd.TensorProductElement(P2tr, P1dg)
                 Ned_vert = fd.HCurlElement(P2P1)
                 Ned_wedge = Ned_horiz + Ned_vert

--- a/tests/unit/test_extrusion_tools.py
+++ b/tests/unit/test_extrusion_tools.py
@@ -7,7 +7,6 @@ def test_extend_function_to_3d():
     mesh2d = fd.UnitSquareMesh(5, 5)
     mesh3d = fd.ExtrudedMesh(mesh2d, 5, layer_height=1.)
     V2d = fd.FunctionSpace(mesh2d, "CG", 1)
-    x, y = fd.SpatialCoordinate(mesh2d)
-    u2d = fd.interpolate(x, V2d)
+    u2d = fd.Function(V2d).interpolate(fd.SpatialCoordinate(mesh2d)[0])
     u3d = extend_function_to_3d(u2d, mesh3d)
     np.testing.assert_allclose(fd.assemble(u3d * fd.dx), 2.5)


### PR DESCRIPTION
Current unit-test execution produces warnings, namely:
- `UserWarning: Discontinuous Lagrange element requested on quadrilateral, creating DQ element.`
- `UserWarning: Discontinuous Lagrange element requested on interval * interval, creating DQ element.`
- `FutureWarning: The use of 'interpolate' to perform the numerical interpolation is deprecated.`
- `UserWarning: PyOP2.Global has no comm, this is likely to break in parallel!`

This PR proposes changes to prevent warning occurrences.