### PR TITLE
Unpin VTK from <9.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
   "pandas",
   "shapely",
-  "vtk<9.5.0",
+  "vtk",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
pyvista has had its 0.46.0 release, which should bring compatibility with this VTK version.