### PR TITLE
Richards tests: mass balance, temporal convergence and Vauclin reference

### DIFF
--- a/tests/richards/richards.py
+++ b/tests/richards/richards.py
@@ -4,12 +4,6 @@ import importlib
 cases = {
     "tracy_2d": {
         "specified_head": {
-            "dg0": {
-                "levels": [51, 101, 201, 401],
-                "cores": [1, 1, 4, 16],
-                "degree": 0,
-                "bc_type": "specified_head",
-            },
             "dg1": {
                 "levels": [51, 101, 201, 401],
                 "cores": [1, 1, 4, 16],

--- a/tests/richards/test_mass_balance.py
+++ b/tests/richards/test_mass_balance.py
@@ -1,0 +1,151 @@
+"""Mass conservation verification for the Richards equation solver.
+
+The stage-value formulation discretises the nonlinear mass term Dt(theta(h))
+as the exact per-stage finite difference, so theta(h) should be conserved to
+solver tolerance. We check that along two axes:
+
+(1) Function space, at fixed BackwardEuler: DQ0/DQ1/DQ2 sit at solver
+    tolerance, while CG1/CG2 pick up an O(1e-4) consistency error from the
+    lack of element-wise conservation.
+
+(2) Time-stepping scheme, at fixed DQ1: BackwardEuler, ImplicitMidpoint and
+    GaussLegendre(2) should all conserve mass to solver tolerance.
+
+The domain is a unit square with no-flux boundaries on left, right and bottom
+and a prescribed inflow flux of 1e-6 m/s on top. The soil follows a Haverkamp
+model with moderate nonlinearity, and specific storage is zero so theta(h) is
+the only conserved quantity.
+"""
+
+import pytest
+from gadopt import *
+
+
+def compute_mass_balance(grid_points, time_step, t_final,
+                         polynomial_degree, time_integrator,
+                         function_space, timestepper_kwargs=None,
+                         scheme_label=None):
+    mesh = UnitSquareMesh(grid_points, grid_points, quadrilateral=True)
+    mesh.cartesian = True
+    V = FunctionSpace(mesh, function_space, polynomial_degree)
+
+    soil_curve = HaverkampCurve(
+        theta_r=0.05,
+        theta_s=0.40,
+        Ks=1e-5,
+        alpha=0.5,
+        beta=1.3,
+        A=0.01,
+        gamma=1.5,
+        Ss=0.0,
+    )
+
+    boundary_ids = get_boundary_ids(mesh)
+    inflow_rate = 1e-06
+    richards_bcs = {
+        boundary_ids.left: {'flux': 0},
+        boundary_ids.right: {'flux': 0},
+        boundary_ids.bottom: {'flux': 0},
+        boundary_ids.top: {'flux': inflow_rate},
+    }
+
+    h = Function(V).assign(-1.0)
+    moisture_content = soil_curve.moisture_content
+    theta = Function(V, name='MoistureContent').interpolate(moisture_content(h))
+
+    dt = Constant(time_step)
+    richards_solver = RichardsSolver(
+        h,
+        soil_curve,
+        delta_t=dt,
+        timestepper=time_integrator,
+        solver_parameters_extra={'snes_atol': 1e-15},
+        bcs=richards_bcs,
+        timestepper_kwargs=timestepper_kwargs,
+    )
+
+    initial_mass = assemble(theta * dx)
+    previous_mass = initial_mass
+    mass_error = 0.0
+
+    time_var = 0.0
+    while time_var < t_final:
+        time_var += float(dt)
+        richards_solver.solve()
+
+        theta.interpolate(moisture_content(h))
+        # Mass entering over the step is the flux integrated over the inflow
+        # boundary, times dt. The top edge has measure 1 on a unit square, so
+        # this equals dt * inflow_rate here, but integrate it properly so the
+        # check stays correct if the domain ever changes.
+        inflow = float(dt) * assemble(Constant(inflow_rate) * ds(boundary_ids.top, domain=mesh))
+        current_mass = assemble(theta * dx)
+
+        mass_error += abs(abs(current_mass - previous_mass) - abs(inflow))
+        previous_mass = current_mass
+
+    PETSc.Sys.Print(
+        f"Net mass loss = {mass_error:.2e} | "
+        f"dx = {1/(grid_points-1):.4f} | "
+        f"dt = {float(dt):.0f} | "
+        f"Function space = {function_space}{polynomial_degree} | "
+        f"Time integration = {scheme_label or time_integrator.__name__}"
+    )
+
+    return mass_error
+
+
+@pytest.mark.parametrize("function_space,polynomial_degree", [
+    ("CG", 1),
+    ("CG", 2),
+    ("DQ", 0),
+    ("DQ", 1),
+    ("DQ", 2),
+])
+def test_mass_balance(function_space, polynomial_degree):
+    grid_points = 26
+    dt = 100.0
+    t_final = 2e05
+
+    mass_error = compute_mass_balance(
+        grid_points, dt, t_final,
+        polynomial_degree, BackwardEuler, function_space
+    )
+
+    if function_space == 'DQ':
+        # DQ spaces with stage_type="value" conserve mass to solver tolerance
+        assert mass_error < 1e-10, \
+            f"Mass imbalance too large for {function_space}{polynomial_degree}: {mass_error:.2e}"
+    else:
+        # CG spaces lack local conservation; expect O(1e-4) mass error
+        assert mass_error < 1e-3, \
+            f"Mass imbalance too large for {function_space}{polynomial_degree}: {mass_error:.2e}"
+
+
+# Same mass-balance check at fixed DQ1, swept over the time-stepping schemes
+# we support (BackwardEuler, ImplicitMidpoint, GaussLegendre(2)). All should
+# conserve mass to solver tolerance.
+@pytest.mark.parametrize("scheme,scheme_kwargs,scheme_label", [
+    (BackwardEuler, None, "BackwardEuler"),
+    (ImplicitMidpoint, None, "ImplicitMidpoint"),
+    (GaussLegendre, {"tableau_parameter": 2}, "GaussLegendre(2)"),
+])
+def test_mass_balance_tableaux(scheme, scheme_kwargs, scheme_label):
+    grid_points = 26
+    dt = 100.0
+    # A hundred steps is enough to distinguish working (solver tolerance,
+    # ~1e-12) from broken (non-SA linear-combination defect at O(dt^2),
+    # ~1e-4); we do not need to integrate to physical steady state to
+    # make the point.
+    t_final = 100 * dt
+
+    mass_error = compute_mass_balance(
+        grid_points, dt, t_final,
+        polynomial_degree=1, time_integrator=scheme,
+        function_space="DQ",
+        timestepper_kwargs=scheme_kwargs,
+        scheme_label=scheme_label,
+    )
+
+    assert mass_error < 1e-10, \
+        f"Mass imbalance too large for {scheme_label}: {mass_error:.2e}"

--- a/tests/richards/test_richards.py
+++ b/tests/richards/test_richards.py
@@ -16,14 +16,12 @@ from .richards import cases, get_case
 
 # Expected convergence rates: DQ theory gives O(h^{p+1})
 expected_rates = {
-    0: {"rate": 1.0, "rtol": 0.1},
     1: {"rate": 2.0, "rtol": 0.1},
     2: {"rate": 3.0, "rtol": 0.1},
 }
 
 # Cases to test and whether they are longtests
 enabled_cases = {
-    "tracy_2d_specified_head_dg0": {},
     "tracy_2d_specified_head_dg1": {},
     "tracy_2d_specified_head_dg2": {},
     "tracy_2d_no_flux_dg1": {},

--- a/tests/richards/test_temporal_convergence.py
+++ b/tests/richards/test_temporal_convergence.py
@@ -1,0 +1,134 @@
+"""Temporal convergence verification via a manufactured solution.
+
+Checks that each time-stepping scheme delivers its formal order: BackwardEuler
+(1), ImplicitMidpoint (2) and GaussLegendre(2) (4).
+
+We pick a spatially uniform solution h(x, y, t) = h0(t) on the unit square,
+with ExponentialCurve soil and Dirichlet h = h0(t) on all four sides. Spatial
+uniformity makes diffusion and gravity contribute zero, so the PDE reduces
+pointwise to dtheta/dt = S, satisfied by construction with
+
+  S(t) = (theta_s - theta_r) * alpha * exp(alpha * h0(t)) * h0'(t).
+
+The BC and source are time-dependent UFL expressions referencing the same
+Constant that Irksome advances through stages, so the stage substitution
+t -> t + c_i*dt is honest for multi-stage tableaux (without it the observed
+order collapses to 1). CG is used so the strong Dirichlet BC handles gravity
+boundary fluxes cleanly. The error at t_final reduces to |h_num - h0(t_final)|
+since h_num is spatially uniform, isolating the temporal truncation.
+"""
+
+import numpy as np
+import pytest
+
+from gadopt import *
+from firedrake import (
+    UnitSquareMesh, FunctionSpace, Function, Constant,
+    sin, cos, exp, pi, errornorm,
+)
+
+
+def _run_one(scheme, scheme_kwargs, dt_value, t_final, mesh_n=4):
+    mesh = UnitSquareMesh(mesh_n, mesh_n, quadrilateral=True)
+    mesh.cartesian = True
+    V = FunctionSpace(mesh, "CG", 1)
+
+    soil_curve = ExponentialCurve(
+        theta_r=0.05, theta_s=0.40, Ks=1e-2, alpha=1.0, Ss=0.0,
+    )
+
+    # Shared time Constant: Irksome's stepper will advance it through
+    # stages once we pass it via timestepper_kwargs={'t': ...}, and the
+    # BC + source expressions below reference it, so stage substitution
+    # is consistent.
+    mc = MeshConstant(mesh)
+    t = mc.Constant(0.0)
+
+    # h0(t): smooth, stays strictly negative on [0, T_period].
+    T_period = 1.0
+    omega = 2 * pi / T_period
+    amplitude = 0.3
+    baseline = -1.0
+
+    h0 = baseline + amplitude * sin(omega * t)
+    h0_dot = amplitude * omega * cos(omega * t)
+
+    source = (
+        (soil_curve.theta_s - soil_curve.theta_r)
+        * soil_curve.alpha
+        * exp(soil_curve.alpha * h0)
+        * h0_dot
+    )
+
+    boundary_ids = get_boundary_ids(mesh)
+    bcs = {
+        boundary_ids.left: {'h': h0},
+        boundary_ids.right: {'h': h0},
+        boundary_ids.bottom: {'h': h0},
+        boundary_ids.top: {'h': h0},
+    }
+
+    h = Function(V).interpolate(Constant(baseline))
+
+    dt = Constant(dt_value)
+    kwargs = {'t': t}
+    if scheme_kwargs:
+        kwargs.update(scheme_kwargs)
+
+    solver = RichardsSolver(
+        h, soil_curve,
+        delta_t=dt,
+        timestepper=scheme,
+        bcs=bcs,
+        source_term=source,
+        timestepper_kwargs=kwargs,
+        solver_parameters_extra={'snes_atol': 1e-13, 'snes_rtol': 1e-12},
+    )
+
+    nsteps = int(round(t_final / dt_value))
+    time_var = 0.0
+    for _ in range(nsteps):
+        solver.solve()
+        time_var += dt_value
+        t.assign(time_var)
+
+    h_exact_val = baseline + amplitude * float(np.sin(omega * time_var))
+    h_exact = Function(V).interpolate(Constant(h_exact_val))
+    return errornorm(h_exact, h, norm_type='L2')
+
+
+@pytest.mark.parametrize("scheme,scheme_kwargs,expected_order,label", [
+    (BackwardEuler, None, 1, "BackwardEuler"),
+    (ImplicitMidpoint, None, 2, "ImplicitMidpoint"),
+    (GaussLegendre, {"tableau_parameter": 2}, 4, "GaussLegendre(2)"),
+])
+def test_temporal_convergence(scheme, scheme_kwargs, expected_order, label):
+    t_final = 0.1
+    dt_values = [t_final / n for n in (2, 4, 8, 16)]
+
+    errors = []
+    for dt_value in dt_values:
+        err = _run_one(scheme, scheme_kwargs, dt_value, t_final)
+        errors.append(err)
+        PETSc.Sys.Print(
+            f"  {label}: dt={dt_value:.5f}  L2 error={err:.3e}"
+        )
+
+    rates = [
+        float(np.log(errors[i] / errors[i + 1]) / np.log(2))
+        for i in range(len(errors) - 1)
+    ]
+    PETSc.Sys.Print(
+        f"{label}: observed rates {rates}, expected order {expected_order}"
+    )
+
+    # Assert the coarsest pair's rate against ~85% of the formal order.
+    # The coarsest pair is furthest from the solver-tolerance floor and
+    # would expose any silent collapse to order 1. Finer-pair rates are
+    # printed above for diagnostic purposes only -- taking max/min over
+    # them lets a single bad rate hide behind a good one.
+    floor = 0.85 * expected_order
+    assert rates[0] >= floor, (
+        f"{label}: coarsest-pair rate {rates[0]:.2f} below expected "
+        f"{expected_order} (floor {floor:.2f}); full rate list {rates}"
+    )

--- a/tests/richards/vauclin_2d.py
+++ b/tests/richards/vauclin_2d.py
@@ -1,0 +1,178 @@
+"""Vauclin 2D water table recharge benchmark.
+
+This test reproduces the benchmark presented in:
+    Vauclin, M., Khanji, D., & Vachaud, G. (1979). Experimental and numerical study
+    of a transient, two-dimensional unsaturated-saturated water table recharge problem.
+    Water Resources Research, 15(5), 1089-1101.
+    https://doi.org/10.1029/WR015i005p01089
+
+The simulation is performed in a domain of 3 x 2 metres, with initial condition
+such that the region z <= 0.65 m is fully saturated (h = z - 0.65). Boundary
+conditions: bottom and left are no-flux, right has fixed water table height
+(h = z - 0.65 m), top has water injection at 14.8 cm/hour for x <= 0.5 m.
+The simulation runs for 8 hours.
+"""
+from gadopt import *
+from mpi4py import MPI
+import gwassess
+
+
+def model(level=0, do_write=False, t_final=None):
+    """Run Vauclin 2D Richards equation benchmark.
+
+    Args:
+        level: Mesh refinement level (0=coarsest)
+        do_write: Whether to output VTK files
+        t_final: Simulation end time [s]. If None, uses paper value (8 hours).
+
+    Returns:
+        Tuple of (min_h, max_h, external_flux, mass_balance)
+    """
+    # Initialize reference solution from gwassess
+    vauclin_solution = gwassess.VauclinRichardsSolution2D()
+
+    # Domain parameters from gwassess
+    Lx = vauclin_solution.Lx
+    Ly = vauclin_solution.Ly
+
+    # Mesh resolution scales with refinement level
+    nodes_x = 91 * (2 ** level)
+    nodes_y = 61 * (2 ** level)
+
+    # Use paper value for final time if not specified
+    if t_final is None:
+        t_final = vauclin_solution.SIMULATION_DURATION
+
+    # Create rectangular mesh with quadrilateral elements
+    mesh = RectangleMesh(nodes_x, nodes_y, Lx, Ly, name="mesh", quadrilateral=True)
+    mesh.cartesian = True
+    X = SpatialCoordinate(mesh)
+
+    # Function spaces
+    V = FunctionSpace(mesh, "DQ", 2)  # Discontinuous Galerkin for pressure head
+    W = VectorFunctionSpace(mesh, "DQ", 2)  # For flux output
+
+    # Get soil parameters from gwassess
+    soil_params = vauclin_solution.get_soil_parameters()
+
+    # Create Haverkamp soil curve with paper parameters
+    soil_curve = HaverkampCurve(
+        theta_r=soil_params['theta_r'],
+        theta_s=soil_params['theta_s'],
+        Ks=soil_params['Ks'],
+        Ss=soil_params['Ss'],
+        alpha=soil_params['alpha'],
+        beta=soil_params['beta'],
+        A=soil_params['A'],
+        gamma=soil_params['gamma'],
+    )
+
+    moisture_content = soil_curve.moisture_content
+    hydraulic_conductivity = soil_curve.hydraulic_conductivity
+
+    # Initial condition: water table at z = 0.65 m
+    water_table_height = vauclin_solution.WATER_TABLE_HEIGHT
+    h_ic = Function(V, name="InitialCondition").interpolate(
+        water_table_height - 1.001 * X[1]
+    )
+    h = Function(V, name="PressureHead").interpolate(h_ic)
+    h_old = Function(V, name="PreviousSolution").interpolate(h_ic)
+
+    # Diagnostic fields
+    theta = Function(V, name="MoistureContent").interpolate(moisture_content(h))
+    q = Function(W, name="VolumetricFlux")
+    K = Function(V, name="RelativeConductivity").interpolate(hydraulic_conductivity(h))
+
+    # Time-dependent top boundary flux. Share Irksome's t Constant with the
+    # BC expression so stage substitution t -> t + c_i*dt is honest for the
+    # multi-stage DIRK22 integrator.
+    mc = MeshConstant(mesh)
+    time_var = mc.Constant(0.0)
+    infiltration_rate = vauclin_solution.INFILTRATION_RATE
+    infiltration_width = vauclin_solution.INFILTRATION_WIDTH
+
+    top_flux = tanh(0.000125 * time_var) * infiltration_rate * (
+        0.5 * (1 + tanh(10 * (X[0] + infiltration_width)))
+        - 0.5 * (1 + tanh(10 * (X[0] - infiltration_width)))
+    )
+
+    # Boundary conditions from paper:
+    # - Left: no flux
+    # - Right: fixed water table height
+    # - Bottom: no flux
+    # - Top: infiltration flux
+    boundary_ids = get_boundary_ids(mesh)
+    richards_bcs = {
+        boundary_ids.left: {'flux': 0.0},
+        boundary_ids.right: {'h': h_ic},  # Fixed water table
+        boundary_ids.bottom: {'flux': 0.0},
+        boundary_ids.top: {'flux': top_flux},
+    }
+
+    # Time stepping
+    dt = Constant(10)
+
+    # Create Richards solver. Hand it the shared t Constant so that stage
+    # times c_i*dt are substituted into top_flux during stage assembly.
+    richards_solver = RichardsSolver(
+        h,
+        soil_curve,
+        delta_t=dt,
+        timestepper=DIRK22,
+        bcs=richards_bcs,
+        solver_parameters="direct",
+        quad_degree=5,
+        timestepper_kwargs={'t': time_var},
+    )
+
+    # Output setup
+    if do_write:
+        output = VTKFile("vauclin.pvd")
+        output.write(h, theta, q)
+
+    # Mass balance tracking
+    time = 0
+    external_flux = 0
+    initial_mass = assemble(theta * dx)
+
+    # Measures with appropriate quadrature
+    ds_mesh = Measure("ds", domain=mesh, metadata={"quadrature_degree": 5})
+    dx_mesh = Measure("dx", domain=mesh, metadata={"quadrature_degree": 5})
+
+    plot_iteration = 0
+
+    # Time loop
+    while time < t_final:
+        h_old.assign(h)
+        time_var.assign(time)
+        richards_solver.solve()
+        time += float(dt)
+
+        # Update diagnostic fields
+        theta.interpolate(moisture_content(h))
+        K.interpolate(hydraulic_conductivity((h + h_old) / 2))
+        q.interpolate(-K * grad((h + h_old) / 2 + X[1]))
+
+        # Track external flux through all boundaries
+        external_flux += assemble(float(dt) * dot(q, -FacetNormal(mesh)) * ds_mesh)
+
+        plot_iteration += 1
+        if do_write and plot_iteration % 25 == 0:
+            output.write(h, theta, q)
+
+    # Final diagnostics
+    final_mass = assemble(theta * dx_mesh)
+    mass_balance = (final_mass - initial_mass) / external_flux if external_flux != 0 else 0
+
+    min_h = mesh.comm.allreduce(h.dat.data_ro.min(), MPI.MIN)
+    max_h = mesh.comm.allreduce(h.dat.data_ro.max(), MPI.MAX)
+
+    return min_h, max_h, external_flux, mass_balance
+
+
+if __name__ == "__main__":
+    min_h, max_h, external_flux, mass_balance = model(level=0, do_write=True)
+    print(f"Min pressure head: {min_h:.4f} m")
+    print(f"Max pressure head: {max_h:.4f} m")
+    print(f"External flux: {external_flux:.6f}")
+    print(f"Mass balance: {mass_balance:.4f}")


### PR DESCRIPTION
Adds the Richards solver test surface on top of the core solver and its Tracy benchmark (#523), covering the time-stepping schemes the solver supports (BackwardEuler, ImplicitMidpoint, GaussLegendre(2)).

`test_mass_balance.py` checks discrete mass conservation along two axes: function space at fixed BackwardEuler (DQ0/DQ1/DQ2 sit at solver tolerance, CG1/CG2 pick up an O(1e-4) consistency error from lacking element-wise conservation), and time-stepping scheme at fixed DQ1 (all three schemes conserve mass to solver tolerance).

`test_temporal_convergence.py` verifies each scheme delivers its formal order (1, 2 and 4) via a spatially-uniform manufactured solution that makes diffusion and gravity vanish and isolates the temporal truncation.

`vauclin_2d.py` is a reference module for the Vauclin (1979) water-table recharge benchmark with Haverkamp soil, DIRK22 and stage-accurate top-flux forcing. The 2D-Vauclin demo (#510) imports its model function.

Sits on top of #525, which carries the core solver, the Tracy convergence benchmark, the vertically-lumped preconditioner tests and the adaptive timestep controller.