### PR TITLE
Update github actions workflows to use Node24 actions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ jobs:
     name: "Run linter"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install linter

--- a/.github/workflows/memprof_plot.yml
+++ b/.github/workflows/memprof_plot.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Install plotter 
         run: |
           pip3 install git+https://github.com/g-adopt/memprof_plotter.git

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           apt update
           apt install -y git-lfs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -46,7 +46,7 @@ jobs:
           git lfs checkout
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run:
           echo skip=true >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ steps.early_exit.outputs.skip != 'true' }}
         with:
           ref: ${{ github.event.push.after || github.event.pull_request.head.sha || github.event.workflow_dispatch.ref }}
@@ -59,7 +59,7 @@ jobs:
           apt install -y git-lfs
           git config --global --add safe.directory $GITHUB_WORKSPACE
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -104,7 +104,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -113,17 +113,16 @@ jobs:
           git lfs checkout
 
       - name: Fetch task spooler
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: dsroberts/tsp_for_hpc
           path: ./tsp
           ref: ${{ vars.TSP_VERSION }}
 
       - name: Build task spooler
-        uses: threeal/cmake-action@v2
-        with:
-          source-dir: ./tsp
-          build-dir: ./tsp_build
+        run: |
+          cmake ./tsp -B ./tsp_build
+          cmake --build ./tsp_build
 
       - name: Put task spooler on PATH
         run: |
@@ -140,7 +139,7 @@ jobs:
           unzip Muller_etal_2022_SE_1Ga_Opt_PlateMotionModel_v1.2.zip -d demos/mantle_convection/gplates_global
 
       - name: Check out repository linked to Trim et al. (2023)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: seantrim/exact-thermochem-solution
           path: ./flib
@@ -174,7 +173,7 @@ jobs:
           python -m pytest -m 'not longtest' --junit-xml=test_results.xml
 
       - name: Pytest report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: ${{ !cancelled() && steps.run_pytest.conclusion != 'skipped' }}
         with:
           check_name: Test suite report
@@ -190,7 +189,7 @@ jobs:
 
       - name: Upload run log
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: run-log
           path: /tmp/tsp_db.sqlite3


### PR DESCRIPTION
Node20 actions are deprecated and being removed. This PR updates all actions to their Node24 equivalents. `longtest.yml` is updated as a part of #493.