### PR TITLE
Only drop leading path element on notebook file

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -472,9 +472,10 @@ def task_convert() -> Iterator[DoitTask]:
             actions.append(
                 f"tar --transform='s|/.*/|/|' --append --file artifact.tar --directory demos {notebook_path}"
             )
-            actions.append(
-                f"tar --append --file artifact.tar --directory demos {output_paths}"
-            )
+            if output_paths:
+                actions.append(
+                    f"tar --append --file artifact.tar --directory demos {output_paths}"
+                )
 
             yield make_convert_task(case_dir, step, cfg)
 


### PR DESCRIPTION
We need other outputs from notebooks to go into a subdirectory named after their respective cases, otherwise all the links break.

Render job at: https://github.com/g-adopt/g-adopt/actions/runs/22695914873, will need to check that the website tarball is built correctly.

Fixes #475