### PR TITLE
Update notebook conversion to use nbconvert

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -57,9 +57,9 @@ jobs:
         run: |
           apt install -y uidmap iproute2
           . .venv/bin/activate
-          jupytext_location="$(which jupytext)"
-          cp .testing/jupytext "$jupytext_location"
-          chmod +x "$jupytext_location"
+          nbconvert_location="$(which jupyter-nbconvert)"
+          cp .testing/jupyter-nbconvert "$nbconvert_location"
+          chmod +x "$nbconvert_location"
 
       - name: Convert notebooks
         run: |

--- a/.testing/jupyter-nbconvert
+++ b/.testing/jupyter-nbconvert
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+XDG_CACHE_HOME=$HOME/.cache unshare --map-root-user --net bash -c "ip link set lo up && python3 -m nbconvert $*" -- "$@"

--- a/.testing/jupytext
+++ b/.testing/jupytext
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-XDG_CACHE_HOME=$HOME/.cache unshare --map-root-user --net bash -c "ip link set lo up && python3 -m jupytext $*" -- "$@"

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -45,6 +45,6 @@ check:
 # instead of trying to fix it at the jupyter level, we can serialise the startup with a semaphore
 %.ipynb: %.py
 	jupytext --to ipynb $<
-	jupyter nbconvert --to notebook --execute --inplace \
+	jupyter-nbconvert --to notebook --execute --inplace \
 		--TagRemovePreprocessor.enabled=True --TagRemovePreprocessor.remove_cell_tags='["exercise"]' \
 		$@


### PR DESCRIPTION
I broke this in #248, forgetting that the execution will be done by `nbconvert` rather than in the `jupytext` stage. Of course, *most* of the workflow runs worked, except for when it got to master :roll_eyes: 

Here's an example successful run (not that that counts for much, apparently!): https://github.com/g-adopt/g-adopt/actions/runs/16957289178