### PR TITLE
Remove level 3 from spherical analytical cases

### DIFF
--- a/tests/analytical_comparisons/analytical.py
+++ b/tests/analytical_comparisons/analytical.py
@@ -37,16 +37,16 @@ cases = {
         },
         "spherical": {
             "freeslip": {
-                "cores": [24, 48, 96, 192],  # cascade lake
-                "levels": [3, 4, 5, 6],
+                "cores": [48, 96, 192],  # cascade lake
+                "levels": [4, 5, 6],
                 "l": [2, 8],
                 "m": [2, 1],  # divide l by this value to get actual m
                 "k": [3, 9],
                 "permutate": False,
             },
             "zeroslip": {
-                "cores": [24, 48, 96, 192],
-                "levels": [3, 4, 5, 6],
+                "cores": [48, 96, 192],
+                "levels": [4, 5, 6],
                 "l": [2, 8],
                 "m": [2, 1],
                 "k": [3, 9],

--- a/tests/analytical_comparisons/test_analytical.py
+++ b/tests/analytical_comparisons/test_analytical.py
@@ -25,8 +25,16 @@ enabled_cases = {
         "rtol": 2e-1,
         "ns_lb": 5e-2,
     },
-    "smooth_spherical_freeslip": {"convergence": (4.0, 2.0, 2.0), "rtol": 1e-1},
-    "smooth_spherical_zeroslip": {"convergence": (4.0, 2.0, 2.0), "rtol": 1e-1},
+    "smooth_spherical_freeslip": {
+        "convergence": (4.0, 2.0, 2.0),
+        "rtol": 1e-1,
+        "ns_lb": 1e-1,
+    },
+    "smooth_spherical_zeroslip": {
+        "convergence": (4.0, 2.0, 2.0),
+        "rtol": 1e-1,
+        "ns_lb": 1e-1,
+    },
 }
 
 longtest_cases = [


### PR DESCRIPTION
These don't converge so well at the lower grid refinements, but the behaviour is still correct. Extending to level 7, both cases are displaying the expected convergence:

Free slip:

   l2error_u  l2error_p  l2error_sigma
1   3.990554   1.863376       1.776315
2   3.938721   1.975899       1.956374
3   3.915053   1.993982       1.990689
4   3.894285   1.998381       1.998217

Zero slip:

   l2error_u  l2error_p  l2error_sigma
1   4.073229   1.823242       1.789542
2   3.914674   1.970972       1.958939
3   3.887527   1.993600       1.990625
4   3.886618   1.998406       1.997803

Instead of making the test accept values from 1.75-2.01, we can drop level 3 and accept values from 1.9 to 2.1, which should hopefully make it easier to spot issues. This way we'll hopefully be back to green on the HPC suite!
