### PR TITLE
Build level set initialisation demo

### DIFF
--- a/demos/.pages
+++ b/demos/.pages
@@ -29,6 +29,8 @@
     - [adjoint_ice](glacial_isostatic_adjustment/adjoint_ice.ipynb)
     - [adjoint_viscosity](glacial_isostatic_adjustment/adjoint_viscosity.ipynb)
 - Multi-material
+    - Initialisation
+        - [level_set_initialisation](multi_material/level_set_initialisation.ipynb)
     - Sources of buoyancy
         - [compositional_buoyancy](multi_material/compositional_buoyancy.ipynb)
         - [thermochemical_buoyancy](multi_material/thermochemical_buoyancy.ipynb)

--- a/demos/multi_material/level_set_initialisation/meta.py
+++ b/demos/multi_material/level_set_initialisation/meta.py
@@ -1,0 +1,3 @@
+entrypoint = "level_set_initialisation.py"
+notebook = "level_set_initialisation.ipynb"
+pytest = None


### PR DESCRIPTION
For some reason this has maybe never been on the website? Even though it doesn't provide any testable output, it still has an `entrypoint` in its `meta.py` so we can ensure it runs before the render job.

- [x] Render job: https://github.com/g-adopt/g-adopt/actions/runs/25470191245