### PR TITLE
Implement a non-recursive Makefile structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.vtu
 *.h5
 __pycache__/
+
+# test artifacts
+.done
+params.log

--- a/.rules.mk
+++ b/.rules.mk
@@ -82,3 +82,31 @@ endef
 
 %.ipynb: %.py
 	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))
+
+# recurse into subdirs
+define include_subdir =
+dir := $(dir)
+include $$(dir)/Makefile
+endef
+
+# for defining the targets within e.g. demos or tests
+# this relies on make_targets having been called within the
+# directory within the "usual" path
+define subdir_targets =
+.PHONY: $(1) clean-$(1)
+$(1):
+	$$(MAKE) -C .. $(2)/$(1)
+
+clean-$(1):
+	$$(MAKE) -C .. clean-$(2)/$(1)
+endef
+
+# for defining the targets of the current directory
+define make_targets =
+.PHONY: $(1) clean-$(1)
+$(1): $$(TGT_$(1))
+
+clean-$(1):
+	rm -f $$(CLEAN_$(1))
+	rm -rf $$(DIR_CLEAN_$(1))
+endef

--- a/.rules.mk
+++ b/.rules.mk
@@ -63,7 +63,7 @@ run_cmd = $(if $(BATCH_MODE),$(run_batch),$(run_regular))
 # to mpiexec, and additional command line arguments.
 # Should not be called directly.
 
-exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETSC_FLAGS) $(exec_args)
+exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $(notdir $<) $(PETSC_FLAGS) $(exec_args)
 
 #
 # Canned recipe
@@ -77,14 +77,5 @@ exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $< $(PETS
 #   	$(run-python)
 
 define run-python =
-@$(call run_cmd,$(exec_cmd),$(or $(desc),$<))
+@(cd $(dir $<); $(call run_cmd,$(exec_cmd),$(or $(desc),$(notdir $<))))
 endef
-
-# Test-related variables
-# ----------------------
-#
-# These are expansion rules that can be used to call the generic test_all.py
-# with reference to the current test/demo.
-
-current_dir = $(notdir $(patsubst %/,%,$(CURDIR)))
-test_class = $(notdir $(patsubst %/,%,$(dir $(CURDIR))))

--- a/.rules.mk
+++ b/.rules.mk
@@ -79,3 +79,6 @@ exec_cmd = $(if $(filter-out 1,$(ncpus)),mpiexec -np $(ncpus)) python3 $(notdir 
 define run-python =
 @(cd $(dir $<); $(call run_cmd,$(exec_cmd),$(or $(desc),$(notdir $<))))
 endef
+
+%.ipynb: %.py
+	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint all-tests demos clean check
+.PHONY: lint all-tests clean check
 
 lint:
 	@echo "Linting module code"

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ include .rules.mk
 dir := demos
 include $(dir)/Makefile
 
-# dir := tests
-# include $(dir)/Makefile
+dir := tests
+include $(dir)/Makefile
 
 all-tests: demos tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Welcome to the G-ADOPT Makefile!
+#
+# This top-level file drives all the automation in the repository. We
+# have, of course, the famous "lint" target that checks for some
+# degree of code style consistency. The main show is the ability to
+# run the tests and demos, and convert the demos to notebooks.
+#
+# For an explanation of how the individual cases are run, check out
+# the .rules.mk file: this dispatches between different methods
+# depending on whether we're using a "batch mode" and also the number
+# of cores required.
+
+# The following tasks are not linked to any real files and are thus
+# always considered "out of date" and executed when requested.
 .PHONY: lint all-tests clean check
 
 lint:
@@ -6,6 +20,18 @@ lint:
 	@echo "Linting demos and tests"
 	@python3 -m flake8 demos tests
 
+# Here begins the fun of the testing system. In order to give Make a
+# global view of the project, and to allow for dependencies between
+# different cases, we're using a non-recursive structure. However, we
+# don't want to encode all of our logic within the one Makefile! Each
+# Makefile is responsible for including all of its children, but also
+# keeping track of *where* that child is with respect to the top-level
+# directory of the project.
+#
+# For example, a test would need to define a target like
+# "tests/example/.done", but we keep a directory stack so that test
+# only has to refer to "$(d)/.done". Look into the following Makefiles
+# for a bit more information on how this mechanism is implemented.
 include .rules.mk
 
 dir := demos
@@ -14,11 +40,16 @@ include $(dir)/Makefile
 dir := tests
 include $(dir)/Makefile
 
+# At this point, all the file targets within the project are
+# defined. We can just define a few more meta-targets: one to run all
+# the test cases.
 all-tests: demos tests
 
+# ...one to run the cases, *and* run pytest (which will include the unit tests)
 check: all-tests
 	python3 -m pytest -m "not longtest"
 
+# ...and one to clean up *all* test artifacts.
 clean:
 	rm -f $(CLEAN)
 	rm -rf $(DIR_CLEAN)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test longtest longtest_output convert_demos
+.PHONY: lint all-tests demos clean check
 
 lint:
 	@echo "Linting module code"
@@ -6,21 +6,19 @@ lint:
 	@echo "Linting demos and tests"
 	@python3 -m flake8 demos tests
 
-test:
-	$(MAKE) -C demos & $(MAKE) -C tests & wait
+include .rules.mk
 
-longtest:
-	$(MAKE) -C tests longtest
+dir := demos
+include $(dir)/Makefile
 
-longtest_output:
-	$(MAKE) -C tests longtest_output
+# dir := tests
+# include $(dir)/Makefile
 
-# convert demo Python scripts to executed notebooks
-convert_demos:
-	$(MAKE) -C demos convert_demos
+all-tests: demos tests
+
+check: all-tests
+	python3 -m pytest -m "not longtest"
 
 clean:
-	$(MAKE) -C demos clean & $(MAKE) -C tests clean & wait
-
-check:
-	python -m pytest -m 'not longtest'
+	rm -f $(CLEAN)
+	rm -rf $(DIR_CLEAN)

--- a/demos/.rules.mk
+++ b/demos/.rules.mk
@@ -1,0 +1,21 @@
+# Standalone demos
+# ----------------
+#
+# This rule dispatches to the .done and .clean targets that are part
+# of $(default_targets) for running a demo standalone within its own directory.
+
+define standalone =
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
+
+.PHONY: all
+all: .done
+
+# This is the important rule that dispatches to the "real" Make
+# workflow to run the case if necessary.
+.done:
+	$$(MAKE) -C ../../.. $$(cwd)/.done
+
+.PHONY: clean
+clean:
+	$$(MAKE) -C ../../../ $$(cwd)/.clean
+endef

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,37 +1,45 @@
-all: targets
-
-include ../.rules.mk
-
-define include_subdir =
-dir := $(dir)
-include $$(dir)/Makefile
-endef
-
-define subdir_targets =
-.PHONY: $(1) clean-$(1)
-$(1): $$(TGT_$(1))
-
-clean-$(1):
-	rm -f $$(CLEAN_$(1))
-	rm -rf $$(DIR_CLEAN_$(1))
-endef
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
 subdirs := mantle_convection multi_material glacial_isostatic_adjustment PDE_constrained_optimisation
 
-$(foreach dir,$(subdirs),$(eval $(include_subdir)))
+ifeq ($(d),)
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-.PHONY: targets
-targets: $(TGT)
+# all direct-execution targets in this directory
+.PHONY: all
+all:
+	$(MAKE) -C .. $(cwd)
+
+.PHONY: check
+check:
+	pytest -k 'not ../tests'
+
+.PHONY: clean
+clean:
+	$(MAKE) -C .. clean-$(cwd)
+
+# create a target for each of the subdirs
+include ../.rules.mk
+$(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir),$(cwd))))
+
+else
+
+$(foreach dir,$(addprefix $(d)/,$(subdirs)),$(eval $(include_subdir)))
 
 notebook_files := $(NOTEBOOK_SRC:.py=.ipynb)
-artifact.tar: $(notebook_files) .pages .diagram.mermaid
+$(d)/artifact.tar: $(notebook_files) $(d)/.pages $(d)/.diagram.mermaid
 	tar --transform='s/.pages/CONTENTS.md/' --create --file $@ $(filter-out %.ipynb,$^)
 	tar --transform='s|/.*/|/|' --append --file $@ $(notebook_files)
 	$(foreach image,$(NOTEBOOK_IMGS),tar --append --file $@ $(image) ;)
 
-$(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir))))
+TGT_$(d) := $(filter $(d)/%,$(TGT))
+CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 
-.PHONY: clean
-clean:
-	rm -f $(CLEAN)
-	rm -rf $(DIR_CLEAN)
+$(eval $(call make_targets,$(d)))
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -14,7 +14,7 @@ all:
 
 .PHONY: check
 check:
-	pytest -k 'not ../tests'
+	python3 -m pytest -k "not ../tests"
 
 .PHONY: clean
 clean:

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,47 +1,31 @@
-include makefile.cases.inc
+all: targets
 
-.PHONY: all convert_demos clean generate $(mc_cases) $(mm_cases) $(gia_cases) $(extra_cases) $(mc_dir) $(mm_dir) $(gia_dir)
+include ../.rules.mk
 
-all: $(mc_cases) $(mm_cases) $(gia_cases) $(extra_cases)
+define include_subdir =
+dir := $(dir)
+include $$(dir)/Makefile
+endef
 
-convert_demos: $(notebook_files) .pages .diagram.mermaid
-	tar --transform='s/.pages/CONTENTS.md/' --create --file artifact.tar .pages .diagram.mermaid
-	tar --transform='s|/.*/|/|' --append --file artifact.tar $(notebook_files)
-	tar --append --file artifact.tar $(mc_dir)/free_surface/temperature_warp.gif
-	tar --append --file artifact.tar $(gia_dir)/base_case/displacement_warp.gif
-	tar --append --file artifact.tar $(gia_dir)/2d_cylindrical/displacement_warp.gif
+define subdir_targets =
+.PHONY: $(1) clean-$(1)
+$(1): $$(TGT_$(1))
 
-# explicit dependencies between notebooks
-# adjoint uses the checkpoint from the forward run
-$(mc_dir)/adjoint/adjoint.ipynb: $(mc_dir)/adjoint/adjoint_forward.ipynb
+clean-$(1):
+	rm -f $$(CLEAN_$(1))
+	rm -rf $$(DIR_CLEAN_$(1))
+endef
 
-# free surface has a comparison plot against the base case
-$(mc_dir)/free_surface/free_surface.ipynb: $(mc_dir)/base_case/base_case.ipynb
+subdirs := mantle_convection multi_material glacial_isostatic_adjustment PDE_constrained_optimisation
 
-# dynamic topography requires the checkpoint from the base case
-$(mc_dir)/dynamic_topography/dynamic_topography.ipynb: $(mc_dir)/base_case/base_case.ipynb
+$(foreach dir,$(subdirs),$(eval $(include_subdir)))
 
