### PR TITLE
Only run longtests on Gadi

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       system_matrix: ${{ steps.build_matrix.outputs.system_matrix }}
     env:
-      SYSTEM: ${{ inputs.system || 'all' }}
+      SYSTEM: ${{ inputs.system || 'gadi' }}
     steps:
     - id: build_matrix
       run: |


### PR DESCRIPTION
Automatic main builds are not set up on Setonix, so limit longtest runs to Gadi.