### PR TITLE
Infra: time_stepper API for stage-accurate time, dodo meta loader, primary_checks, CI label fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: self-hosted
     container:
       # Prefer specific branch, then PR base, then actual branch
-      image: firedrakeproject/firedrake-vanilla-default:dev-${{ inputs.target_container || github.base_ref || github.ref_name }}
+      image: firedrakeproject/firedrake-vanilla-default:dev-${{ inputs.target_container || (github.event_name == 'pull_request' && case(contains(github.event.pull_request.labels.*.name, 'container:main'), 'main', contains(github.event.pull_request.labels.*.name, 'container:release'), 'release', github.base_ref)) || github.ref_name }}
       options: --cap-add SYS_NICE
 
     concurrency:

--- a/demos/generate_expected.py
+++ b/demos/generate_expected.py
@@ -17,12 +17,15 @@ if __name__ == "__main__":
 
     for case in requested_cases:
         try:
-            extra_checks = cases[case].get("extra_checks", [])
+            case_config = cases[case]
         except KeyError:
             print(f"Skipping unknown case: {case}")
             continue
 
+        extra_checks = case_config.get("extra_checks", [])
+        primary_checks = case_config.get("primary_checks", ["u_rms"])
+
         b = Path(__file__).parent.resolve() / case
-        df = get_convergence(b)[["u_rms"] + extra_checks]
+        df = get_convergence(b)[primary_checks + extra_checks]
 
         df.to_pickle(b / "expected.pkl")

--- a/dodo.py
+++ b/dodo.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import uuid
 
 from doit import get_var
 from doit.action import CmdAction
@@ -51,25 +52,36 @@ def discover_cases() -> Iterator[tuple[Path, CaseMeta]]:
 def load_meta(meta_path: Path) -> CaseMeta:
     """Load a meta.py file by path.
 
-    We temporarily add the module to the system collection
-    when running the loader so that it is executed as its
-    own package. This way, the meta file can import files
-    in its directory.
+    Each meta file is loaded under its own uuid-derived package name so
+    that relative imports (``from .scaling import ...``) resolve to the
+    meta's own directory without cross-contaminating sys.modules with a
+    sibling test's equivalently named submodule. An empty
+    ``submodule_search_locations`` is the CPython-documented signal
+    that the module is a package; the loader fills in the parent
+    directory from the spec's ``origin``.
 
     Returns:
       The module resulting from loading the meta file.
 
     """
 
+    mod_name = f"meta-{uuid.uuid4()}"
+
     spec = importlib.util.spec_from_file_location(
-        "meta",
+        mod_name,
         meta_path,
         submodule_search_locations=[],
     )
     mod = importlib.util.module_from_spec(spec)
-    sys.modules["meta"] = mod
-    spec.loader.exec_module(mod)
-    del sys.modules["meta"]
+    sys.modules[mod_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        # Evict the package and every submodule it pulled in; a broken
+        # meta.py otherwise leaves stale entries behind, and a
+        # successful load has no reason to keep them around either.
+        for key in [k for k in sys.modules if k.startswith(mod_name)]:
+            del sys.modules[key]
     return mod
 
 

--- a/gadopt/time_stepper.py
+++ b/gadopt/time_stepper.py
@@ -61,6 +61,19 @@ class IrksomeIntegrator:
                 denser mass matrix with block-diagonal stiffness.
         solver_parameters:
             Dictionary of solver parameters provided to PETSc
+        t:
+            Optional pre-existing `MeshConstant` to use as the stepper's
+            internal time variable. The default (None) creates one internally
+            and the caller updates time as a Python float through `solve(t=t)`,
+            which is the standard g-adopt pattern. The kwarg is for the niche
+            case of time-dependent BC or source expressions that must see
+            stage times: build the BC referencing a shared `MeshConstant`
+            (importable from `gadopt`), pass that Constant in here, and Irksome
+            will substitute `t -> t + c_i*dt` at every stage. Without the
+            shared Constant, multi-stage methods see frozen-at-t_n forcing and
+            their formal order collapses to one. See
+            `tests/richards/test_temporal_convergence.py` and
+            `demos/groundwater/2d_vauclin/2d_vauclin.py` for examples.
         adaptive_parameters:
             Optional dict for adaptive time-stepping (`stage_type="deriv"` only).
             - `tol`
@@ -123,6 +136,7 @@ class IrksomeIntegrator:
         bc_type: str = "DAE",
         solver_parameters: dict[str, Any] | None = None,
         initial_time: float = 0.0,
+        t: fd.Constant | None = None,
         adaptive_parameters: dict[str, Any] | None = None,
         **irksome_kwargs,
     ):
@@ -140,7 +154,12 @@ class IrksomeIntegrator:
         # Create MeshConstant objects for time variables (what Irksome expects)
         # These are shared with Irksome's TimeStepper (ensures synchronisation)
         mc = MeshConstant(equation.mesh)
