### PR TITLE
Incomplete `check` target for `scalar_advection_diffusion`

### DIFF
--- a/tests/scalar_advection_diffusion/Makefile
+++ b/tests/scalar_advection_diffusion/Makefile
@@ -10,10 +10,10 @@ all: $(cases) integrated_q.log integrated_q_DH219.log
 
 $(cases): %: .sentinel.%
 
-$(sentinels) : category := scalar_advection_diffusion_DH27
+$(sentinels) : category := tests
 $(sentinels) : exec_args = $(subst .sentinel.,,$@)
 $(sentinels) : desc = $(exec_args)
-$(sentinels) : scalar_advection_diffusion_DH27.py
+$(sentinels): scalar_advection_diffusion_DH27.py
 	$(run-python)
 
 integrated_q.log : category := tests
@@ -28,5 +28,5 @@ clean:
 	rm -f *.dat .sentinel.* *.log
 	rm -rf __pycache__
 
-check: $(sentinels)
+check: all
 	python3 -m pytest


### PR DESCRIPTION
The `check` target currently only runs one of the three test scripts. The proposed changes fix this issue.