### PR TITLE
Fix pandas 3.0 compatibility in test assertions

### DIFF
--- a/demos/test_all.py
+++ b/demos/test_all.py
@@ -64,7 +64,11 @@ def check_series(
     extra_checks,
 ):
     pd.testing.assert_series_equal(
-        actual[["u_rms"] + extra_checks], expected, check_names=False, **compare_params
+        actual[["u_rms"] + extra_checks],
+        expected,
+        check_names=False,
+        check_index_type=False,
+        **compare_params,
     )
 
     assert abs(actual.name - expected.name) <= convergence_tolerance

--- a/tests/base_gmsh/test_base_case.py
+++ b/tests/base_gmsh/test_base_case.py
@@ -24,7 +24,7 @@ def hash_check():
 def test_base_case():
     df = pd.read_csv(b / "params.log", sep="\\s+", header=0).iloc[-1]
     expected = pd.read_pickle(b / "expected.pkl")
-    kwargs = {"check_names": False}
+    kwargs = {"check_names": False, "check_index_type": False}
     different_mesh = hash_check()
     if different_mesh:
         kwargs |= {"rtol": 1e-4}


### PR DESCRIPTION
## Summary
- Add `check_index_type=False` to `pd.testing.assert_series_equal` calls in `demos/test_all.py` and `tests/base_gmsh/test_base_case.py`

## Context
Pandas 3.0.0 changed the default string dtype from `object` to `StringDtype`, causing test failures when comparing against expected data pickled with older pandas versions.

Closes #364