### PR TITLE
Fix scheduled longtest launches.

### DIFF
--- a/.github/workflows/longtest.yml
+++ b/.github/workflows/longtest.yml
@@ -28,7 +28,7 @@ jobs:
         if [[ "${SYSTEM}" == "all" ]]; then
           export SYSTEMS='[ "gadi", "setonix" ]'
         else
-          export SYSTEMS='[ "${{ inputs.system }}" ]'
+          export SYSTEMS='[ "'"${SYSTEM}"'" ]'
         fi
         echo system_matrix=$( jq -cn --argjson sys "$SYSTEMS" '{system: $sys}' ) >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Use `SYSTEM` variable instead of `inputs.system` to construct `SYSTEMS` json array. Schedule launches do not set inputs, this worked previously as the default used to be 'all' and the check above uses `SYSTEM`.