### PR TITLE
Avoid creating a FunctionSpace from a MeshSequenceGeometry

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -967,10 +967,10 @@ class BoundaryNormalStressSolver(SolverConfigurationMixin):
                 "BoundaryNormalStressSolver: Pressure field is discontinuous. Using an equivalent continous lagrange element."
             )
             Q = fd.FunctionSpace(
-                self.mesh.unique(), "Lagrange", self.p.function_space().ufl_element().degree()
+                self.p.function_space().mesh(), "Lagrange", self.p.function_space().ufl_element().degree()
             )
         else:
-            Q = fd.FunctionSpace(self.mesh.unique(), self.p.ufl_element())
+            Q = fd.FunctionSpace(self.p.function_space().mesh(), self.p.ufl_element())
 
         self.force = fd.Function(Q, name=f"force_{self.subdomain_id}")
 


### PR DESCRIPTION
I'm not sure what situation causes this to happen, but we may have to call `mesh.unique()` when creating FunctionSpaces if the mesh is a `MeshSequenceGeometry`.

@dsroberts do you know why we don't need this e.g. here https://github.com/g-adopt/g-adopt/blob/2391f0d220c3b5eca7b791ebac4aad191d4e7894/gadopt/stokes_integrators.py#L734