### PR TITLE
Fix numpy 'where' without 'out' warning in gplates

### DIFF
--- a/gadopt/gplates/gplates.py
+++ b/gadopt/gplates/gplates.py
@@ -529,6 +529,7 @@ class pyGplatesConnector(object):
 
         # Rescale to preserve original magnitude (avoid division by zero)
         scale_factor = np.divide(original_magnitudes, tangential_magnitudes,
+                                 out=np.ones_like(original_magnitudes),
                                  where=tangential_magnitudes > pyGplatesConnector.eps_rel)
 
         res_u = res_u_tangential * scale_factor[:, np.newaxis]


### PR DESCRIPTION
## Summary
- Fixes numpy warning: `'where' used without 'out', expect uninitialized memory in output`
- Adds `out=np.ones_like(original_magnitudes)` to `np.divide` call in velocity tangent projection
- Default of 1.0 is correct: when tangential magnitude is near zero, no rescaling is needed

This should remove the warnings visible on https://gadopt.org/tutorials/mantle_convection/gplates_global/