### PR TITLE
Small update to `get_boundary_ids`

### DIFF
--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -518,7 +518,24 @@ def interpolate_1d_profile(function: Function, one_d_filename: str):
     averager.extrapolate_layer_average(function, interpolated_visc)
 
 
-def get_boundary_ids(mesh) -> SimpleNamespace:
+class BoundaryIDNamespace(SimpleNamespace):
+    def keys(self):
+        return self.__dict__.keys()
+
+    def items(self):
+        return self.__dict__.items()
+
+    def values(self):
+        return self.__dict__.values()
+
+    def __contains__(self, item):
+        return item in self.__dict__
+
+    def __iter__(self):
+        return self.values().__iter__()
+
+
+def get_boundary_ids(mesh) -> BoundaryIDNamespace:
     # PETSc creates these labels when loading meshes from files, Firedrake imitates it
     # in its own mesh creation functions.
 
@@ -587,7 +604,7 @@ def get_boundary_ids(mesh) -> SimpleNamespace:
     # utilised by 'CombinedSurfaceMeasure' above
     else:
         kwargs = {"bottom": "bottom", "top": "top"}
-    return SimpleNamespace(**kwargs)
+    return BoundaryIDNamespace(**kwargs)
 
 
 def extruded_layer_heights(

--- a/tests/unit/test_symmetry.py
+++ b/tests/unit/test_symmetry.py
@@ -70,7 +70,7 @@ def test_stokes_symmetry(approximation, mesh, solution_space):
 
     T = fd.Function(solution_space.sub(1))
     boundary = gadopt.get_boundary_ids(mesh)
-    bids = list(vars(boundary).values())
+    bids = list(boundary)
     bcs = {bids[0]: {'un': 0}, bids[1]: {'normal_stress': 0}}
     # cylindrical/spherical meshes only have 2 boundaries
     # if we have more, let's test some more bc types


### PR DESCRIPTION
This update subclasses `SimpleNamespace` to provide a few convenience routines for accessing the `__dict__` attribute of the object returned from `get_boundary_ids`. Needed as part of the diagnostic base class update, but out of scope for those changes.