-### make mantle_convection/base_case should just run the mantle_convection/base_case demo
-### make mantle_convection should run all mantle convection demos
-$(all_cases) $(mc_dir) $(mm_dir) $(gia_dir):
-	$(MAKE) -C $@
+.PHONY: targets
+targets: $(TGT)
 
-generate:
-	python3 generate_expected.py
+$(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir))))
 
+.PHONY: clean
 clean:
-	rm -rf __pycache__
-	@$(foreach case, $(all_cases), \
-		$(MAKE) -C $(case) $(MAKECMDGOALS) ; \
-	)
-
-check:
-	python3 -m pytest -m demo
-
-# pattern rule for executing demo scripts as a notebook
-# because jupyter is an insane jumble of components, there's absolutely no way to configure it
-# to try to bind to its control port when it needs it. instead, the provisioner checks for a free
-# port and writes that to a connection file. this is of course completely prone to race conditions.
-# instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
-%.ipynb: %.py
-	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))
+	rm -f $(CLEAN)
+	rm -rf $(DIR_CLEAN)

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -23,6 +23,12 @@ $(foreach dir,$(subdirs),$(eval $(include_subdir)))
 .PHONY: targets
 targets: $(TGT)
 
+notebook_files := $(NOTEBOOK_SRC:.py=.ipynb)
+artifact.tar: $(notebook_files) .pages .diagram.mermaid
+	tar --transform='s/.pages/CONTENTS.md/' --create --file $@ $(filter-out %.ipynb,$^)
+	tar --transform='s|/.*/|/|' --append --file $@ $(notebook_files)
+	$(foreach image,$(NOTEBOOK_IMGS),tar --append --file $@ $(image) ;)
+
 $(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir))))
 
 .PHONY: clean

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,13 +1,25 @@
+# Welcome to the Makefile for all the demos
+#
+# This Makefile is part of a "recursive inclusion system". At the top,
+# we maintain a directory stack, so that the $(d) variable ends up
+# where it should be once we've processed this file. To refer to the
+# current directory of a given Makefile, this is also the variable we
+# should be using!
 sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
-subdirs := mantle_convection multi_material glacial_isostatic_adjustment PDE_constrained_optimisation
+# These are the subdirectories for recursive processing. In general,
+# we try not to pollute the global variable "namespace", so we suffix
+# things by the current directory.
+subdirs_$(d) := mantle_convection multi_material glacial_isostatic_adjustment PDE_constrained_optimisation
 
 ifeq ($(d),)
+# If we execute "make" within the demos/ directory, it would be nice
+# to do something sensible. We call the main Makefile, and can run the
+# test cases, check their correctness, or clean all artifacts.
 cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-# all direct-execution targets in this directory
 .PHONY: all
 all:
 	$(MAKE) -C .. $(cwd)
@@ -20,20 +32,43 @@ check:
 clean:
 	$(MAKE) -C .. clean-$(cwd)
 
-# create a target for each of the subdirs
+# Because each of the subdirectories is actually a "category", we
+# provide an additional target to run the tests specific to that
+# subdirectory directly.
+#
+# The documentation gets more sparse as we go, but you can check out
+# the mantle_convection/Makefile for an idea of how the category-level
+# Makefiles work.
 include ../.rules.mk
-$(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir),$(cwd))))
+$(foreach dir,$(subdirs_$(d)),$(eval $(call subdir_targets,$(dir),$(cwd))))
 
 else
