### PR TITLE
Make direct solver parameters the default for 2-D simulations

### DIFF
--- a/demos/glacial_isostatic_adjustment/2d_cylindrical/2d_cylindrical.py
+++ b/demos/glacial_isostatic_adjustment/2d_cylindrical/2d_cylindrical.py
@@ -447,6 +447,7 @@ stokes_solver = ViscoelasticStokesSolver(
     displacement,
     dt=dt,
     bcs=stokes_bcs,
+    solver_parameters="iterative",
     constant_jacobian=True,
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,

--- a/demos/mantle_convection/2d_cylindrical/2d_cylindrical.py
+++ b/demos/mantle_convection/2d_cylindrical/2d_cylindrical.py
@@ -166,6 +166,7 @@ stokes_solver = StokesSolver(
     approximation,
     T,
     bcs=stokes_bcs,
+    solver_parameters="iterative",
     constant_jacobian=True,
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,

--- a/demos/mantle_convection/dynamic_topography/dynamic_topography.py
+++ b/demos/mantle_convection/dynamic_topography/dynamic_topography.py
@@ -126,7 +126,6 @@ stokes_solver = StokesSolver(
     bcs=stokes_bcs,
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,
-    solver_parameters="direct",
 )
 
 stokes_solver.solve()

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -468,7 +468,7 @@ class StokesSolverBase(abc.ABC, metaclass=MetaPostInit):
                     self.solver_parameters |= iterative_stokes_solver_parameters
                 case _:
                     raise ValueError("Solver type must be 'direct' or 'iterative'.")
-        elif self.mesh.topological_dimension() == 2 and is_cartesian(self.mesh):
+        elif self.mesh.topological_dimension() == 2:
             self.solver_parameters |= direct_stokes_solver_parameters
         else:
             self.solver_parameters |= iterative_stokes_solver_parameters

--- a/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
+++ b/tests/2d_cylindrical_TALA_DG/2d_cylindrical_TALA_DG.py
@@ -207,6 +207,7 @@ stokes_solver = StokesSolver(
     approximation,
     T,
     bcs=stokes_bcs,
+    solver_parameters="iterative",
     solver_parameters_update={"fieldsplit_0": {"ksp_converged_reason": None}},
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,

--- a/tests/adjoint_2d_cylindrical/forward.py
+++ b/tests/adjoint_2d_cylindrical/forward.py
@@ -87,7 +87,6 @@ def run_forward(visualise=False):
         approximation,
         T,
         bcs=stokes_bcs,
-        solver_parameters="direct",
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,

--- a/tests/adjoint_2d_cylindrical/inverse.py
+++ b/tests/adjoint_2d_cylindrical/inverse.py
@@ -244,7 +244,6 @@ def generate_inverse_problem(alpha_T=1.0, alpha_u=-1, alpha_d=-1, alpha_s=-1, ch
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,
         near_nullspace=Z_near_nullspace,
-        solver_parameters="direct",
     )
 
     # Control variable for optimisation

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip.py
@@ -85,6 +85,7 @@ def model(level, nn, do_write=False):
         approximation,
         additional_forcing_term=additional_forcing_term,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_freeslip_dpc.py
@@ -86,6 +86,7 @@ def model(level, nn, do_write=False):
         approximation,
         additional_forcing_term=additional_forcing_term,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip.py
@@ -85,6 +85,7 @@ def model(level, nn, do_write=False):
         approximation,
         additional_forcing_term=additional_forcing_term,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
+++ b/tests/analytical_comparisons/delta_cylindrical_zeroslip_dpc.py
@@ -86,6 +86,7 @@ def model(level, nn, do_write=False):
         approximation,
         additional_forcing_term=additional_forcing_term,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freeslip.py
@@ -79,6 +79,7 @@ def model(level, k, nn, do_write=False):
         approximation,
         T,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_freesurface.py
@@ -115,6 +115,7 @@ def model(level, k, nn, do_write=False):
         T,
         dt=dt,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
+++ b/tests/analytical_comparisons/smooth_cylindrical_zeroslip.py
@@ -79,6 +79,7 @@ def model(level, k, nn, do_write=False):
         approximation,
         T,
         bcs=stokes_bcs,
+        solver_parameters="iterative",
         solver_parameters_update=solver_parameters_update,
         nullspace=Z_nullspace,
         transpose_nullspace=Z_nullspace,

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -53,8 +53,9 @@ def test_solver_parameters_argument(test_case):
         case "cartesian_false":
             mesh.cartesian = False
             solver_parameters = None
-            expected_value = base_linear_params_with_log | iterative_stokes_solver_parameters
-            expected_value["fieldsplit_1"] |= {"ksp_converged_reason": None}
+            expected_value = (
+                base_linear_params_with_log | direct_stokes_solver_parameters
+            )
         case "linear_false":
             mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
             solver_parameters = "direct"


### PR DESCRIPTION
To have a consistent behaviour between transport and Stokes solvers, this PR enforces direct solver parameters for all 2-D simulations. Existing demos and tests that relied on an iterative solver now explicitly specify this need.

Closes #125