### PR TITLE
Infrastructure plumbing for the gplates indicator/geotherm stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           uv venv --system-site-packages
-          uv pip install .[demos,optimisation] pygplates
+          uv pip install .[demos,optimisation,gplates] pygplates
 
       - name: Get Muller et al 2022 plate reconstructions
         run: |

--- a/gadopt/gplates/gplatesfiles.py
+++ b/gadopt/gplates/gplatesfiles.py
@@ -9,7 +9,9 @@ _default_muller2022_plate_files = {
         "1000-410-Divergence.gpml",
         "1000-410-Topologies.gpml",
         "1000-410-Transforms.gpml"
-    ]
+    ],
+    "continental_polygons": "shapes_continents.gpml",
+    "static_polygons": "shapes_static_polygons_Merdith_et_al.gpml",
 }
 
 reconstructions = {
@@ -53,17 +55,29 @@ reconstructions = {
 
 
 def check_and_get_absolute_paths(base_path: Path, filenames: dict):
+    # Normalize all values to lists
+    def to_list(value):
+        return value if isinstance(value, list) else [value]
+
     # Check if all files are present
-    all_files_present = all((base_path / filename).exists() for files in filenames.values() for filename in files)
+    all_files_present = all(
+        (base_path / filename).exists()
+        for files in filenames.values()
+        for filename in to_list(files)
+    )
 
     if not all_files_present:
         raise FileNotFoundError("Some files are missing. Cannot proceed without downloading the required files.")
 
     # Return absolute paths of the files
-    return {
-        key: [str(base_path / filename) for filename in files]
-        for key, files in filenames.items()
-    }
+    # Keep single values as single strings, not lists
+    result = {}
+    for key, files in filenames.items():
+        if isinstance(files, list):
+            result[key] = [str(base_path / filename) for filename in files]
+        else:
+            result[key] = str(base_path / files)
+    return result
 
 
 def ensure_reconstruction(reconstruction: str, base_path: str | Path):

--- a/gadopt/gplates/gplatesfiles.py
+++ b/gadopt/gplates/gplatesfiles.py
@@ -75,15 +75,11 @@ def check_and_get_absolute_paths(base_path: Path, filenames: dict):
     if not all_files_present:
         raise FileNotFoundError("Some files are missing. Cannot proceed without downloading the required files.")
 
-    # Return absolute paths of the files
-    # Keep single values as single strings, not lists
-    result = {}
-    for key, files in filenames.items():
-        if isinstance(files, list):
-            result[key] = [str(base_path / filename) for filename in files]
-        else:
-            result[key] = str(base_path / files)
-    return result
+    # Return absolute paths of the files, normalized to lists
+    return {
+        key: [str(base_path / filename) for filename in to_list(files)]
+        for key, files in filenames.items()
+    }
 
 
 def ensure_reconstruction(reconstruction: str, base_path: str | Path):

--- a/gadopt/gplates/gplatesfiles.py
+++ b/gadopt/gplates/gplatesfiles.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from pathlib import Path
 
 _default_muller2022_plate_files = {
@@ -57,7 +58,12 @@ reconstructions = {
 def check_and_get_absolute_paths(base_path: Path, filenames: dict):
     # Normalize all values to lists
     def to_list(value):
-        return value if isinstance(value, list) else [value]
+        if isinstance(value, str):
+            return [value]
+        elif isinstance(value, Sequence):
+            return list(value)
+        else:
+            return [value]
 
     # Check if all files are present
     all_files_present = all(

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -31,8 +31,14 @@ except ImportError:
 log_level = logging.getLevelName(os.environ.get("GADOPT_LOGLEVEL", "INFO").upper())
 
 
-def log(*args):
-    """Log output to stdout from root processor only"""
+def log(*args, level=None):
+    """Log output to stdout from root processor only.
+
+    If level is provided, the message is only printed when that level is
+    enabled by the GADOPT_LOGLEVEL environment variable.
+    """
+    if level is not None and level < log_level:
+        return
     PETSc.Sys.Print(*args)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 demos = ["assess", "gadopt-demo-utils @ git+https://github.com/g-adopt/gadopt-demo-utils.git", "gmsh", "imageio", "jupytext", "openpyxl", "pyvista"]
 optimisation = ["pyroltrilinos"]
+gplates = ["gtrack"]
 
 [tool.setuptools]
 packages = ["gadopt", "gadopt.gplates", "gadopt.demos"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 demos = ["assess", "gadopt-demo-utils @ git+https://github.com/g-adopt/gadopt-demo-utils.git", "gmsh", "imageio", "jupytext", "openpyxl", "pyvista"]
 optimisation = ["pyroltrilinos"]
-gplates = ["gtrack"]
+gplates = ["gtrack", "pygplates"]
 
 [tool.setuptools]
 packages = ["gadopt", "gadopt.gplates", "gadopt.demos"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,5 @@ ignore =
 exclude = manual_diff_*
 per-file-ignores =
     gadopt/__init__.py:F401
+    gadopt/gplates/__init__.py:F401
     demos/multi_material/level_set_initialisation/level_set_initialisation.py:E266


### PR DESCRIPTION
This is the base of the gtrack stack: the small plumbing that lets the later PRs import and configure cleanly. Nothing here is behavioural on its own.

The file-path helper in `gplatesfiles.py` now accepts either a single string or a list for each reconstruction entry. A bare string used to be treated as a sequence of characters, which is the bug Daniel flagged; it now normalises a lone string to a one-element list and carries the continental and static polygon defaults. `log()` gains an optional `level=` kwarg so callers can gate verbose output on `GADOPT_LOGLEVEL`.

On Angus's point about the dependency: rather than adding `gtrack` to the hard dependencies (which would force pygplates onto every install), it goes in as an optional `gplates` extra. A plain `pip install g-adopt` stays lean, and `pip install g-adopt[gplates]` activates the plate stack. The regression CI job installs that extra alongside pygplates, and there's the small `gadopt/gplates/__init__.py` flake8 ignore.

Note for reviewers: this stack was rebuilt on top of the Source/Output redesign, so the diff you see now is the current shape rather than the original one. The five PRs still compose to the same gtrack feature as before.
