### PR TITLE
Run longtests periodically

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -11,16 +11,20 @@ on:
           - all
           - gadi
           - setonix
+  schedule:
+    - cron: "5 19 * * 0"
 
 jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
       system_matrix: ${{ steps.build_matrix.outputs.system_matrix }}
+    env:
+      SYSTEM: ${{ inputs.system || 'all' }}
     steps:
     - id: build_matrix
       run: |
-        if [[ "${{ inputs.system }}" == "all" ]]; then
+        if [[ "${SYSTEM}" == "all" ]]; then
           export SYSTEMS='[ "gadi", "setonix" ]'
         else
           export SYSTEMS='[ "${{ inputs.system }}" ]'


### PR DESCRIPTION
Run long tests on all HPC systems at 1905 Sunday UTC (5:05am AEST, 6:05am AEDT every Monday). Scheduled downtimes on Gadi and Setonix are on Tuesdays, so these jobs should not be affected by scheduled downtimes.