-        self.t = mc.Constant(initial_time)  # Shared time variable with Irksome
+        # Callers that need stage-accurate time substitution in their UFL
+        # (e.g. time-dependent BC expressions, MMS source terms) must build
+        # those expressions referencing the *same* `t` Constant Irksome advances
+        # internally. Passing `t` here lets the caller construct the form first
+        # and hand the Constant in; otherwise we create one.
+        self.t = t if t is not None else mc.Constant(initial_time)
         self.dt_irksome = mc.Constant(dt)  # Irksome's dt, synced from dt_reference
         # Store Dirichlet conditions for application before advancing the integrator
         self.strong_bcs = strong_bcs or []
@@ -324,13 +343,15 @@ class RKGeneric(IrksomeIntegrator):
                 f"{self.__class__.__name__} must define a butcher_tableau attribute"
             )
 
+        stage_type = kwargs.pop('stage_type', self.stage_type)
+        bc_type = kwargs.pop('bc_type', self.bc_type)
         super().__init__(
             equation,
             solution,
             dt,
             self.butcher_tableau,
-            stage_type=self.stage_type,
-            bc_type=self.bc_type,
+            stage_type=stage_type,
+            bc_type=bc_type,
             **kwargs,
         )
 
@@ -373,7 +394,9 @@ def create_custom_tableau(
         raise ValueError("Inconsistent Butcher tableau: Row sum of 'a' is not 'c'")
 
     return ButcherTableau(
-        A=a, b=b, btilde=None, c=c, order=len(b), embedded_order=None, gamma0=None
+        A=np.asarray(a, dtype=float), b=np.asarray(b, dtype=float),
+        btilde=None, c=np.asarray(c, dtype=float),
+        order=len(b), embedded_order=None, gamma0=None
     )
 
 
@@ -1031,7 +1054,7 @@ rk_schemes_irksome = [
 ]
 
 __all__ = (
-    ["IrksomeIntegrator"]
+    ["IrksomeIntegrator", "MeshConstant"]
     + [scheme.__name__ for scheme in rk_schemes_gadopt]
     + [scheme.__name__ for scheme in rk_schemes_irksome]
 )

--- a/gadopt/time_stepper.py
+++ b/gadopt/time_stepper.py
@@ -343,15 +343,15 @@ class RKGeneric(IrksomeIntegrator):
                 f"{self.__class__.__name__} must define a butcher_tableau attribute"
             )
 
-        stage_type = kwargs.pop('stage_type', self.stage_type)
-        bc_type = kwargs.pop('bc_type', self.bc_type)
+        kwargs = {
+            "stage_type": self.stage_type,
+            "bc_type": self.bc_type,
+        } | kwargs
         super().__init__(
             equation,
             solution,
             dt,
             self.butcher_tableau,
-            stage_type=stage_type,
-            bc_type=bc_type,
             **kwargs,
         )
 


### PR DESCRIPTION
Three cross-cutting infrastructure changes the Richards equation work needs but that are useful on their own, plus a one-line CI workflow fix.

`gadopt/time_stepper.py` picks up an optional `t` kwarg on `IrksomeIntegrator` so callers can pre-build a `MeshConstant`, pass it in, and reference it from time-dependent BC or source expressions. Without this, multi-stage methods see forcing frozen at $t_n$ and their formal order collapses to one. `MeshConstant` is re-exported from `gadopt` so users don't have to import it from Irksome. `RKGeneric` learns to accept `stage_type` and `bc_type` overrides through kwargs, which is what a mass-conservative Richards solver needs to inject `stage_type="value"` regardless of the tableau default. `create_custom_tableau` coerces its arrays to float64 so newer Irksome `ButcherTableau` objects accept them.

`dodo.py` loads each `meta.py` under a uuid-suffixed package name so relative imports resolve to the meta's own directory without sibling tests' equivalently named submodules colliding in `sys.modules`. A finally clause evicts all keys with that prefix.

`demos/generate_expected.py` learns a `primary_checks` key in case configs, defaulting to the existing `u_rms` behaviour. Demos with their own scalar diagnostics (groundwater needs `min_h`, `max_h`) can declare their primary columns explicitly.

`.github/workflows/test.yml`: line 84 now mirrors line 50's existing `case(...)` expression so the benchmark regression test honors the `container:main` and `container:release` labels, just like the smoke test already does. The label-aware logic was added to the smoke test in #479 but the benchmark test was overlooked at the time. Without this the upper layers of any stacked PR series can't run benchmark CI against a real container.

This is the bottom of a six-PR stack adding the Richards equation. The full stack lands the new module, its tests, two demos, parallel-scaling baselines, and non-stiffly-accurate verification at the tip.
