### PR TITLE
Don't use build isolation for installing animate

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -54,7 +54,7 @@ jobs:
 
           uv venv --system-site-packages
           uv pip install nbval nbconvert jupytext siphash24 .[demos,optimisation] pygplates
-          uv pip install git+https://github.com/mesh-adaptation/animate
+          uv pip install --no-build-isolation git+https://github.com/mesh-adaptation/animate
 
       - name: Get Muller et al 2022 plate reconstructions
         run: |


### PR DESCRIPTION
petsc4py/firedrake/etc. are *build time* requirements for animate because they appear in a Cython file. We can't reinstall these in the isolated build environment easily, so we use a non-isolated build for this package alone.

Render run at: https://github.com/g-adopt/g-adopt/actions/runs/22382568016
