### PR TITLE
Remove "exercise" tags from rendered output

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - name: Install Git LFS
         run: |
-          sudo apt update
-          sudo apt install -y git-lfs
+          apt update
+          apt install -y git-lfs
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -34,7 +34,7 @@ jobs:
         env:
           S3CONFIG: ${{ secrets.S3CONFIG }}
         run: |
-          sudo apt install -y xvfb gmsh gh s3cmd unzip
+          apt install -y xvfb gmsh gh s3cmd unzip
 
           mkdir -p $HOME/.s3cfg
           echo "${S3CONFIG}" > $HOME/.s3cfg/config
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set up for network namespacing
         run: |
-          sudo apt install -y uidmap iproute2
+          apt install -y uidmap iproute2
           . .venv/bin/activate
           jupytext_location="$(which jupytext)"
           cp .testing/jupytext "$jupytext_location"

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -44,4 +44,7 @@ check:
 # port and writes that to a connection file. this is of course completely prone to race conditions.
 # instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
 %.ipynb: %.py
-	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))
+	jupytext --to ipynb $<
+	jupyter nbconvert --to notebook --execute \
+		--TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags='["exercise"]' \
+		$@ --output $@

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -45,6 +45,6 @@ check:
 # instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
 %.ipynb: %.py
 	jupytext --to ipynb $<
-	jupyter nbconvert --to notebook --execute \
+	jupyter nbconvert --to notebook --execute --inplace \
 		--TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags='["exercise"]' \
-		$@ --output $@
+		$@


### PR DESCRIPTION
It could also be useful to use the "skip-execution" tag on these cells, so they can have stub/invalid code in them. I've written a bit of documentation, including these tags [on the wiki](https://github.com/g-adopt/g-adopt/wiki/Writing-tutorials).

Closes #248