### PR TITLE
Fix time-step logic in `update_forcings`

### DIFF
--- a/gadopt/time_stepper.py
+++ b/gadopt/time_stepper.py
@@ -72,7 +72,6 @@ class TimeIntegrator(TimeIntegratorBase):
         self.equation = equation
         self.test = firedrake.TestFunction(solution.function_space())
         self.solution = solution
-        self.dt = float(dt)
         self.dt_const = ensure_constant(dt)
         self.solution_old = solution_old or firedrake.Function(solution, name='Old'+solution.name())
 
@@ -198,7 +197,7 @@ class ERKGeneric(RungeKuttaTimeIntegrator):
         """Evaluates the tendency of i-th stage"""
         if self._nontrivial:
             if update_forcings is not None and t is not None:
-                update_forcings(t + self.c[i_stage] * self.dt)
+                update_forcings(t + self.c[i_stage] * float(self.dt_const))
             elif update_forcings is not None:
                 update_forcings()
 
@@ -323,7 +322,7 @@ class DIRKGeneric(RungeKuttaTimeIntegrator):
             raise ValueError('Time integrator {:} is not initialized'.format(self.name))
 
         if update_forcings is not None and t is not None:
-            update_forcings(t + self.c[i_stage] * self.dt)
+            update_forcings(t + self.c[i_stage] * float(self.dt_const))
         elif update_forcings is not None:
             update_forcings()
 


### PR DESCRIPTION
The time step currently used in `update_forcings` is set in stone when the time stepper is instantiated. This is an issue if the simulation's time step varies along the way. This PR addresses this issue. 