### PR TITLE
Generalise boundaries in `BaseDiagnostics`

### DIFF
--- a/gadopt/diagnostics.py
+++ b/gadopt/diagnostics.py
@@ -112,10 +112,8 @@ class FunctionContext:
     @cached_property
     def boundary_ids(self):
         """The boundary IDs of the mesh associated with this instance"""
-        return (
-            tuple(self.mesh.topology.exterior_facets.unique_markers) + ("top", "bottom")
-            if self.mesh.extruded
-            else ()
+        return tuple(self.mesh.topology.exterior_facets.unique_markers) + (
+            ("top", "bottom") if self.mesh.extruded else ()
         )
 
     @cache


### PR DESCRIPTION
This change uses `mesh.topology.exterior_facets.unique_markers` to determine which boundary IDs are valid for diagnostics rather than relying on `get_boundary_ids()`. Also allows tuples to be passed in as boundary ids. Resolves #358.