### PR TITLE
Fix smoke test: add safe.directory for containerised git

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           apt update
           apt install -y git-lfs
+          git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The smoke_test job runs inside a Firedrake container where the checkout UID differs from the container user. When vcs-versioning calls git during `uv pip install .`, git refuses with a "dubious ownership" error and the build fails. The build job already had `git config --global --add safe.directory` but the smoke_test job was missing it — this adds the same line there.

Closes #485