### PR TITLE
Request Riesz representation on derivative calls

### DIFF
--- a/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
@@ -125,7 +125,15 @@ tape.clear_tape()
 
 T0.project(T_wrong)
 
-m = Control(T0)
+# At this stage we need to define the control variable for the adjoint-based optimisation problem
+# by wrapping T0 in a Control object.
+# This registers T0 as the optimisation variable with pyadjoint's automatic differentiation framework.
+# Furthermore, the L2 Riesz map specification is crucial for two reasons:
+# 1. It defines the inner product structure on the control space, ensuring that gradients are computed
+#    in the $L^2$ Hilbert space with respect to the inner product.
+# 2. It guarantees mesh-independent gradient representations, which is essential for consistent
+#    optimisation convergence across different mesh refinements in finite element discretisations.
+m = Control(T0, riesz_map="L2")
 
 J = AdjFloat(0.0)  # Initialise functional
 factor = AdjFloat(0.5)  # First & final boundary integral weighted by 0.5 to implement mid-point rule time-integration.
@@ -171,9 +179,8 @@ print(reduced_functional(T0_ref))
 T_wrong.assign(0.0)
 reduced_functional(T_wrong)
 
-# In unstructured mesh optimisation problems, it is important to work in the L2 Riesz representation
-# to ensure a grid-independent result:
-
+# Here we calculate the derivative by calling the derivative method of the reduced functional.
+# We need to apply the L2 Riesz map to the gradient to ensure a grid-independent result.
 gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]

--- a/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
@@ -124,15 +124,20 @@ tape = get_working_tape()
 tape.clear_tape()
 
 T0.project(T_wrong)
+# -
 
 # At this stage we need to define the control variable for the adjoint-based optimisation problem
-# by wrapping T0 in a Control object.
-# This registers T0 as the optimisation variable with pyadjoint's automatic differentiation framework.
+# by wrapping `T0` in a Control object.
+# This registers `T0` as the optimisation variable with pyadjoint's automatic differentiation framework.
 # Furthermore, the L2 Riesz map specification is crucial for two reasons:
 # 1. It defines the inner product structure on the control space, ensuring that gradients are computed
 #    in the $L^2$ Hilbert space with respect to the inner product.
 # 2. It guarantees mesh-independent gradient representations, which is essential for consistent
 #    optimisation convergence across different mesh refinements in finite element discretisations.
+#
+# Note that L2 is the default Riesz map if none is explicitly specified.
+
+# +
 m = Control(T0, riesz_map="L2")
 
 J = AdjFloat(0.0)  # Initialise functional
@@ -179,8 +184,10 @@ print(reduced_functional(T0_ref))
 T_wrong.assign(0.0)
 reduced_functional(T_wrong)
 
-# Here we calculate the derivative by calling the derivative method of the reduced functional.
-# We need to apply the L2 Riesz map to the gradient to ensure a grid-independent result.
+# Here we calculate the gradient by calling the derivative method of
+# the reduced functional with the L2 Riesz map applied to ensure a
+# grid-independent result.
+
 gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]

--- a/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
@@ -174,7 +174,7 @@ reduced_functional(T_wrong)
 # In unstructured mesh optimisation problems, it is important to work in the L2 Riesz representation
 # to ensure a grid-independent result:
 
-gradJ = reduced_functional.derivative(options={"riesz_representation": "L2"})
+gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]
 # fig, axes = plt.subplots()

--- a/demos/PDE_constrained_optimisation/PDE_constrained_field.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_field.py
@@ -135,11 +135,13 @@ tape.clear_tape()
 
 T0.project(T_target)
 
-# We want to optimise this initial temperature state, T0, and so we specify this as the *control*:
-# Here we specify the L2 Riesz map specification which is to define the inner product structure on
-# the control space, ensuring that gradients are computed in the $L^2$ Hilbert space with respect
-# to the inner product.
-m = Control(T0)
+# We want to optimise this initial temperature state, T0, and so we
+# specify this as the *control*: Here we specify the L2 as the Riesz
+# map, which defines the inner product structure on the control space,
+# ensuring that gradients are computed in the $L^2$ Hilbert space with
+# respect to the inner product.
+
+m = Control(T0, riesz_map="L2")
 
 # Based on our guess for the initial temperature, we run the model for a specified number of timesteps:
 
@@ -211,6 +213,7 @@ reduced_functional(T_target)
 
 # We note that in unstructured mesh optimisation problems, it is important to work in the L2 Riesz
 # representation to ensure a grid-independent result:
+
 gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]

--- a/demos/PDE_constrained_optimisation/PDE_constrained_field.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_field.py
@@ -136,7 +136,9 @@ tape.clear_tape()
 T0.project(T_target)
 
 # We want to optimise this initial temperature state, T0, and so we specify this as the *control*:
-
+# Here we specify the L2 Riesz map specification which is to define the inner product structure on
+# the control space, ensuring that gradients are computed in the $L^2$ Hilbert space with respect
+# to the inner product.
 m = Control(T0)
 
 # Based on our guess for the initial temperature, we run the model for a specified number of timesteps:
@@ -209,7 +211,6 @@ reduced_functional(T_target)
 
 # We note that in unstructured mesh optimisation problems, it is important to work in the L2 Riesz
 # representation to ensure a grid-independent result:
-
 gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]

--- a/demos/PDE_constrained_optimisation/PDE_constrained_field.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_field.py
@@ -210,7 +210,7 @@ reduced_functional(T_target)
 # We note that in unstructured mesh optimisation problems, it is important to work in the L2 Riesz
 # representation to ensure a grid-independent result:
 
-gradJ = reduced_functional.derivative(options={"riesz_representation": "L2"})
+gradJ = reduced_functional.derivative(apply_riesz=True)
 
 # + tags=["active-ipynb"]
 # fig, axes = plt.subplots()

--- a/tests/unit/test_adjoints.py
+++ b/tests/unit/test_adjoints.py
@@ -42,7 +42,7 @@ def tape_generation_staggered_solves(scheduler):
     # Storing the diagnostics
     ret = {}
     ret["J1"] = reduced_functional(u_0)
-    ret["dJdm1"] = reduced_functional.derivative().dat.data_ro.copy()
+    ret["dJdm1"] = reduced_functional.derivative(apply_riesz=True).dat.data_ro.copy()
 
     return ret
 
@@ -78,7 +78,7 @@ def tape_generation_control_invariant_assign(scheduler):
     reduced_functional = ReducedFunctional(J, Control(u_0))
 
     J = reduced_functional(u_0)
-    dJdm = reduced_functional.derivative()
+    dJdm = reduced_functional.derivative(apply_riesz=True)
 
     ret = {}
     ret["djdm_0"] = dJdm.dat.data_ro
@@ -96,13 +96,13 @@ def tape_generation_control_invariant_assign(scheduler):
     Jm = reduced_functional(u_0)
     ret["j_1"] = Jm
 
-    dJdm = reduced_functional.derivative()
+    dJdm = reduced_functional.derivative(apply_riesz=True)
     dJdm = dtemp._ad_dot(dJdm)
     ret["djdm_2"] = dJdm
 
     Jm = reduced_functional(u_0)
     ret["j_2"] = Jm
-    dJdm = reduced_functional.derivative()
+    dJdm = reduced_functional.derivative(apply_riesz=True)
     dJdm = dtemp._ad_dot(dJdm)
     ret["djdm_3"] = dJdm
 


### PR DESCRIPTION
For testing and visualisation, we want to be dealing with the primal derivative quantity (the gradient), so we need to explicitly apply the Riesz representation. This is the API change due to the `AbstractReducedFunctional` in pyadjoint.