### PR TITLE
Symlink forward model output for adjoint_ice demo

### DIFF
--- a/demos/glacial_isostatic_adjustment/adjoint_ice/Makefile
+++ b/demos/glacial_isostatic_adjustment/adjoint_ice/Makefile
@@ -10,7 +10,7 @@ functional.txt: adjoint_ice.py forward-2d-cylindrical-disp-vel.h5
 
 forward-2d-cylindrical-disp-vel.h5: ../2d_cylindrical_lvv/2d_cylindrical_lvv.py
 	$(MAKE) -C ../2d_cylindrical_lvv
-	cp ../2d_cylindrical_lvv/forward-2d-cylindrical-disp-vel.h5 .
+	ln -s ../2d_cylindrical_lvv/forward-2d-cylindrical-disp-vel.h5
 
 clean:
 	rm -rf functional.txt taylor_test_minconv.txt *.h5 *.pvd adj_ice ice optimisation_checkpoint output updated* viscosity


### PR DESCRIPTION
Hopefully a workaround for the `adjoint_ice` failures we've been seeing in the CI until the non-recursive makefile structure is in place.