### PR TITLE
Allow tag to change base container for PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # Prefer specific branch, then PR base, then actual branch
-      image: firedrakeproject/firedrake-vanilla-default:dev-${{ inputs.target_container || github.base_ref || github.ref_name }}
+      image: firedrakeproject/firedrake-vanilla-default:dev-${{ inputs.target_container || (github.event_name == 'pull_request' && case(contains(github.event.pull_request.labels.*.name, 'container:main'), 'main', contains(github.event.pull_request.labels.*.name, 'container:release'), 'release', github.base_ref)) || github.ref_name }}
 
     needs: check_commit
     if: ${{ needs.check_commit.outputs.skip != 'true' }}


### PR DESCRIPTION
We can override the automatic selection of container by adding the `container:main` or `container:release` labels to a PR that targets a branch other than `main` or `release`.