### PR TITLE
Fix LFS path in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-demos/adjoint_2d_cylindrical/Checkpoint230.h5 filter=lfs diff=lfs merge=lfs -text
+demos/mantle_convection/adjoint_2d_cylindrical/Checkpoint230.h5 filter=lfs diff=lfs merge=lfs -text
 tests/2d_cylindrical_TALA_DG/initial_condition_mat_prop/Final_State.h5 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
I guess because we're not (currently) using this test, the fact that its LFS checkout hasn't been working since we migrated the demo structure has never come up! The object it references is still on the server, so after fixing this we can `git lfs checkout` to get the file in place.