### PR TITLE
Exclude Zenodo tags as version candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,4 @@ packages = ["gadopt", "gadopt.gplates", "gadopt.demos"]
 package-dir = { "gadopt.demos" = "demos" }
 
 [tool.setuptools_scm]
+scm.git.describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--abbrev=40", "--match", "*[0-9]*", "--exclude", "Zenodo*"]


### PR DESCRIPTION
setuptools_scm is pretty eager in the tags it picks up (anything containing a number!). We never want a "Zenodo_*" tag as a software version, so we can ignore these when getting the list of possible tags as versions.