+# Otherwise, we were included from the Makefile at the level above us,
+# and should continue to build out the tree.
+$(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-$(foreach dir,$(addprefix $(d)/,$(subdirs)),$(eval $(include_subdir)))
-
+# For the demos specifically, we have a second purpose: to convert the
+# demos to jupyter notebooks that serve as tutorials. This target
+# performs the conversion, then builds an archive containing the
+# notebooks and some supplementary files (a page index and flowchart,
+# and any external images that were generated and recorded in
+# $(NOTEBOOK_IMGS)).
 notebook_files := $(NOTEBOOK_SRC:.py=.ipynb)
 $(d)/artifact.tar: $(notebook_files) $(d)/.pages $(d)/.diagram.mermaid
 	tar --transform='s/.pages/CONTENTS.md/' --create --file $@ $(filter-out %.ipynb,$^)
 	tar --transform='s|/.*/|/|' --append --file $@ $(notebook_files)
 	$(foreach image,$(NOTEBOOK_IMGS),tar --append --file $@ $(image) ;)
 
+# Here is the pattern rule for converting a notebook from its linked
+# jupytext source file. The $< automatic variable is the name of the
+# first prerequisite (i.e. the source file), and we also make sure to
+# change to the directory containing the source file so path
+# references, etc. make sense from the viewpoint of the script.
+%.ipynb: %.py
+	jupytext --to ipynb --execute $< --run-path $(dir $(abspath $<))
+
+# Finally, we create the standalone build and clean targets for this
+# directory.
 TGT_$(d) := $(filter $(d)/%,$(TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
@@ -41,5 +76,7 @@ DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 $(eval $(call make_targets,$(d)))
 endif
 
+# This is the bookkeeping for a stack that returns $(d) to where it
+# was, so it continues to work after including sub-Makefiles.
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/PDE_constrained_optimisation/.gitignore
+++ b/demos/PDE_constrained_optimisation/.gitignore
@@ -1,0 +1,2 @@
+functional_boundary.txt
+functional_field.txt

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done $(d)/test_pde_constrained_optimisation.py
+	python3 -m pytest $(d)/test_pde_constrained_optimisation.py
+
+else
+
 CASES_$(d) := $(d)/functional_boundary.txt $(d)/functional_field.txt
 
 $(d)/.done: $(CASES_$(d))
@@ -19,11 +37,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done $(d)/test_pde_constrained_optimtisation.py
-	python3 -m pytest $(d)/test_pde_constrained_optimtisation.py
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -1,18 +1,30 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := functional_boundary.txt functional_field.txt
+CASES_$(d) := $(d)/functional_boundary.txt $(d)/functional_field.txt
 
-.PHONY: all clean check
+$(d)/.done: $(CASES_$(d))
+	@touch $@
 
-all: $(cases)
-
-functional_%.txt : category := pde_constrained
-$(cases): functional_%.txt: PDE_constrained_%.py
+$(CASES_$(d)) : category := pde_constrained
+$(CASES_$(d)): $(d)/functional_%.txt: $(d)/PDE_constrained_%.py
 	$(run-python)
 
-clean:
-	rm $(cases) *.h5
-	rm -rf __pycache__
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := $(CASES_$(d)) *.h5
+DIR_CLEAN_$(d) := __pycache__
 
-check: $(cases)
-	python3 -m pytest test_pde_constrained_optimisation.py
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done $(d)/test_pde_constrained_optimtisation.py
+	python3 -m pytest $(d)/test_pde_constrained_optimtisation.py
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done $(d)/test_pde_constrained_optimisation.py

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -20,19 +20,19 @@ check: $(d)/.done $(d)/test_pde_constrained_optimisation.py
 
 else
 
-TGT_$(d) := $(d)/.done
-SRC_$(d) := $(d)/PDE_constrained_boundary.py $(d)/PDE_constrained_field.py
+CASES_$(d) := boundary field
+
+TGT_$(d) := $(CASES_$(d):%=$(d)/functional_%.txt)
+SRC_$(d) := $(CASES_$(d):%=$(d)/PDE_constrained_%.py)
 NOTEBOOK_SRC_$(d) := $(d)/PDE_constrained_boundary.py $(d)/PDE_constrained_field.py
 CLEAN_$(d) := $(CASES_$(d)) *.h5
 DIR_CLEAN_$(d) := __pycache__
 
-CASES_$(d) := $(d)/functional_boundary.txt $(d)/functional_field.txt
-
-$(d)/.done: $(CASES_$(d))
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
-$(CASES_$(d)) : category := pde_constrained
-$(CASES_$(d)): $(d)/functional_%.txt: $(d)/PDE_constrained_%.py
+$(TGT_$(d)) : category := pde_constrained
+$(TGT_$(d)): $(d)/functional_%.txt: $(d)/PDE_constrained_%.py
 	$(run-python)
 
 TGT := $(TGT) $(TGT_$(d))

--- a/demos/PDE_constrained_optimisation/Makefile
+++ b/demos/PDE_constrained_optimisation/Makefile
@@ -20,6 +20,12 @@ check: $(d)/.done $(d)/test_pde_constrained_optimisation.py
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/PDE_constrained_boundary.py $(d)/PDE_constrained_field.py
+NOTEBOOK_SRC_$(d) := $(d)/PDE_constrained_boundary.py $(d)/PDE_constrained_field.py
+CLEAN_$(d) := $(CASES_$(d)) *.h5
+DIR_CLEAN_$(d) := __pycache__
+
 CASES_$(d) := $(d)/functional_boundary.txt $(d)/functional_field.txt
 
 $(d)/.done: $(CASES_$(d))
@@ -29,11 +35,8 @@ $(CASES_$(d)) : category := pde_constrained
 $(CASES_$(d)): $(d)/functional_%.txt: $(d)/PDE_constrained_%.py
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := $(CASES_$(d)) *.h5
-DIR_CLEAN_$(d) := __pycache__
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -20,14 +20,14 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/2d_cylindrical.py $(d)/unstructured_annulus.py
 NOTEBOOK_SRC_$(d) := $(d)/2d_cylindrical.py
 NOTEBOOK_IMGS_$(d) := $(d)/displacement_warp.gif
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
 DIR_CLEAN_$(d) := output density ice mesh viscosity __pycache__
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := gia

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -23,6 +23,7 @@ else
 TGT_$(d) := $(d)/.done
 SRC_$(d) := $(d)/2d_cylindrical.py $(d)/unstructured_annulus.py
 NOTEBOOK_SRC_$(d) := $(d)/2d_cylindrical.py
+NOTEBOOK_IMGS_$(d) := $(d)/displacement_warp.gif
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
 DIR_CLEAN_$(d) := output density ice mesh viscosity __pycache__
 
@@ -35,6 +36,7 @@ $(d)/params.log: $(SRC_$(d))
 
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
+NOTEBOOK_IMGS := $(NOTEBOOK_IMGS) $(NOTEBOOK_IMGS_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := gia
-params.log: 2d_cylindrical.py
+$(d)/params.log : category := gia
+$(d)/params.log: $(d)/2d_cylindrical.py $(d)/unstructured_annulus.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif
-	rm -rf output density ice mesh viscosity __pycache__
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
+DIR_CLEAN_$(d) := output density ice mesh viscosity __pycache__
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -20,18 +20,21 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/2d_cylindrical.py $(d)/unstructured_annulus.py
+NOTEBOOK_SRC_$(d) := $(d)/2d_cylindrical.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
+DIR_CLEAN_$(d) := output density ice mesh viscosity __pycache__
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := gia
-$(d)/params.log: $(d)/2d_cylindrical.py $(d)/unstructured_annulus.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
-DIR_CLEAN_$(d) := output density ice mesh viscosity __pycache__
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/glacial_isostatic_adjustment/Makefile
+++ b/demos/glacial_isostatic_adjustment/Makefile
@@ -1,18 +1,14 @@
-include ../makefile.cases.inc
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(notdir $(gia_cases))
+subdirs_$(d) := base_case 2d_cylindrical
 
-.PHONY: all $(cases) clean check
+$(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-all: $(cases)
+TGT_$(d) := $(filter $(dir)/%,$(TGT))
+CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
 
-$(cases):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-clean:
-	@$(foreach case, $(cases), \
-		$(MAKE) -C $(case) $(MAKECMDGOALS); \
-	)
-
-check: $(cases)
-	python -m pytest $(CURDIR)/../test_all.py -k $(gia_dir)
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/glacial_isostatic_adjustment/Makefile
+++ b/demos/glacial_isostatic_adjustment/Makefile
@@ -2,6 +2,19 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+
+.PHONY: all
+all:
+	$(MAKE) -C .. $(cwd)
+
+.PHONY: check
+check: all
+	pytest ../test_all.py . -k $(cwd)
+
+else
+
 subdirs_$(d) := base_case 2d_cylindrical
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
@@ -9,6 +22,8 @@ $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 TGT_$(d) := $(filter $(d)/%,$(TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
+
+endif
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/glacial_isostatic_adjustment/Makefile
+++ b/demos/glacial_isostatic_adjustment/Makefile
@@ -6,9 +6,9 @@ subdirs_$(d) := base_case 2d_cylindrical
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-TGT_$(d) := $(filter $(dir)/%,$(TGT))
-CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
-DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
+TGT_$(d) := $(filter $(d)/%,$(TGT))
+CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -20,18 +20,21 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/base_case.py
+NOTEBOOK_SRC_$(d) := $(d)/base_case.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := gia
-$(d)/params.log: $(d)/base_case.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -23,6 +23,7 @@ else
 TGT_$(d) := $(d)/.done
 SRC_$(d) := $(d)/base_case.py
 NOTEBOOK_SRC_$(d) := $(d)/base_case.py
+NOTEBOOK_IMGS_$(d) := $(d)/displacement_warp.gif
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
 DIR_CLEAN_$(d) := output
 
@@ -35,6 +36,7 @@ $(d)/params.log: $(SRC_$(d))
 
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
+NOTEBOOK_IMGS := $(NOTEBOOK_IMGS) $(NOTEBOOK_IMGS_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := gia
-params.log: base_case.py
+$(d)/params.log : category := gia
+$(d)/params.log: $(d)/base_case.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.gif
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.gif params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/glacial_isostatic_adjustment/base_case/Makefile
+++ b/demos/glacial_isostatic_adjustment/base_case/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -20,19 +20,22 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/2d_compressible_ALA.py
+NOTEBOOK_SRC_$(d) := $(d)/2d_compressible_ALA.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
-$(d)/params.log: $(d)/2d_compressible_ALA.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output reference_state
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: 2d_compressible_ALA.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/2d_compressible_ALA.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output reference_state
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/2d_compressible_ALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_ALA/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/2d_compressible_ALA.py
 NOTEBOOK_SRC_$(d) := $(d)/2d_compressible_ALA.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output reference_state
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -20,19 +20,22 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/2d_compressible_TALA.py
+NOTEBOOK_SRC_$(d) := $(d)/2d_compressible_TALA.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
-$(d)/params.log: $(d)/2d_compressible_TALA.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output reference_state
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/2d_compressible_TALA.py
 NOTEBOOK_SRC_$(d) := $(d)/2d_compressible_TALA.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output reference_state
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: 2d_compressible_TALA.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/2d_compressible_TALA.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output reference_state
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/2d_compressible_TALA/Makefile
+++ b/demos/mantle_convection/2d_compressible_TALA/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: 2d_cylindrical.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/2d_cylindrical.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -20,19 +20,22 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/2d_cylindrical.py
+NOTEBOOK_SRC_$(d) := $(d)/2d_cylindrical.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
-$(d)/params.log: $(d)/2d_cylindrical.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output reference_state
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/2d_cylindrical/Makefile
+++ b/demos/mantle_convection/2d_cylindrical/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/2d_cylindrical.py
 NOTEBOOK_SRC_$(d) := $(d)/2d_cylindrical.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output reference_state
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/3d_cartesian.py
 NOTEBOOK_SRC_$(d) := $(d)/3d_cartesian.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output reference_state
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -20,19 +20,22 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/3d_cartesian.py
+NOTEBOOK_SRC_$(d) := $(d)/3d_cartesian.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
-$(d)/params.log: $(d)/3d_cartesian.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output reference_state
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: 3d_cartesian.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/3d_cartesian.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output reference_state
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/3d_cartesian/Makefile
+++ b/demos/mantle_convection/3d_cartesian/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: 3d_spherical.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/3d_spherical.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -20,17 +20,17 @@ check: $(d)/.done
 
 else
 
-$(d)/.done: $(d)/params.log
+TGT_$(d) := $(d)/params.log
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
 $(d)/params.log: $(d)/3d_spherical.py
 	$(run-python)
-
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
 
 TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))

--- a/demos/mantle_convection/3d_spherical/Makefile
+++ b/demos/mantle_convection/3d_spherical/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -2,6 +2,19 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+
+.PHONY: all
+all:
+	$(MAKE) -C .. $(cwd)
+
+.PHONY: check
+check: all
+	pytest ../test_all.py . -k $(cwd)
+
+else
+
 subdirs_$(d) := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_case 2d_cylindrical 3d_spherical 3d_cartesian adjoint gplates_global free_surface dynamic_topography
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
@@ -9,6 +22,8 @@ $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 TGT_$(d) := $(filter $(d)/%,$(TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
+
+endif
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -1,8 +1,13 @@
+# Makefile stack management, refer to demos/Makefile for an idea of
+# what this does and why it's needed. Or, if you're interested in how
+# a specific case is implemented, check out base_case/Makefile.
 sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
 ifeq ($(d),)
+# If we execute "make" within this directory, we provide targets to
+# build and check all the contained cases.
 cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
 .PHONY: all
@@ -15,10 +20,13 @@ check: all
 
 else
 
+# Otherwise, we're in the recursive inclusion process, and need to
+# include all the cases we're responsible for.
 subdirs_$(d) := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_case 2d_cylindrical 3d_spherical 3d_cartesian adjoint gplates_global free_surface dynamic_topography
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
+# These category-specific collections of targets are used at the level above.
 TGT_$(d) := $(filter $(d)/%,$(TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -1,21 +1,14 @@
-include ../makefile.cases.inc
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(notdir $(mc_cases))
+subdirs_$(d) := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_case 2d_cylindrical 3d_spherical 3d_cartesian adjoint gplates_global free_surface dynamic_topography
 
-.PHONY: all $(cases) clean check
+$(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-all: $(cases)
+TGT_$(d) := $(filter $(dir)/%,$(TGT))
+CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
 
-# dynamic topography must come after base case
-dynamic_topography: .WAIT base_case
-
-$(cases):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-clean:
-	@$(foreach case, $(cases), \
-		$(MAKE) -C $(case) $(MAKECMDGOALS); \
-	)
-
-check: $(cases)
-	python -m pytest $(CURDIR)/../test_all.py -k $(mc_dir)
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/Makefile
+++ b/demos/mantle_convection/Makefile
@@ -6,9 +6,9 @@ subdirs_$(d) := base_case 2d_compressible_ALA 2d_compressible_TALA viscoplastic_
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-TGT_$(d) := $(filter $(dir)/%,$(TGT))
-CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
-DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
+TGT_$(d) := $(filter $(d)/%,$(TGT))
+CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/mantle_convection/adjoint/.gitignore
+++ b/demos/mantle_convection/adjoint/.gitignore
@@ -1,0 +1,1 @@
+functional.txt

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -1,20 +1,33 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/functional.txt
+	@touch $@
 
-all: functional.txt
-
-functional.txt : category := mantle_convection
-functional.txt: adjoint.py adjoint-demo-checkpoint-state.h5
+$(d)/functional.txt : category := mantle_convection
+$(d)/functional.txt: $(d)/adjoint.py $(d)/adjoint-demo-checkpoint-state.h5
 	$(run-python)
 
-adjoint-demo-checkpoint-state.h5 : category := mantle_convection
-adjoint-demo-checkpoint-state.h5 : ncpus := 2
-adjoint-demo-checkpoint-state.h5: adjoint_forward.py
+$(d)/adjoint-demo-checkpoint-state.h5 : category := mantle_convection
+$(d)/adjoint-demo-checkpoint-state.h5 : ncpus := 2
+$(d)/adjoint-demo-checkpoint-state.h5: $(d)/adjoint_forward.py
 	$(run-python)
 
-clean:
-	rm -rf functional.txt *.h5 *.pvd solutions solution visualisation_vtk optimisation_checkpoint
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := functional.txt *.h5 *.pvd .done
+DIR_CLEAN_$(d) := solutions solution visualisation_vtk optimisation_checkpoint
 
-check: functional.txt
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
 	python3 -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -20,6 +20,12 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/adjoint.py $(d)/adjoint_forward.py
+NOTEBOOK_SRC_$(d) := $(d)/adjoint.py $(d)/adjoint_forward.py
+CLEAN_$(d) := functional.txt *.h5 *.pvd .done
+DIR_CLEAN_$(d) := solutions solution visualisation_vtk optimisation_checkpoint
+
 $(d)/.done: $(d)/functional.txt
 	@touch $@
 
@@ -32,11 +38,12 @@ $(d)/adjoint-demo-checkpoint-state.h5 : ncpus := 2
 $(d)/adjoint-demo-checkpoint-state.h5: $(d)/adjoint_forward.py
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := functional.txt *.h5 *.pvd .done
-DIR_CLEAN_$(d) := solutions solution visualisation_vtk optimisation_checkpoint
+# we also need the ordering between the notebooks to ensure
+# the forward is executed first
+$(d)/adjoint.ipynb: $(d)/adjoint_forward.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
 $(d)/.done: $(d)/functional.txt
 	@touch $@
 
@@ -22,11 +40,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/adjoint/Makefile
+++ b/demos/mantle_convection/adjoint/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/functional.txt
 SRC_$(d) := $(d)/adjoint.py $(d)/adjoint_forward.py
 NOTEBOOK_SRC_$(d) := $(d)/adjoint.py $(d)/adjoint_forward.py
 CLEAN_$(d) := functional.txt *.h5 *.pvd .done
 DIR_CLEAN_$(d) := solutions solution visualisation_vtk optimisation_checkpoint
 
-$(d)/.done: $(d)/functional.txt
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/functional.txt : category := mantle_convection

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -20,18 +20,21 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/base_case.py
+NOTEBOOK_SRC_$(d) := $(d)/base_case.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
-$(d)/params.log: $(d)/base_case.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/base_case.py
 NOTEBOOK_SRC_$(d) := $(d)/base_case.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log: base_case.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log: $(d)/base_case.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -1,35 +1,23 @@
 # Makefile stack management, refer to demos/Makefile for an idea of
 # what this does and why it's needed.
-sp := $(sp).x
-dirstack_$(sp) := $(d)
-d := $(dir)
+$(eval $(header))
 
 ifeq ($(d),)
 # If we're working on a single case, it's probably a bit easier to be
 # running a tighter development loop within its directory
 # specifically. We define targets specific to this directory, so we
 # can run "make check" to ensure the tests are still passing!
-#
-# Unlike the level above, we don't use a completely phony "all"
-# target: we want to rely on the ".done" sentinel that flags that all
-# the requisite output files for this case have been generated (or
-# recreates them if, for example, their corresponding source file
-# changes). To do this, we define $(d) just for some consistency in
-# style, but it's not completely necessary!
-d := .
-cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
-.PHONY: all
-all: $(d)/.done
-
-# This is the important rule that dispatches to the "real" Make
-# workflow to run the case if necessary.
-$(d)/.done:
-	$(MAKE) -C ../../.. $(cwd)/.done
+# We define some "standard" rules for demos, which allows us to run
+# "make" and "make clean". However, because the actual command to run
+# for "make check" changes depending on the actual case, we have to
+# define that on a case-by-case basis!
+include ../../.rules.mk
+$(eval $(standalone))
 
 .PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k $(cwd)
+check: .done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 
 else
 
@@ -68,12 +56,10 @@ CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 # with "rm -f".
 DIR_CLEAN_$(d) := output
 
-# Now we create the actual targets for running the test. The .done
-# target just ensures the output files are created, and updates the
-# timestamp on .done. This exists just for the standalone invocation
-# within the current directory.
-$(d)/.done: $(TGT_$(d))
-	@touch $@
+# Now we create the actual targets for running the test. The following
+# rule defines the ".done" and ".clean" targets, which are used for
+# standalone running.
+$(eval $(default_targets))
 
 # This is where a lot of the magic happens. The "run-python" canned
 # recipe (defined in .rules.mk) is controlled by a few magic
@@ -94,5 +80,4 @@ DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
 endif
 
-d := $(dirstack_$(sp))
-sp := $(basename $(sp))
+$(eval $(trailer))

--- a/demos/mantle_convection/base_case/Makefile
+++ b/demos/mantle_convection/base_case/Makefile
@@ -1,16 +1,29 @@
+# Makefile stack management, refer to demos/Makefile for an idea of
+# what this does and why it's needed.
 sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
 ifeq ($(d),)
-
+# If we're working on a single case, it's probably a bit easier to be
+# running a tighter development loop within its directory
+# specifically. We define targets specific to this directory, so we
+# can run "make check" to ensure the tests are still passing!
+#
+# Unlike the level above, we don't use a completely phony "all"
+# target: we want to rely on the ".done" sentinel that flags that all
+# the requisite output files for this case have been generated (or
+# recreates them if, for example, their corresponding source file
+# changes). To do this, we define $(d) just for some consistency in
+# style, but it's not completely necessary!
 d := .
-# current directory relative to root makefile
 cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
+# This is the important rule that dispatches to the "real" Make
+# workflow to run the case if necessary.
 $(d)/.done:
 	$(MAKE) -C ../../.. $(cwd)/.done
 
@@ -20,19 +33,60 @@ check: $(d)/.done
 
 else
 
+# This is the general (but not completely rigid) structure for
+# defining the inputs and outputs of a case.
+
+# TGT_$(d) should define the actual files that we require to be
+# generated out of the test. Usually this is the actual results file
+# that we're performing some kind of test on. There may be auxiliary
+# outputs (checkpoints, visualisation), but unless they're required
+# specifically, they don't need to go here.
 TGT_$(d) := $(d)/params.log
+
+# SRC_$(d) is just to make things cleaner: we can define any source
+# files on which the case depends. Make will ensure that if these
+# dependencies are changed (i.e. their modification time is *newer*
+# than the latest result), the case will be run again. Nothing here is
+# strictly necessary, but it can lead to a nicer development workflow
+# if the dependencies are captured correctly.
 SRC_$(d) := $(d)/base_case.py
+
+# For the demos specifically, we want to record which source file
+# contains the jupytext-compatible source for conversion to a
+# notebook.
 NOTEBOOK_SRC_$(d) := $(d)/base_case.py
+
+# To give ourselves the best chance of reproducibility and
+# cleanliness, we can define file- and directory-based artifacts that
+# are produced from running the case. Because there can be a lot of
+# entries here, these are written relative to the current directory
+# (i.e. without the $(d) prefix). It's important that .done and all
+# the files listed in $(TGT_$(d)) end up here.
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+# As a small insulation from foot-shooting, the following directories
+# are removed with "rm -rf", whereas the above files are only removed
+# with "rm -f".
 DIR_CLEAN_$(d) := output
 
+# Now we create the actual targets for running the test. The .done
+# target just ensures the output files are created, and updates the
+# timestamp on .done. This exists just for the standalone invocation
+# within the current directory.
 $(d)/.done: $(TGT_$(d))
 	@touch $@
 
+# This is where a lot of the magic happens. The "run-python" canned
+# recipe (defined in .rules.mk) is controlled by a few magic
+# variables, and knows how to run python on a case for most
+# situations, except where we require a submission manager.
 $(d)/params.log : category := mantle_convection
 $(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
+
+# Once we are sure that all our variables are correctly populated, we
+# can update the global target lists so that the top-level knows that
+# this case exists.
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -30,11 +30,11 @@ $(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
-$(d)/params.log: $(SRC_$(d)) $(dir $(d))base_case/.done
+$(d)/params.log: $(SRC_$(d)) demos/mantle_convection/base_case/.done
 	$(run-python)
 
 # this case relies on the base case
-$(NOTEBOOK_SRC_$(d):.py=.ipynb): $(dir $(d))base_case/base_case.ipynb
+$(NOTEBOOK_SRC_$(d):.py=.ipynb): demos/mantle_convection/base_case/base_case.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -1,17 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log: dynamic_topography.py
-	$(MAKE) -C ../base_case
+$(d)/params.log : category := mantle_convection
+$(d)/params.log: $(d)/dynamic_topography.py $(dir $(d))base_case/.done
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -20,18 +20,24 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/dynamic_topography.py
+NOTEBOOK_SRC_$(d) := $(d)/dynamic_topography.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
-$(d)/params.log: $(d)/dynamic_topography.py $(dir $(d))base_case/.done
+$(d)/params.log: $(SRC_$(d)) $(dir $(d))base_case/.done
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
+# this case relies on the base case
+$(NOTEBOOK_SRC_$(d):.py=.ipynb): $(dir $(d))base_case/base_case.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/dynamic_topography/Makefile
+++ b/demos/mantle_convection/dynamic_topography/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/dynamic_topography.py
 NOTEBOOK_SRC_$(d) := $(d)/dynamic_topography.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -23,6 +23,7 @@ else
 TGT_$(d) := $(d)/.done
 SRC_$(d) := $(d)/free_surface.py
 NOTEBOOK_SRC_$(d) := $(d)/free_surface.py
+NOTEBOOK_IMGS_$(d) := $(d)/temperature_warp.gif
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
@@ -38,6 +39,7 @@ $(NOTEBOOK_SRC_$(d):.py=.ipynb): $(dir $(d))base_case/base_case.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
+NOTEBOOK_IMGS := $(NOTEBOOK_IMGS) $(NOTEBOOK_IMGS_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -20,14 +20,14 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/free_surface.py
 NOTEBOOK_SRC_$(d) := $(d)/free_surface.py
 NOTEBOOK_IMGS_$(d) := $(d)/temperature_warp.gif
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log: free_surface.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log: $(d)/free_surface.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -20,18 +20,24 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/free_surface.py
+NOTEBOOK_SRC_$(d) := $(d)/free_surface.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
-$(d)/params.log: $(d)/free_surface.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
+# this case relies on the base case
+$(NOTEBOOK_SRC_$(d):.py=.ipynb): $(dir $(d))base_case/base_case.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/free_surface/Makefile
+++ b/demos/mantle_convection/free_surface/Makefile
@@ -35,7 +35,7 @@ $(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
 # this case relies on the base case
-$(NOTEBOOK_SRC_$(d):.py=.ipynb): $(dir $(d))base_case/base_case.ipynb
+$(NOTEBOOK_SRC_$(d):.py=.ipynb): demos/mantle_convection/base_case/base_case.ipynb
 
 TGT := $(TGT) $(TGT_$(d))
 NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -20,18 +20,21 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/gplates_global.py
+NOTEBOOK_SRC_$(d) := $(d)/gplates_global.py
+CLEAN_$(d) := *.pvd *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
-$(d)/params.log: $(d)/gplates_global.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.h5 params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/gplates_global.py
 NOTEBOOK_SRC_$(d) := $(d)/gplates_global.py
 CLEAN_$(d) := *.pvd *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/gplates_global/Makefile
+++ b/demos/mantle_convection/gplates_global/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log: gplates_global.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log: $(d)/gplates_global.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -18,11 +36,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -20,13 +20,13 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := $(d)/.done
+TGT_$(d) := $(d)/params.log
 SRC_$(d) := $(d)/viscoplastic_case.py
 NOTEBOOK_SRC_$(d) := $(d)/viscoplastic_case.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
 DIR_CLEAN_$(d) := output
 
-$(d)/.done: $(d)/params.log
+$(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/params.log : category := mantle_convection

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -1,17 +1,29 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := mantle_convection
-params.log : ncpus := 4
-params.log: viscoplastic_case.py
+$(d)/params.log : category := mantle_convection
+$(d)/params.log : ncpus := 4
+$(d)/params.log: $(d)/viscoplastic_case.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/mantle_convection/viscoplastic_case/Makefile
+++ b/demos/mantle_convection/viscoplastic_case/Makefile
@@ -20,19 +20,22 @@ check: $(d)/.done
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/viscoplastic_case.py
+NOTEBOOK_SRC_$(d) := $(d)/viscoplastic_case.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := mantle_convection
 $(d)/params.log : ncpus := 4
-$(d)/params.log: $(d)/viscoplastic_case.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/mantle_convection/visualise_ALA_p_nullspace/Makefile
+++ b/demos/mantle_convection/visualise_ALA_p_nullspace/Makefile
@@ -1,0 +1,10 @@
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
+
+NOTEBOOK_SRC_$(d) := visualise_ALA_p_nullspace.py
+
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -1,18 +1,14 @@
-include ../makefile.cases.inc
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(notdir $(mm_cases))
+subdirs_$(d) := compositional_buoyancy thermochemical_buoyancy
 
-.PHONY: all $(cases) clean check
+$(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-all: $(cases)
+TGT_$(d) := $(filter $(dir)/%,$(TGT))
+CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
 
-$(cases):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-clean:
-	@$(foreach case, $(cases), \
-		$(MAKE) -C $(case) $(MAKECMDGOALS); \
-	)
-
-check: $(cases)
-	python -m pytest $(CURDIR)/../test_all.py -k $(mm_dir)
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -2,6 +2,18 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+
+.PHONY: all
+all:
+	$(MAKE) -C .. $(cwd)
+
+.PHONY: check
+check: all
+	pytest ../test_all.py . -k $(cwd)
+else
+
 subdirs_$(d) := compositional_buoyancy thermochemical_buoyancy
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
@@ -9,6 +21,8 @@ $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 TGT_$(d) := $(filter $(d)/%,$(TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
+
+endif
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -8,10 +8,6 @@ cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 .PHONY: all
 all:
 	$(MAKE) -C .. $(cwd)
-
-.PHONY: check
-check: all
-	pytest ../test_all.py . -k $(cwd)
 else
 
 subdirs_$(d) := compositional_buoyancy thermochemical_buoyancy

--- a/demos/multi_material/Makefile
+++ b/demos/multi_material/Makefile
@@ -6,9 +6,9 @@ subdirs_$(d) := compositional_buoyancy thermochemical_buoyancy
 
 $(foreach dir,$(addprefix $(d)/,$(subdirs_$(d))),$(eval $(include_subdir)))
 
-TGT_$(d) := $(filter $(dir)/%,$(TGT))
-CLEAN_$(d) := $(filter $(dir)/%,$(CLEAN))
-DIR_CLEAN_$(d) := $(filter $(dir)/%,$(DIR_CLEAN))
+TGT_$(d) := $(filter $(d)/%,$(TGT))
+CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 else
 

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -14,10 +14,6 @@ all: $(d)/.done
 $(d)/.done:
 	$(MAKE) -C ../.. $(cwd)/.done
 
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k $(cwd)
-
 else
 
 $(d)/.done: $(d)/params.log

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := multi_material
-params.log: compositional_buoyancy.py
+$(d)/params.log : category := multi_material
+$(d)/params.log: $(d)/compositional_buoyancy.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -16,18 +16,21 @@ $(d)/.done:
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/compositional_buoyancy.py
+NOTEBOOK_SRC_$(d) := $(d)/compositional_buoyancy.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := multi_material
-$(d)/params.log: $(d)/compositional_buoyancy.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/multi_material/compositional_buoyancy/Makefile
+++ b/demos/multi_material/compositional_buoyancy/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -6,13 +6,13 @@ ifeq ($(d),)
 
 d := .
 # current directory relative to root makefile
-cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C ../.. $(cwd)/.done
+	$(MAKE) -C ../../.. $(cwd)/.done
 
 else
 

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -14,10 +14,6 @@ all: $(d)/.done
 $(d)/.done:
 	$(MAKE) -C ../.. $(cwd)/.done
 
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k $(cwd)
-
 else
 
 $(d)/.done: $(d)/params.log

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -2,6 +2,24 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
+ifeq ($(d),)
+
+d := .
+# current directory relative to root makefile
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
+
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k $(cwd)
+
+else
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
@@ -17,11 +35,6 @@ TGT := $(TGT) $(TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-# XXX placeholder for old check routine
-ifdef undefined
-.PHONY: check
-check: $(d)/.done
-	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
 endif
 
 d := $(dirstack_$(sp))

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -16,18 +16,21 @@ $(d)/.done:
 
 else
 
+TGT_$(d) := $(d)/.done
+SRC_$(d) := $(d)/thermochemical_buoyancy.py
+NOTEBOOK_SRC_$(d) := $(d)/thermochemical_buoyancy.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
+
 $(d)/.done: $(d)/params.log
 	@touch $@
 
 $(d)/params.log : category := multi_material
-$(d)/params.log: $(d)/thermochemical_buoyancy.py
+$(d)/params.log: $(SRC_$(d))
 	$(run-python)
 
-TGT_$(d) := $(d)/.done
-CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
-DIR_CLEAN_$(d) := output
-
 TGT := $(TGT) $(TGT_$(d))
+NOTEBOOK_SRC := $(NOTEBOOK_SRC) $(NOTEBOOK_SRC_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 

--- a/demos/multi_material/thermochemical_buoyancy/Makefile
+++ b/demos/multi_material/thermochemical_buoyancy/Makefile
@@ -1,16 +1,28 @@
-include ../../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+$(d)/.done: $(d)/params.log
+	@touch $@
 
-all: params.log
-
-params.log : category := multi_material
-params.log: thermochemical_buoyancy.py
+$(d)/params.log : category := multi_material
+$(d)/params.log: $(d)/thermochemical_buoyancy.py
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output
+TGT_$(d) := $(d)/.done
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../test_all.py -k $(test_class)/$(current_dir)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+# XXX placeholder for old check routine
+ifdef undefined
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../test_all.py -k mantle_convection/base_case
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/2d_cylindrical_TALA_DG/Makefile
+++ b/tests/2d_cylindrical_TALA_DG/Makefile
@@ -1,17 +1,42 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+ifeq ($(d),)
 
-all: params.log
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-params.log : category := tests
-params.log : ncpus := 16
-params.log: 2d_cylindrical_TALA_DG.py
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../demos/test_all.py -k $(shell realpath --strip --relative-to=../../demos $(CURDIR))
+
+else
+
+TGT_$(d) := $(d)/params.log
+SRC_$(d) := $(d)/2d_cylindrical_TALA_DG.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output reference_state __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)): category := tests
+$(TGT_$(d)): ncpus := 16
+$(TGT_$(d)): $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output reference_state __pycache__
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../demos/test_all.py -k "../tests/2d_cylindrical_TALA_DG"
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/Drucker-Prager_rheology/Makefile
+++ b/tests/Drucker-Prager_rheology/Makefile
@@ -19,9 +19,10 @@ check: $(d)/.done
 
 else
 
-CASES_$(d) := $(shell python3 $(d)/test_spiegelman.py)
-TGT_$(d) := $(CASES_$(d):%=$(d)/%d/newton.txt)
+CASES_$(d) := $(addprefix spiegelman_,$(shell python3 $(d)/test_spiegelman.py))
+TGT_$(d) := $(CASES_$(d):%=$(d)/%/newton.txt)
 SRC_$(d) := $(d)/spiegelman.py
+CLEAN_$(d) := .done
 DIR_CLEAN_$(d) := __pycache__ $(CASES_$(d))
 
 $(d)/.done: $(TGT_$(d))
@@ -30,7 +31,7 @@ $(d)/.done: $(TGT_$(d))
 $(TGT_$(d)) : category := Drucker-Prager_rheology
 $(TGT_$(d)) : exec_args = $*
 $(TGT_$(d)) : desc = $(exec_args)
-$(TGT_$(d)): $(d)/%/newton.txt: $(SRC_$(d))
+$(TGT_$(d)): $(d)/spiegelman_%/newton.txt: $(SRC_$(d))
 	$(run-python)
 
 TGT := $(TGT) $(TGT_$(d))

--- a/tests/Drucker-Prager_rheology/Makefile
+++ b/tests/Drucker-Prager_rheology/Makefile
@@ -1,19 +1,43 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(shell python3 test_spiegelman.py)
+ifeq ($(d),)
 
-.PHONY: all clean check
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-all: $(addprefix spiegelman_,$(cases))
+.PHONY: all
+all: $(d)/.done
 
-spiegelman_% : category := Drucker-Prager_rheology
-spiegelman_% : exec_args = $*
-spiegelman_% : desc = $(exec_args)
-spiegelman_%: spiegelman.py
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+CASES_$(d) := $(shell python3 $(d)/test_spiegelman.py)
+TGT_$(d) := $(CASES_$(d):%=$(d)/%d/newton.txt)
+SRC_$(d) := $(d)/spiegelman.py
+DIR_CLEAN_$(d) := __pycache__ $(CASES_$(d))
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)) : category := Drucker-Prager_rheology
+$(TGT_$(d)) : exec_args = $*
+$(TGT_$(d)) : desc = $(exec_args)
+$(TGT_$(d)): $(d)/%/newton.txt: $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -rf $(addprefix spiegelman_,$(cases)) __pycache__
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: $(addprefix spiegelman_,$(cases))
-	python -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
-subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh
+subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh parallel_scaling
 
 ifeq ($(d),)
 cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
@@ -13,7 +13,11 @@ all:
 
 .PHONY: check
 check:
-	python3 -m pytest ../demos/test_all.py . -k "../tests or tests"
+	python3 -m pytest ../demos -m "not demo and not longtest"
+
+.PHONY: longcheck
+longcheck:
+	python3 -m pytest -m "longtest"
 
 .PHONY: clean
 clean:
@@ -27,37 +31,18 @@ else
 $(foreach dir,$(addprefix $(d)/,$(subdirs)),$(eval $(include_subdir)))
 
 TGT_$(d) := $(filter $(d)/%,$(TGT))
+HPC_TGT_$(d) := $(filter $(d)/%,$(HPC_TGT))
 CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
 DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
 
 $(eval $(call make_targets,$(d)))
+
+# define hpc tests, if there are any
+ifneq ($(HPC_TGT_$(d)),)
+hpc-tests: $(HPC_TGT_$(d))
+endif
+
 endif
 
 d := $(dirstack_$(sp))
 sp := $(basename $(sp))
-
-# ##############
-
-# cases := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh
-# long_cases := analytical_comparisons parallel_scaling
-
-# .PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
-
-# all: $(cases)
-
-# longtest: $(long_cases)
-
-# longtest_output: $(long_cases)
-
-# # sort to remove duplicates which define both short and long tests
-# $(sort $(cases) $(long_cases)):
-# 	$(MAKE) -C $@ $(MAKECMDGOALS)
-
-# clean: $(cases)
-# 	rm -rf __pycache__
-
-# check:
-# 	python -m pytest . ../demos -m 'not demo and not longtest'
-
-# longcheck:
-# 	python -m pytest -m longtest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,23 +1,56 @@
-cases := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh
-long_cases := analytical_comparisons parallel_scaling
+all: targets
 
-.PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
+include ../.rules.mk
 
-all: $(cases)
+define include_subdir =
+dir := $(dir)
+include $$(dir)/Makefile
+endef
 
-longtest: $(long_cases)
+define subdir_targets =
+.PHONY $(1) clean-$(1)
+$(1): $$(TGT_$(1))
 
-longtest_output: $(long_cases)
+clean-$(1):
+	rm -f $$(CLEAN_$(1))
+	rm -rf $$(DIR_CLEAN_$(1))
+endef
 
-# sort to remove duplicates which define both short and long tests
-$(sort $(cases) $(long_cases)):
-	$(MAKE) -C $@ $(MAKECMDGOALS)
+subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion
 
-clean: $(cases)
-	rm -rf __pycache__
+$(foreach dir,$(subdirs),$(eval $(include_subdir)))
 
-check:
-	python -m pytest . ../demos -m 'not demo and not longtest'
+.PHONY: targets
+targets: $(TGT)
 
-longcheck:
-	python -m pytest -m longtest
+.PHONY: clean
+clean:
+	rm -f $(CLEAN)
+	rm -rf $(DIR_CLEAN)
+
+
+# ##############
+
+# cases := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh
+# long_cases := analytical_comparisons parallel_scaling
+
+# .PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
+
+# all: $(cases)
+
+# longtest: $(long_cases)
+
+# longtest_output: $(long_cases)
+
+# # sort to remove duplicates which define both short and long tests
+# $(sort $(cases) $(long_cases)):
+# 	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+# clean: $(cases)
+# 	rm -rf __pycache__
+
+# check:
+# 	python -m pytest . ../demos -m 'not demo and not longtest'
+
+# longcheck:
+# 	python -m pytest -m longtest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ sp := $(sp).x
 dirstack_$(sp) := $(d)
 d := $(dir)
 
-subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint
+subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint 2d_cylindrical_TALA_DG viscoplastic_case_DG free_surface viscoelastic base_gmsh
 
 ifeq ($(d),)
 cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,33 +1,40 @@
-all: targets
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-include ../.rules.mk
+subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion Drucker-Prager_rheology adjoint
 
-define include_subdir =
-dir := $(dir)
-include $$(dir)/Makefile
-endef
+ifeq ($(d),)
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-define subdir_targets =
-.PHONY $(1) clean-$(1)
-$(1): $$(TGT_$(1))
+.PHONY: all
+all:
+	$(MAKE) -C .. $(cwd)
 
-clean-$(1):
-	rm -f $$(CLEAN_$(1))
-	rm -rf $$(DIR_CLEAN_$(1))
-endef
-
-subdirs := analytical_comparisons multi_material optimisation_checkpointing scalar_advection scalar_advection_diffusion
-
-$(foreach dir,$(subdirs),$(eval $(include_subdir)))
-
-.PHONY: targets
-targets: $(TGT)
+.PHONY: check
+check:
+	python3 -m pytest ../demos/test_all.py . -k "../tests or tests"
 
 .PHONY: clean
 clean:
-	rm -f $(CLEAN)
-	rm -rf $(DIR_CLEAN)
+	$(MAKE) -C .. clean-$(cwd)
 
+include ../.rules.mk
+$(foreach dir,$(subdirs),$(eval $(call subdir_targets,$(dir),$(cwd))))
+
+else
+
+$(foreach dir,$(addprefix $(d)/,$(subdirs)),$(eval $(include_subdir)))
+
+TGT_$(d) := $(filter $(d)/%,$(TGT))
+CLEAN_$(d) := $(filter $(d)/%,$(CLEAN))
+DIR_CLEAN_$(d) := $(filter $(d)/%,$(DIR_CLEAN))
+
+$(eval $(call make_targets,$(d)))
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))
 
 # ##############
 

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -33,7 +33,7 @@ $(d)/.done: $(TGT_$(d))
 	@touch $@
 
 $(d)/adjoint-demo-checkpoint-state.h5: demos/mantle_convection/adjoint/adjoint-demo-checkpoint-state.h5
-	@ln -sf $< $@
+	@ln -sf ../../$< $@
 
 $(TGT_$(d)) : category := tests/adjoint
 $(TGT_$(d)) : ncpus := 2

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -1,30 +1,52 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := damping smoothing Tobs uobs uimposed
-scheduler := noscheduler fullmemory fullstorage
+ifeq ($(d),)
 
-cases_schedulers := $(foreach case,$(cases),$(foreach sched,$(scheduler),$(case)_$(sched)))
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-.PHONY: all clean check
+.PHONY: all
+all: $(d)/.done
 
-all: $(addsuffix .conv,$(cases_schedulers))
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
 
-%.conv : category := tests/adjoint
-%.conv : ncpus := 2
-%.conv : exec_args = $*
-%.conv : desc = $(exec_args)
-%.conv: taylor_test.py adjoint-demo-checkpoint-state.h5
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+CASES_COMPONENTS_$(d) := damping smoothing Tobs uobs uimposed
+CASES_SCHEDULERS_$(d) := noscheduler fullmemory fullstorage
+CASES_$(d) := $(foreach case,$(CASES_COMPONENTS_$(d)),$\
+	$(foreach scheduler,$(CASES_SCHEDULERS_$(d)),$\
+		$(case)_$(scheduler)))
+TGT_$(d) := $(CASES_$(d):%=$(d)/%.conv)
+SRC_$(d) := $(d)/taylor_test.py
+CLEAN_$(d) := *.h5 *.conv *.dat
+DIR_CLEAN_$(d) := __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(d)/adjoint-demo-checkpoint-state.h5: $(realpath $(dir $(d))/../demos/mantle_convection/adjoint/adjoint-demo-checkpoint-state.h5)
+	@ln -sf $< $@
+
+$(TGT_$(d)) : category := tests/adjoint
+$(TGT_$(d)) : ncpus := 2
+$(TGT_$(d)) : exec_args = $*
+$(TGT_$(d)) : desc = $(exec_args)
+$(TGT_$(d)): $(d)/%.conv: $(SRC_$(d)) $(d)/adjoint-demo-checkpoint-state.h5
 	$(run-python)
 
-adjoint-demo-checkpoint-state.h5 : category := tests/adjoint
-adjoint-demo-checkpoint-state.h5 : ncpus := 2
-adjoint-demo-checkpoint-state.h5 : desc := forward
-adjoint-demo-checkpoint-state.h5: ../../demos/mantle_convection/adjoint/adjoint_forward.py
-	$(run-python)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-clean:
-	rm -f *.h5 *.conv *.dat
-	rm -rf __pycache__
+endif
 
-check: $(addsuffix .conv,$(cases))
-	python -m pytest
+d := $(dirstack_$(sp)
+sp := $(basename $(sp))

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -32,7 +32,7 @@ DIR_CLEAN_$(d) := __pycache__
 $(d)/.done: $(TGT_$(d))
 	@touch $@
 
-$(d)/adjoint-demo-checkpoint-state.h5: $(realpath $(dir $(d))/../demos/mantle_convection/adjoint/adjoint-demo-checkpoint-state.h5)
+$(d)/adjoint-demo-checkpoint-state.h5: demos/mantle_convection/adjoint/adjoint-demo-checkpoint-state.h5
 	@ln -sf $< $@
 
 $(TGT_$(d)) : category := tests/adjoint

--- a/tests/adjoint/Makefile
+++ b/tests/adjoint/Makefile
@@ -48,5 +48,5 @@ DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
 endif
 
-d := $(dirstack_$(sp)
+d := $(dirstack_$(sp))
 sp := $(basename $(sp))

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -1,38 +1,53 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := smooth_cylindrical_freeslip smooth_cylindrical_zeroslip delta_cylindrical_freeslip delta_cylindrical_zeroslip delta_cylindrical_freeslip_dpc delta_cylindrical_zeroslip_dpc
-long_cases := smooth_cylindrical_freesurface smooth_spherical_freeslip smooth_spherical_zeroslip
+ifeq ($(d),)
 
-sentinels := $(addprefix .sentinel.,$(cases))
+d := .
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-.PHONY: all longtest longtest_output $(cases) $(long_cases) clean check longcheck
+.PHONY: all
+all: $(d)/.done
 
-all: $(cases)
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
 
-longtest: $(long_cases)
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest -m "not longtest"
 
-$(cases): %: .sentinel.%
+else
 
-tsp_string = $(if $(BATCH_MODE),tsp -N {cores} -f)
-$(sentinels): analytical.py
-	@$(call run_regular,python3 analytical.py submit -t "$(tsp_string) mpiexec -np {cores}" $(subst .sentinel.,,$@),analytical $(subst .sentinel.,,$@))
-	@echo "done" > $@
+CASES_$(d) := smooth_cylindrical_freeslip smooth_cylindrical_zeroslip delta_cylindrical_freeslip delta_cylindrical_zeroslip delta_cylindrical_freeslip_dpc delta_cylindrical_zeroslip_dpc
+HPC_CASES_$(d) := smooth_cylindrical_freesurface smooth_spherical_freeslip smooth_spherical_zeroslip
+TGT_$(d) := $(addprefix $(d)/.sentinel.,$(CASES_$(d)))
+HPC_TGT_$(d) := $(addprefix $(d)/.sentinel.,$(HPC_CASES_$(d)))
+SRC_$(d) := $(d)/analytical.py
+CLEAN_$(d) := *.dat .sentinel.* .done
+DIR_CLEAN_$(d) := batch_output __pycache__
 
-.ONESHELL:
-SHELL = /bin/bash
-$(long_cases): analytical.py clean
-	echo "running spherical $@" >&2
-	mkdir -p batch_output
-	python3 analytical.py submit $@ -H -o batch_output/$(subst /,-,$@)_l{level}_{params}.out -e batch_output/$(subst /,-,$@)_l{level}_{params}.err
+$(d)/.done: $(TGT_$(d))
+	@touch $@
 
-clean:
-	rm -rf batch_output *.dat sentinel.* .sentinel.* __pycache__
+$(TGT_$(d)): $(SRC_$(d))
+	@$(let case tsp_string,$(patsubst .sentinel.%,%,$(notdir $@)) $(if $(BATCH_MODE),tsp -N {cores} -f ),\
+		$(call run_regular,python3 analytical.py submit -t "$(tsp_string)mpiexec -np {cores}" $(case),analytical $(case)))
+	@touch $@
 
-longtest_output:
-	[[ -d batch_output ]] && tail -n +1 batch_output/*
+batch_output:
+	mkdir batch_output
 
-check: $(sentinels)
-	python -m pytest -m 'not longtest'
+$(HPC_TGT_$(d)): $(SRC_$(d)) batch_output clean-$(d)
+	$(let case,$(patsubst .sentinel.%,%,$(notdir $@)),\
+		python3 analytical.py submit $(case) -H -o batch_output/$(case)_l{level}_{params}.out -e batch_output/$(case)_l{level}_{params.err})
 
-longcheck:
-	python -m pytest -m longtest
+TGT := $(TGT) $(TGT_$(d))
+HPC_TGT := $(HPC_TGT) $(HPC_TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -36,17 +36,19 @@ $(TGT_$(d)): $(SRC_$(d))
 	@(cd $(dir $<); $(call run_regular,python3 analytical.py submit -t "$(tsp_string)mpiexec -np {cores}" $(case),analytical $(case)))
 	@touch $@
 
-batch_output:
-	mkdir batch_output
+$(d)/batch_output:
+	@mkdir $@
 
 $(HPC_TGT_$(d)) : case = $(patsubst .sentinel.%,%,$(notdir $@))
-$(HPC_TGT_$(d)): $(SRC_$(d)) batch_output clean-$(d)
+$(HPC_TGT_$(d)): $(SRC_$(d)) $(d)/batch_output clean-$(d)
 	(cd $(dir $<); python3 analytical.py submit $(case) -H -o batch_output/$(case)_l{level}_{params}.out -e batch_output/$(case)_l{level}_{params.err}))
 
 TGT := $(TGT) $(TGT_$(d))
 HPC_TGT := $(HPC_TGT) $(HPC_TGT_$(d))
 CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
 DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+$(eval $(call make_targets,$(d)))
 
 endif
 

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -30,17 +30,18 @@ DIR_CLEAN_$(d) := batch_output __pycache__
 $(d)/.done: $(TGT_$(d))
 	@touch $@
 
+$(TGT_$(d)) : case = $(patsubst .sentinel.%,%,$(notdir $@))
+$(TGT_$(d)) : tsp_string := $(if $(BATCH_MODE),tsp -N {cores} -f )
 $(TGT_$(d)): $(SRC_$(d))
-	@$(let case tsp_string,$(patsubst .sentinel.%,%,$(notdir $@)) $(if $(BATCH_MODE),tsp -N {cores} -f ),\
-		$(call run_regular,python3 analytical.py submit -t "$(tsp_string)mpiexec -np {cores}" $(case),analytical $(case)))
+	@(cd $(dir $<); $(call run_regular,python3 analytical.py submit -t "$(tsp_string)mpiexec -np {cores}" $(case),analytical $(case)))
 	@touch $@
 
 batch_output:
 	mkdir batch_output
 
+$(HPC_TGT_$(d)) : case = $(patsubst .sentinel.%,%,$(notdir $@))
 $(HPC_TGT_$(d)): $(SRC_$(d)) batch_output clean-$(d)
-	$(let case,$(patsubst .sentinel.%,%,$(notdir $@)),\
-		python3 analytical.py submit $(case) -H -o batch_output/$(case)_l{level}_{params}.out -e batch_output/$(case)_l{level}_{params.err})
+	(cd $(dir $<); python3 analytical.py submit $(case) -H -o batch_output/$(case)_l{level}_{params}.out -e batch_output/$(case)_l{level}_{params.err}))
 
 TGT := $(TGT) $(TGT_$(d))
 HPC_TGT := $(HPC_TGT) $(HPC_TGT_$(d))

--- a/tests/analytical_comparisons/Makefile
+++ b/tests/analytical_comparisons/Makefile
@@ -5,13 +5,13 @@ d := $(dir)
 ifeq ($(d),)
 
 d := .
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/tests/base_gmsh/Makefile
+++ b/tests/base_gmsh/Makefile
@@ -1,19 +1,44 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+ifeq ($(d),)
 
-all: params.log
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-%.msh: %.geo
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+TGT_$(d) := $(d)/params.log
+SRC_$(d) := $(d)/base_case.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 *.msh params.log .done
+DIR_CLEAN_$(d) := output
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(d)/square.msh: %.msh: %.geo
 	gmsh -2 $<
 
-params.log : category := tests/gmsh
-params.log: base_case.py square.msh
+$(TGT_$(d)): category := tests/gmsh
+$(TGT_$(d)): $(SRC_$(d)) $(d)/square.msh
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log *.msh
-	rm -rf output
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: params.log
-	python3 -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/free_surface/Makefile
+++ b/tests/free_surface/Makefile
@@ -1,27 +1,47 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-serial_cases := explicit implicit implicit_top_bottom
-parallel_cases := implicit_top_bottom_buoyancy implicit_cylindrical
+ifeq ($(d),)
 
-serial_sentinels := $(addprefix .sentinel.,$(serial_cases))
-parallel_sentinels := $(addprefix .sentinel.,$(parallel_cases))
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-.PHONY: all clean check $(serial_cases) $(parallel_cases)
+.PHONY: all
+all: $(d)/.done
 
-all: $(serial_cases) $(parallel_cases)
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
 
-#Allow 'make <easy name>' to effectively alias to 'make <long ugly file name>'
-$(serial_cases) $(parallel_cases): %: .sentinel.%
-
-$(serial_sentinels) $(parallel_sentinels) : category := tests/free_surface
-$(parallel_sentinels) : ncpus := 8
-
-$(serial_sentinels) $(parallel_sentinels): .sentinel.%: %_free_surface.py
-	$(run-python)
-	@echo "done" > $@
-
-clean:
-	rm -rf *.dat .sentinel.* __pycache__
-
-check: $(serial_sentinels) $(parallel_sentinels)
+.PHONY: check
+check: $(d)/.done
 	python3 -m pytest
+
+else
+
+CASES_SERIAL_$(d) := explicit implicit implicit_top_bottom
+CASES_PARALLEL_$(d) := implicit_top_bottom_buoyancy implicit_cylindrical
+CASES_$(d) := $(CASES_SERIAL_$(d)) $(CASES_PARALLEL_$(d))
+TGT_SERIAL_$(d) := $(addprefix $(d)/.sentinel.,$(CASES_SERIAL_$(d)))
+TGT_PARALLEL_$(d) := $(addprefix $(d)/.sentinel.,$(CASES_PARALLEL_$(d)))
+TGT_$(d) := $(TGT_SERIAL_$(d)) $(TGT_PARALLEL_$(d))
+SRC_$(d) := $(addsuffix _free_surface.py,$(CASES_$(d)))
+CLEAN_$(d) := *.dat .sentinel.* .done
+DIR_CLEAN_$(d) := __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_PARALLEL_$(d)) : ncpus := 8
+$(TGT_$(d)) : category := tests/free_surface
+$(TGT_$(d)): $(d)/.sentinel.%: $(d)/%_free_surface.py
+	$(run-python)
+
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -1,27 +1,45 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(wildcard benchmarks/*)
-archive := output_0_reference.npz
-outputs := $(foreach case,$(cases),$(case)/${archive})
+ifeq ($(d),)
 
-.PHONY: all clean check
+d := .
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-all: $(outputs)
+.PHONY: all
+all: $(d)/.done
 
-%/${archive} : category := multi_material
-%/${archive} : ncpus := 8
-%/${archive} : exec_cmd = mpiexec -np $(ncpus) python3 $< $(dir $@)
-%/${archive} : desc = $*
-%/${archive}: run_benchmark.py
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+CASES_$(d) := $(notdir $(wildcard $(d)/benchmarks/*))
+TGT_$(d) := $(CASES_$(d):%=$(d)/benchmarks/%/output_0_reference.npz)
+SRC_$(d) := $(d)/run_benchmark.py
+CLEAN_$(d) := .done $(CASES_$(d):%=benchmarks/%/*.pdf) $(CASES_$(d):%=benchmarks/%/*.npz) $(CASES_$(d):%=benchmarks/%/mesh/*.msh)
+DIR_CLEAN_$(d) := __pycache__ $(CASES_$(d):%=benchmarks/%/__pycache) $(CASES_$(d):%=benchmarks/%/outputs)
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)) : category := multi_material
+$(TGT_$(d)) : ncpus := 8
+$(TGT_$(d)) : exec_cmd = mpiexec -np $(ncpus) python3 $(notdir $<) benchmarks/$*
+$(TGT_$(d)) : desc = $*
+$(TGT_$(d)): $(d)/benchmarks/%/output_0_reference.npz: $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -rf __pycache__
-	@$(foreach case,$(cases),rm -rf $(case)/__pycache__;)
-	@$(foreach case,$(cases),rm -rf $(case)/outputs;)
-	@$(foreach case,$(cases),rm -f $(case)/*.pdf;)
-	@$(foreach case,$(cases),rm -f $(case)/*.npz;)
-	@$(foreach case,$(cases),rm -f $(case)/mesh/*.msh;)
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: all
-	python3 -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/multi_material/Makefile
+++ b/tests/multi_material/Makefile
@@ -5,13 +5,13 @@ d := $(dir)
 ifeq ($(d),)
 
 d := .
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -1,19 +1,43 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := full_optimisation_np1.dat full_optimisation_np2.dat
+ifeq ($(d),)
 
-.PHONY: all clean check
+d := .
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-all: $(cases)
+.PHONY: all
+all: $(d)/.done
 
-full_optimisation_np%.dat : category := optimisation_checkpointing
-full_optimisation_np%.dat : ncpus = $*
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
 
-$(cases): full_optimisation_np%.dat: helmholtz.py
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+CASES_$(d) := full_optimisation_np1 full_optimisation_np2
+TGT_$(d) := $(CASES_$(d):%=$(d)/%.dat)
+SRC_$(d) := $(d)/helmholtz.py
+CLEAN_$(d) := *.dat *.h5 .done
+DIR_CLEAN_$(d) := optimisation_checkpoint_* __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)): category := optimisation_checkpointing
+$(TGT_$(d)): ncpus = $*
+$(TGT_$(d)): $(d)/full_optimisation_np%.dat: $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -rf optimisation_checkpoint_* __pycache__ *.h5 *.dat
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: $(cases)
-	python -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/optimisation_checkpointing/Makefile
+++ b/tests/optimisation_checkpointing/Makefile
@@ -5,13 +5,13 @@ d := $(dir)
 ifeq ($(d),)
 
 d := .
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/tests/parallel_scaling/Makefile
+++ b/tests/parallel_scaling/Makefile
@@ -1,22 +1,45 @@
-levels := 5 6 7
-levels := $(addsuffix .txt,$(addprefix profile_,$(levels)))
+sp := $(sp).x
+dirstack_$sp) := $(d)
+d := $(dir)
 
-.PHONY: longtest clean check
+ifeq ($(d),)
 
-longtest: $(levels)
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-.ONESHELL:
-SHELL = /bin/bash
-profile_%.txt: scaling.py stokes_cubed_sphere.py
-	echo "running parallel scaling on level $*"
-	mkdir -p batch_output
-	gadopt_hpcrun --debug -n $$( python3 scaling.py get_ncpus $* ) -v LEVEL=$* -N scaling_$* -o batch_output/l$*.out -e batch_output/l$*.err --template-file ./run.template python3 scaling.py run $*
+.PHONY: all
+all: $(d)/.hpc_done
 
-clean:
-	rm -rf batch_output profile_*.txt level_*.out level_*.err
+$(d)/.hpc_done:
+	$(MAKE) -C ../.. $(cwd)/.hpc_done
 
-longtest_output:
-	tail -n +1 level_*.{err,out}
-
-check: $(levels)
+.PHONY: check
+check: $(d)/.hpc_done
 	python3 -m pytest
+
+else
+
+# refinement levels
+HPC_CASES_$(d) := 5 6 7
+HPC_TGT_$(d) := $(HPC_CASES_$(d):%=$(d)/profile_%.txt)
+SRC_$(d) := $(d)/scaling.py $(d)/stokes_cubed_sphere.py
+CLEAN_$(d) := profile_*.txt level_*.out level_*.err
+DIR_CLEAN_$(d) := batch_output
+
+$(d)/.hpc_done: $(HPC_TGT_$(d))
+	@touch $@
+
+$(d)/batch_output:
+	@mkdir $@
+
+$(HPC_TGT_$(d)): $(d)/profile_%.txt: $(SRC_$(d)) $(d)/batch_output $(d)/run.template
+	(cd $(dir $<); gadopt_hpcrun --debug -n $$(python3 scaling.py get_ncpus $*) -v LEVEL=$* -N scaling_$* -o batch_output/l$*.out -e batch_output/$*.err --template-file ./run.template python3 scaling.py run $*
+
+HPC_TGT := $(HPC_TGT) $(HPC_TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/scalar_advection/Makefile
+++ b/tests/scalar_advection/Makefile
@@ -1,16 +1,41 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+ifeq ($(d),)
 
-all: final_error.log
+d := .
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-final_error.log : category := tests
-final_error.log: scalar_advection.py
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest
+
+else
+
+TGT_$(d) := final_error.log
+SRC_$(d) := $(d)/scalar_advection.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 final_error.log .done
+DIR_CLEAN_$(d) := output
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)): category := tests
+$(TGT_$(d)): $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 final_error.log
-	rm -rf output
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: final_error.log
-	python3 -m pytest
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/scalar_advection/Makefile
+++ b/tests/scalar_advection/Makefile
@@ -5,13 +5,13 @@ d := $(dir)
 ifeq ($(d),)
 
 d := .
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/tests/scalar_advection/Makefile
+++ b/tests/scalar_advection/Makefile
@@ -19,7 +19,7 @@ check: $(d)/.done
 
 else
 
-TGT_$(d) := final_error.log
+TGT_$(d) := $(d)/final_error.log
 SRC_$(d) := $(d)/scalar_advection.py
 CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 final_error.log .done
 DIR_CLEAN_$(d) := output

--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -5,13 +5,13 @@ d := $(dir)
 ifeq ($(d),)
 
 d := .
-cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
 .PHONY: all
 all: $(d)/.done
 
 $(d)/.done:
-	$(MAKE) -C .. $(cwd)/.done
+	$(MAKE) -C ../.. $(cwd)/.done
 
 .PHONY: check
 check: $(d)/.done

--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -1,32 +1,56 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := $(shell python3 test_scalar_advection_diffusion_DH27.py)
+ifeq ($(d),)
 
-sentinels := $(addprefix .sentinel.,$(cases))
+d := .
+cwd := $(shell realpath --strip --relative-to=.. $(CURDIR))
 
-.PHONY: all $(cases) clean check
+.PHONY: all
+all: $(d)/.done
 
-all: $(cases) integrated_q.log integrated_q_DH219.log
+$(d)/.done:
+	$(MAKE) -C .. $(cwd)/.done
 
-$(cases): %: .sentinel.%
-
-$(sentinels) : category := scalar_advection_diffusion_DH27
-$(sentinels) : exec_args = $(subst .sentinel.,,$@)
-$(sentinels) : desc = $(exec_args)
-$(sentinels) : scalar_advection_diffusion_DH27.py
-	$(run-python)
-
-integrated_q.log : category := tests
-integrated_q.log: scalar_advection_diffusion.py
-	$(run-python)
-
-integrated_q_DH219.log : category := tests
-integrated_q_DH219.log: scalar_advection_diffusion_DH219_skew.py
-	$(run-python)
-
-clean:
-	rm -f *.dat .sentinel.* *.log
-	rm -rf __pycache__
-
-check: $(sentinels)
+.PHONY: check
+check: $(d)/.done
 	python3 -m pytest
+
+else
+
+CASES_$(d) := $(shell python3 $(d)/test_scalar_advection_diffusion_DH27.py)
+TGT_$(d) := $(addprefix $(d)/.sentinel.,$(CASES_$(d)))
+SRC_$(d) := $(d)/scalar_advection_diffusion_DH27.py
+CLEAN_$(d) := *.dat *.log .sentinel.*
+DIR_CLEAN_$(d) := __pycache__
+
+$(TGT_$(d)) : category := scalar_advection_diffusion_DH27
+$(TGT_$(d)) : exec_args = $(patsubst .sentinel.%,%,$(notdir $@))
+$(TGT_$(d)) : desc = $(exec_args)
+$(TGT_$(d)): $(d)/scalar_advection_diffusion_DH27.py
+	$(run-python)
+
+TGT_$(d) += $(d)/integrated_q.log $(d)/integrated_q_DH219.log
+SRC_$(d) += $(d)/scalar_advection_diffusion.py $(d)/scalar_advection_diffusion_DH219_skew.py
+
+$(d)/integrated_q.log : category := tests
+$(d)/integrated_q.log: $(d)/scalar_advection_diffusion.py
+	$(run-python)
+
+$(d)/integrated_q_DH219.log : category := tests
+$(d)/integrated_q_DH219.log: $(d)/scalar_advection_diffusion_DH219_skew.py
+	$(run-python)
+
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
+
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/viscoelastic/Makefile
+++ b/tests/viscoelastic/Makefile
@@ -1,20 +1,40 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-cases := elastic viscoelastic viscous
-output_files := $(foreach case,$(cases),errors-$(case)-zhong-free-surface.dat)
+ifeq ($(d),)
 
-.PHONY: all clean check
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-all: $(output_files)
+.PHONY: all
+all: $(d)/.done
 
-errors-%-zhong-free-surface.dat : category := tests/viscoelastic
-errors-%-zhong-free-surface.dat : exec_args = --case $*
-errors-%-zhong-free-surface.dat : desc = $*
-errors-%-zhong-free-surface.dat: zhong_viscoelastic_free_surface.py
-	$(run-python)
-	
-clean:
-	rm -rf errors*.dat __pycache__
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
 
-check: $(output_files)
+.PHONY: check
+check: $(d)/.done
 	python3 -m pytest
+
+else
+
+CASES_$(d) := elastic viscoelastic viscous
+TGT_$(d) := $(CASES_$(d):%=$(d)/errors-%-zhong-free-surface.dat)
+SRC_$(d) := $(d)/zhong_viscoelastic_free_surface.py
+CLEAN_$(d) := *.dat
+DIR_CLEAN_$(d) := __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)) : category := tests/viscoelastic
+$(TGT_$(d)) : exec_args = --case $*
+$(TGT_$(d)) : desc = $*
+$(TGT_$(d)): $(d)/errors-%-zhong-free-surface.dat: $(SRC_$(d))
+	$(run-python)
+
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))

--- a/tests/viscoplastic_case_DG/Makefile
+++ b/tests/viscoplastic_case_DG/Makefile
@@ -1,17 +1,42 @@
-include ../../rules.mk
+sp := $(sp).x
+dirstack_$(sp) := $(d)
+d := $(dir)
 
-.PHONY: all clean check
+ifeq ($(d),)
 
-all: params.log
+d := .
+cwd := $(shell realpath --strip --relative-to=../.. $(CURDIR))
 
-params.log : category := tests
-params.log : ncpus := 4
-params.log: viscoplastic_case_DG.py
+.PHONY: all
+all: $(d)/.done
+
+$(d)/.done:
+	$(MAKE) -C ../.. $(cwd)/.done
+
+.PHONY: check
+check: $(d)/.done
+	python3 -m pytest ../../demos/test_all.py -k $(shell realpath --strip --relative-to=../../demos $(CURDIR))
+
+else
+
+TGT_$(d) := $(d)/params.log
+SRC_$(d) := $(d)/viscoplastic_case_DG.py
+CLEAN_$(d) := *.pvd *.vtu *.pvtu *.h5 params.log .done
+DIR_CLEAN_$(d) := output __pycache__
+
+$(d)/.done: $(TGT_$(d))
+	@touch $@
+
+$(TGT_$(d)): category := tests
+$(TGT_$(d)): ncpus := 4
+$(TGT_$(d)): $(SRC_$(d))
 	$(run-python)
 
-clean:
-	rm -f *.pvd *.vtu *.pvtu *.h5 params.log
-	rm -rf output __pycache__
+TGT := $(TGT) $(TGT_$(d))
+CLEAN := $(CLEAN) $(addprefix $(d)/,$(CLEAN_$(d)))
+DIR_CLEAN := $(DIR_CLEAN) $(addprefix $(d)/,$(DIR_CLEAN_$(d)))
 
-check: params.log
-	python3 -m pytest $(CURDIR)/../../demos/test_all.py -k "../tests/viscoplastic_case_DG"
+endif
+
+d := $(dirstack_$(sp))
+sp := $(basename $(sp))


### PR DESCRIPTION
## Context

I'll start off by saying that this is more of a request for feedback than a definite feature that should go in. I'll definitely take the blame for implementing a recursive Make system for running the tests/demos. There are some advantages:
- Makefiles for a given directory are fairly standalone
- things like parallel make still work just fine

But I also see some disadvantages:
- incorporating a case into the overall build system requires a bit of "global state" in the `makefile.cases.inc` file
- we can't record dependencies between separate cases (i.e. saying that dynamic topography requires the base case)
- the rules enforced some structure on filenames (tutorial notebooks having the same name as their containing directory)

## This PR

I've attempted to restructure the system with a bit of retrospective context about what we're actually using it for. In particular, I think it's a bit more logical for adding new cases (and demos). Importantly, we can also put arbitrary dependencies between different targets and cases. However, the structure of an individual Makefile does radically change.

I've written a new documentation page giving a bit of an overview of the system, and how to approach it from the viewpoint of adding a new case: https://gist.github.com/angus-g/8ba3b2374a8abd1920f99e02e06e2b28

To get an idea of how the files themselves are structured, I'd probably recommend reading the base [`Makefile`](https://github.com/g-adopt/g-adopt/blob/angus-g/makefile-restructure/Makefile), then [`demos/Makefile`](https://github.com/g-adopt/g-adopt/blob/angus-g/makefile-restructure/demos/Makefile), [`demos/mantle_convection/Makefile`](https://github.com/g-adopt/g-adopt/blob/angus-g/makefile-restructure/demos/mantle_convection/Makefile) and finally [`demos/mantle_convection/base_case/Makefile`](https://github.com/g-adopt/g-adopt/blob/angus-g/makefile-restructure/Makefile). The "category-level" files are vaguely the same, and largely won't require interaction (except for adding to a single line for adding new cases), but the Makefile for the base case is where the largest changes are.

At the moment, I'm not settled on the level of automation (magic) to include, so I haven't got full feature parity across the cases: you can't run `make clean` in an individual directory. The base case does show a possible implementation of this, using the `$(CLEAN_$(d))` target. 

## What I'm looking for

Ultimately, it would be nice to know whether this at all desirable. We could instead just live with running some of our test cases several times. We have 3 or 4 re-runs across the test suite currently, but this is the only strategy we have at the moment as we can't set dependencies between cases. Nothing is set in stone, and if there's something you violently disagree with, I'm open to changing it!