### PR TITLE
Add the lithosphere source, erf geotherm, and lithosphere factories

### DIFF
--- a/gadopt/gplates/__init__.py
+++ b/gadopt/gplates/__init__.py
@@ -2,12 +2,28 @@ from .connectors import ScalarFieldConnector, InterpolationConfig
 from .gplates import (
     GplatesScalarFunction,
     GplatesVelocityFunction,
-    PlateModelFiles,
     ensure_reconstruction,
     pyGplatesConnector,
+    PlateModelFiles,
 )
-from .outputs import MeshConfig, OutputStrategy
-from .sources import Source
+from .outputs import (
+    GeothermERFOutput,
+    MeshConfig,
+    OutputStrategy,
+    QuinticOutput,
+    ocean_erf_normalized,
+    radial_quintic_step,
+)
+from .sources import (
+    CloudDataType,
+    LithosphereSource,
+    LithosphereSourceConfig,
+    Source,
+)
+from .factories import (
+    ConnectorFactory,
+    LithosphereConnectorFactory,
+)
 
 __all__ = [
     # Firedrake function wrappers
@@ -21,7 +37,18 @@ __all__ = [
     "ScalarFieldConnector",
     "InterpolationConfig",
     "MeshConfig",
-    # Abstract source / output contracts
+    # Sources
     "Source",
+    "LithosphereSource",
+    "LithosphereSourceConfig",
+    "CloudDataType",
+    # Outputs
     "OutputStrategy",
+    "QuinticOutput",
+    "GeothermERFOutput",
+    "ocean_erf_normalized",
+    "radial_quintic_step",
+    # Factories
+    "ConnectorFactory",
+    "LithosphereConnectorFactory",
 ]

--- a/gadopt/gplates/factories.py
+++ b/gadopt/gplates/factories.py
@@ -1,0 +1,395 @@
+"""---------------------------------------------------------------------------
+Factory class
+---------------------------------------------------------------------------
+The ConnectorFactory class controls the ways in which users can combine
+various Source, Output and ScalarFieldConnector objects (e.g. disallow
+the construction of a Source if the factory has already been assigned a
+Source). Construction of objects in this class happens on an as-needed
+basis. Common combinations of Source + Output + Geotherm can be created by
+subclassing ConnectorFactory with a call to super().__init__() with the
+source_class, output_class and geotherm_output_class specified.
+"""
+
+import numpy as np
+from mpi4py import MPI
+from typing import Callable, TYPE_CHECKING
+from functools import cached_property
+
+from .connectors import ScalarFieldConnector, InterpolationConfig
+from .outputs import MeshConfig, OutputStrategy, QuinticOutput, GeothermERFOutput
+from .sources import CloudDataType, Source, LithosphereSource, LithosphereSourceConfig
+
+if TYPE_CHECKING:
+    from .gplates import pyGplatesConnector, PlateModelFiles
+
+__all__ = [
+    "ConnectorFactory",
+    "LithosphereConnectorFactory",
+]
+
+
+class ConnectorFactory:
+    """Control the creation of linked Source, Output and Geotherm objects.
+
+    `ConnectorFactory` manages the creation of `ScalarFieldConnector` objects
+    based on the Source and Output objects it manages. Because the factory
+    holds a single Source, the indicator and geotherm connectors it creates
+    share that Source by construction — the underlying (possibly stateful)
+    machinery advances once per geological age no matter how many connectors
+    it feeds.
+
+    The factory can take existing Source and Output objects (via the
+    `source`, `output` and `geotherm_output` setters) or construct them from
+    classes provided at construction time (via the `construct_<object>`
+    methods). The two routes are mutually exclusive per slot: a factory
+    refuses a second Source or a second indicator/geotherm Output, however
+    they were made. Accessing `indicator` (or `geotherm`) before both the
+    Source and the corresponding Output exist raises a `RuntimeError`;
+    nothing is defaulted silently.
+
+    Args:
+        source_class: The type of Source object to construct.
+        output_class: The type of Output object to construct for the indicator.
+        geotherm_output_class: The type of Output object to construct for the
+            associated geotherm.
+        mesh: `MeshConfig` forwarded to every `ScalarFieldConnector` this
+            factory creates.
+        interpolation: `InterpolationConfig` forwarded to every
+            `ScalarFieldConnector` this factory creates.
+        gc_collect_frequency: forwarded to every `ScalarFieldConnector` this
+            factory creates; see `ScalarFieldConnector` for the semantics.
+
+    Examples:
+        >>> factory = ConnectorFactory()
+        >>> factory.source = source
+        >>> factory.output = output
+        >>> indicator = factory.indicator
+
+        >>> factory = ConnectorFactory(source_class=LithosphereSource, output_class=QuinticOutput)
+        >>> factory.construct_source(
+        ...    gplates_connector=plate_model_with_polygons,
+        ...    continental_data=synthetic_data,
+        ...    age_to_property=half_space_cooling,
+        ...    plate_files=plate_files,
+        ... )
+        >>> factory.construct_output()
+        >>> indicator = factory.indicator
+    """
+
+    def __init__(
+        self,
+        source_class: type[Source] | None = None,
+        output_class: type[OutputStrategy] | None = None,
+        geotherm_output_class: type[OutputStrategy] | None = None,
+        *,
+        mesh: MeshConfig | None = None,
+        interpolation: InterpolationConfig | None = None,
+        gc_collect_frequency: int | None = 10,
+    ):
+        self._source_class = source_class
+        self._output_class = output_class
+        self._geotherm_output_class = geotherm_output_class
+        self._source: Source | None = None
+        self._output: OutputStrategy | None = None
+        self._geotherm_output: OutputStrategy | None = None
+        self._mesh = mesh
+        self._interpolation = interpolation
+        self._gc_collect_frequency = gc_collect_frequency
+
+    @property
+    def source(self):
+        """The Source object used to construct the `ScalarFieldConnector`
+
+        The initial value is None, and can be set to an initialised Source object
+        by the setter.
+
+        Returns:
+            The Source object
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing a `Source` object
+        """
+        return self._source
+
+    @source.setter
+    def source(self, source: Source | None):
+        if self._source is not None:
+            raise RuntimeError("This factory already has a Source!")
+        self._source = source
+
+    def construct_source(self, *source_args, **source_kwargs):
+        """Have this ConnectorFactory construct a Source object
+
+        All input arguments are passed directly to the `self._source_class`
+        constructor, which must be set on initialisation of this ConnectorFactory
+        object. Note that calling this function is mutually exclusive to calling
+        the `source` setter.
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing a `Source` object
+            TypeError: Attempted to construct a Source without setting `_source_class`
+        """
+        if self._source is not None:
+            raise RuntimeError("This factory already has a Source!")
+        if self._source_class is None:
+            raise TypeError("Do not know what kind of Source to construct!")
+        self._source = self._source_class(*source_args, **source_kwargs)
+
+    @property
+    def output(self):
+        """The `OutputStrategy` object used to construct the `ScalarFieldConnector`
+        belonging to the indicator created by this `ConnectorFactory` object
+
+        The initial value is None, and can be set to an initialised `OutputStrategy`
+        object by the setter.
+
+        Returns:
+            The `OutputStrategy` object
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing an indicator
+                          `OutputStrategy` object
+        """
+        return self._output
+
+    @output.setter
+    def output(self, output: OutputStrategy | None):
+        if self._output is not None:
+            raise RuntimeError("This factory already has an indicator Output!")
+        self._output = output
+
+    def construct_output(self, **output_kwargs):
+        """Have this ConnectorFactory construct an `OutputStrategy` object for an
+        indicator
+
+        All input arguments are passed directly to the `self._output_class`
+        constructor, which must be set on initialisation of this ConnectorFactory
+        object. Note that calling this function is mutually exclusive to calling
+        the `output` setter.
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing an indicator
+                          `OutputStrategy` object
+            TypeError: Attempted to construct `output` without setting `_output_class`
+        """
+        if self._output is not None:
+            raise RuntimeError("This factory already has an indicator Output!")
+        if self._output_class is None:
+            raise TypeError("Do not know what kind of Output to construct!")
+        self._output = self._output_class(**output_kwargs)
+
+    @property
+    def geotherm_output(self):
+        """The `OutputStrategy` object used to construct the `ScalarFieldConnector`
+        belonging to the geotherm created by this `ConnectorFactory` object
+
+        The initial value is None, and can be set to an initialised Output object
+        by the setter.
+
+        Returns:
+            The `OutputStrategy` object
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing a geotherm
+                          `OutputStrategy` object
+
+        """
+        return self._geotherm_output
+
+    @geotherm_output.setter
+    def geotherm_output(self, geotherm_output: OutputStrategy | None):
+        if self._geotherm_output is not None:
+            raise RuntimeError("This factory already has a geotherm Output!")
+        self._geotherm_output = geotherm_output
+
+    def construct_geotherm(self, **output_kwargs):
+        """Have this ConnectorFactory construct an `OutputStrategy` object for a
+        geotherm
+
+        All input arguments are passed directly to the `self._geotherm_output_class`
+        constructor, which must be set on initialisation of this ConnectorFactory
+        object. Note that calling this function is mutually exclusive to calling
+        the `geotherm_output` setter.
+
+        Raises:
+            RuntimeError: This ConnectorFactory is already managing a geotherm
+                          `OutputStrategy` object
+            TypeError: Attempted to construct `geotherm_output` without setting
+                       `geotherm_output_class`
+        """
+        if self._geotherm_output is not None:
+            raise RuntimeError("This factory already has a geotherm Output!")
+        if self._geotherm_output_class is None:
+            raise TypeError("Do not know what kind of geotherm Output to construct!")
+        self._geotherm_output = self._geotherm_output_class(**output_kwargs)
+
+    @cached_property
+    def indicator(self):
+        """Construct and retrieve the indicator `ScalarFieldConnector`.
+
+        This function creates the `ScalarFieldConnector` for the indicator. If
+        the Source and/or the indicator `OutputStrategy` object have not been
+        created (or assigned), this function raises a RuntimeError — nothing is
+        defaulted silently. `cached_property` is used to ensure sanity checks
+        and object creation only run once.
+
+        Returns:
+            `ScalarFieldConnector` for the indicator
+
+        Raises:
+            RuntimeError: Attempted to construct the indicator while no source
+                          or output is present.
+        """
+        if self._source is None:
+            raise RuntimeError(
+                "A source must be either constructed or connected in order to construct the indicator"
+            )
+        if self._output is None:
+            raise RuntimeError(
+                "An output must be either constructed or connected in order to construct the indicator"
+            )
+        return ScalarFieldConnector(
+            self._source,
+            self._output,
+            mesh=self._mesh,
+            interpolation=self._interpolation,
+            gc_collect_frequency=self._gc_collect_frequency,
+        )
+
+    @cached_property
+    def geotherm(self):
+        """Construct and retrieve the geotherm `ScalarFieldConnector`.
+
+        This function creates the `ScalarFieldConnector` for the geotherm. If
+        the Source and/or the geotherm `OutputStrategy` object have not been
+        created (or assigned), this function raises a RuntimeError — nothing is
+        defaulted silently. `cached_property` is used to ensure sanity checks
+        and object creation only run once.
+
+        Returns:
+            `ScalarFieldConnector` for the geotherm
+
+        Raises:
+            RuntimeError: Attempted to construct the geotherm while no source
+                          or geotherm_output is present.
+        """
+        if self._source is None:
+            raise RuntimeError(
+                "A source must be either constructed or connected in order to construct the geotherm"
+            )
+        if self._geotherm_output is None:
+            raise RuntimeError(
+                "A geotherm_output must be either constructed or connected in order to construct the geotherm"
+            )
+        return ScalarFieldConnector(
+            self._source,
+            self._geotherm_output,
+            mesh=self._mesh,
+            interpolation=self._interpolation,
+            gc_collect_frequency=self._gc_collect_frequency,
+        )
+
+
+class LithosphereConnectorFactory(ConnectorFactory):
+    """A subclass of ConnectorFactory used for constructing Lithosphere objects
+
+    `LithosphereConnectorFactory` ties together a `LithosphereSource`,
+    `QuinticOutput` and `GeothermERFOutput` to create a convenience class for a
+    common combination of Sources and Outputs.
+
+    Args:
+        mesh: `MeshConfig` forwarded to every `ScalarFieldConnector` this
+            factory creates.
+        interpolation: `InterpolationConfig` forwarded to every
+            `ScalarFieldConnector` this factory creates.
+        gc_collect_frequency: forwarded to every `ScalarFieldConnector` this
+            factory creates; see `ScalarFieldConnector` for the semantics.
+    """
+
+    def __init__(
+        self,
+        *,
+        mesh: MeshConfig | None = None,
+        interpolation: InterpolationConfig | None = None,
+        gc_collect_frequency: int | None = 10,
+    ):
+        super().__init__(
+            LithosphereSource,
+            QuinticOutput,
+            GeothermERFOutput,
+            mesh=mesh,
+            interpolation=interpolation,
+            gc_collect_frequency=gc_collect_frequency,
+        )
+
+    def construct_source(
+        self,
+        gplates_connector: "pyGplatesConnector",
+        continental_data: CloudDataType,
+        age_to_property: Callable[[np.ndarray], np.ndarray],
+        plate_files: "PlateModelFiles",
+        config: LithosphereSourceConfig | None = None,
+        *,
+        default_continental_age_myr: float = 500.0,
+        walk_start_age: float | None = None,
+        comm: MPI.Comm = MPI.COMM_WORLD,
+    ):
+        """Overloaded construct_source
+
+        Match argument list to `LithosphereSource` to allow static argument
+        checking and IDE introspection; see `LithosphereSource` for the
+        meaning of each argument.
+        """
+        super().construct_source(
+            gplates_connector,
+            continental_data,
+            age_to_property,
+            plate_files,
+            config,
+            default_continental_age_myr=default_continental_age_myr,
+            walk_start_age=walk_start_age,
+            comm=comm,
+        )
+
+    def construct_output(
+        self,
+        width_km: float = 10.0,
+        *,
+        fade_ref_km: float | None = None,
+        default_thickness_km: float = 100.0,
+    ):
+        """Overloaded construct_output
+
+        Match argument list to `QuinticOutput` to allow static argument
+        checking and IDE introspection; see `QuinticOutput` for the meaning
+        of each argument.
+
+        ``fade_ref_km`` is optional: the lithosphere thickness channel never
+        vanishes laterally (``default_thickness_km`` fills uncovered nodes),
+        so the unfaded one-sided step is a legitimate configuration.
+        """
+        super().construct_output(
+            width_km=width_km,
+            fade_ref_km=fade_ref_km,
+            default_thickness_km=default_thickness_km,
+        )
+
+    def construct_geotherm(
+        self,
+        kappa: float = 1e-6,
+        default_thickness_km: float = 100.0,
+        too_far_age_myr: float = 500.0,
+        geotherm: Callable | None = None,
+    ):
+        """Overloaded construct_geotherm
+
+        Match argument list to `GeothermERFOutput` to allow static argument
+        checking and IDE introspection; see `GeothermERFOutput` for the
+        meaning of each argument.
+        """
+        super().construct_geotherm(
+            kappa=kappa,
+            default_thickness_km=default_thickness_km,
+            too_far_age_myr=too_far_age_myr,
+            geotherm=geotherm,
+        )

--- a/gadopt/gplates/gplates.py
+++ b/gadopt/gplates/gplates.py
@@ -1,6 +1,7 @@
 import warnings
 from dataclasses import dataclass
 
+
 import firedrake as fd
 import numpy as np
 import pygplates
@@ -18,7 +19,6 @@ __all__ = [
     "ensure_reconstruction",
     "GplatesVelocityFunction",
     "GplatesScalarFunction",
-    "ScalarFieldConnector",
     "PlateModelFiles",
     "pyGplatesConnector",
 ]
@@ -695,9 +695,8 @@ class GplatesScalarFunction(fd.Function):
     reconstructions.
 
     Wraps any ``ScalarFieldConnector`` (built either directly via composition
-    of a ``Source`` and an ``OutputStrategy``, or via one of the convenience
-    factories ``lithosphere_indicator``, ``lithosphere_geotherm``,
-    ``polygon_indicator``, ``polygon_geotherm``). Calling
+    of a ``Source`` and an ``OutputStrategy``, or via a ``ConnectorFactory``
+    such as ``LithosphereConnectorFactory``). Calling
     ``update_plate_reconstruction(ndtime)`` recomputes the field and assigns
     it onto the underlying Firedrake DoFs.
 

--- a/gadopt/gplates/gplatesfiles.py
+++ b/gadopt/gplates/gplatesfiles.py
@@ -75,7 +75,7 @@ def check_and_get_absolute_paths(base_path: Path, filenames: dict):
     if not all_files_present:
         raise FileNotFoundError("Some files are missing. Cannot proceed without downloading the required files.")
 
-    # Return absolute paths of the files, normalized to lists
+    # Return absolute paths of the files, normalised to lists
     return {
         key: [str(base_path / filename) for filename in to_list(files)]
         for key, files in filenames.items()

--- a/gadopt/gplates/outputs.py
+++ b/gadopt/gplates/outputs.py
@@ -4,25 +4,52 @@ An OutputStrategy turns interpolated source arrays at target mesh nodes into a
 scalar field. The current two flavours are:
 
   - indicator fields  — ~1 inside the region of interest, ~0 outside, with a
-    smooth tanh transition at the region base (TanhOutput).
+    smooth quintic transition at the region base (QuinticOutput).
 
   - normalised geotherms — (T - T_surface) / (T_LAB - T_surface) in [0, 1],
-    using an erf profile (oceanic, age-dependent) or a linear profile
-    (continental). The "outside" value is 1 — i.e. mantle temperature.
+    using an erf profile (oceanic, age-dependent). The "outside" value is 1 —
+    i.e. mantle temperature.
 
 Outputs declare what they need from the source via the class-level ``requires``
 set; the connector validates this against the source's ``provides`` set at
 construction time so, e.g. a polygon source paired with an erf geotherm fails loudly
 rather than silently dropping the missing key.
+
+The radial primitive shared by every indicator output is ``radial_quintic_step``,
+a ONE-SIDED quintic smoothstep: exactly 1 from the surface down to the region
+base, decaying to exactly 0 over one transition width BELOW the base. Unlike
+the symmetric tanh kernel it replaced, the transition never straddles the base,
+so the surface value stays faithful — exactly 1 wherever the region has any
+thickness — and the field is exactly 0 below base + width (no asymptotic tail).
+The 0.5-crossing therefore sits at base + width/2 in depth, not at the base.
+
+One consequence to keep in mind: where thickness is exactly zero the base sits
+at the surface and the SURFACE NODE still reads 1 (the transition hangs just
+below it). Zero-outside sources (polygon seeds-plus-zero-background) therefore MUST pair
+the step with a lateral fade (``fade_ref_km``) so the exterior column is
+multiplied to 0 — an unfaded variable-depth step is only safe for sources whose
+thickness never vanishes laterally without a fade, or whose fallback thickness
+fills the gap (lithosphere-style ``default_thickness_km=100``).
+
+``QuinticOutput`` covers the whole indicator family through two switches:
+
+  ============================ ==================== ===================
+  Configuration                Base depth           Lateral fade
+  ============================ ==================== ===================
+  QuinticOutput()              variable (per-node)  none
+  QuinticOutput(base_depth_km) fixed                optional
+  QuinticOutput(fade_ref_km)   variable             clip(h/ref, 0, 1)
+  ============================ ==================== ===================
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Callable, ClassVar
 
 import numpy as np
+from scipy.special import erf
 
 
 # Mesh geometry
@@ -45,6 +72,58 @@ class MeshConfig:
             raise ValueError(f"r_outer must be positive, got {self.r_outer}")
         if self.depth_scale <= 0:
             raise ValueError(f"depth_scale must be positive, got {self.depth_scale}")
+
+
+# Geotherm functions (used by GeothermERFOutput)
+def ocean_erf_normalized(depth_m, z_lab_m, age_myr, kappa):
+    """Normalised erf geotherm for oceanic lithosphere.
+
+    T_norm = erf(z / a) / erf(z_lab / a), where a = 2 * sqrt(kappa * t).
+    T_norm = 0 at the surface, 1 at the LAB depth. Falls back to linear
+    when age <= 0 (just-formed crust at a ridge).
+    """
+    depth_m = np.asarray(depth_m, dtype=float)
+    z_lab_m = np.asarray(z_lab_m, dtype=float)
+    age_myr = np.asarray(age_myr, dtype=float)
+
+    age_sec = np.maximum(age_myr, 0.0) * 3.15576e13
+    a = 2.0 * np.sqrt(kappa * np.maximum(age_sec, 1.0))
+
+    result = np.zeros_like(depth_m)
+    valid = z_lab_m > 0
+    erf_z = erf(depth_m[valid] / a[valid])
+    erf_zlab = erf(z_lab_m[valid] / a[valid])
+    safe = erf_zlab > 1e-10
+    result[valid] = np.where(
+        safe, erf_z / np.maximum(erf_zlab, 1e-10),
+        depth_m[valid] / z_lab_m[valid],
+    )
+    return np.clip(result, 0.0, 1.0)
+
+
+def radial_quintic_step(r_target, base_r, width_nondim):
+    """One-sided quintic smoothstep: 1 above the base, 0 one width below it.
+
+    Returns exactly 1 for ``r >= base_r``, exactly 0 for
+    ``r <= base_r - width_nondim``, and the quintic polynomial
+    ``6t^5 - 15t^4 + 10t^3`` (t the normalised position inside the band) in
+    between. The polynomial has zero first AND second derivatives at both
+    ends, so the field is C^2 across the junctions.
+
+    The transition sits entirely BELOW the base: a node at the base itself
+    reads exactly 1 (the tanh kernel this replaced read 0.5 there), and the
+    0.5-crossing is at ``base_r - width_nondim / 2``. All radii are in
+    non-dimensional mesh units. ``base_r`` may be a scalar (fixed base depth)
+    or a per-node array (variable base depth read from the thickness channel).
+    """
+    # (r - base)/w + 1 rather than (r - (base - w))/w: any r >= base_r then
+    # lands at t >= 1 BEFORE rounding, so the clip makes the upper plateau
+    # exactly 1 (no 1-ulp shortfall at the base itself).
+    t = np.clip(
+        (np.asarray(r_target, dtype=float) - base_r) / width_nondim + 1.0,
+        0.0, 1.0,
+    )
+    return t * t * t * (t * (6.0 * t - 15.0) + 10.0)
 
 
 # OutputStrategy ABC
@@ -76,3 +155,136 @@ class OutputStrategy(ABC):
                 ``InterpolationConfig.distance_threshold``.
             mesh: mesh geometry for radius↔depth conversion.
         """
+
+
+# ---------------------------------------------------------------------------
+# Concrete outputs
+# ---------------------------------------------------------------------------
+
+class QuinticOutput(OutputStrategy):
+    """Smooth indicator field built on the one-sided quintic radial step.
+
+    The field is exactly 1 from the surface down to the region base, decays
+    to exactly 0 over ``width_km`` below it, and is optionally multiplied by
+    a lateral amplitude fade. Two switches select the configuration:
+
+    ``base_depth_km``
+        ``None`` (default): the base depth is per-node, read from the
+        interpolated ``thickness`` channel — deep cratonic roots and shallow
+        margins are both captured, the radial transition moves with h(x).
+        A number: the base is FIXED at that depth; the thickness channel
+        then only feeds the fade (the separable lateral-fade x radial-step
+        decomposition previously provided by FadedRadialStepOutput).
+
+    ``fade_ref_km``
+        ``None`` (default): no fade. The surface reads exactly 1 wherever
+        thickness is nonzero — including where it is barely nonzero, so this
+        configuration is only safe when thickness never vanishes laterally
+        (or ``default_thickness_km`` fills the gaps, lithosphere-style).
+        A number: the step is multiplied by ``clip(h / fade_ref_km, 0, 1)``.
+        REQUIRED (in practice) for zero-outside polygon sources: without it
+        the exterior surface — where the base coincides with the surface —
+        reads 1 instead of 0.
+
+    ``default_thickness_km`` fills the thickness channel at ``too_far``
+    nodes: 100 for lithosphere-style sources (no seed nearby => assume a
+    100 km plate), 0 for polygon-style sources where missing seeds must read
+    as "outside the region".
+    """
+
+    requires = frozenset({"thickness"})
+
+    def __init__(
+        self,
+        width_km: float = 10.0,
+        *,
+        base_depth_km: float | None = None,
+        fade_ref_km: float | None = None,
+        default_thickness_km: float = 0.0,
+    ):
+        if width_km <= 0:
+            raise ValueError(f"width_km must be positive, got {width_km}")
+        if base_depth_km is not None and base_depth_km <= 0:
+            raise ValueError(
+                f"base_depth_km must be positive, got {base_depth_km}"
+            )
+        if fade_ref_km is not None and fade_ref_km <= 0:
+            raise ValueError(
+                f"fade_ref_km must be positive, got {fade_ref_km}"
+            )
+        if default_thickness_km < 0:
+            raise ValueError(
+                f"default_thickness_km must be non-negative, "
+                f"got {default_thickness_km}"
+            )
+        self.width_km = width_km
+        self.base_depth_km = base_depth_km
+        self.fade_ref_km = fade_ref_km
+        self.default_thickness_km = default_thickness_km
+
+    def compute(self, interpolated, r_target, too_far, mesh):
+        thickness_km = interpolated["thickness"].copy()
+        thickness_km[too_far] = self.default_thickness_km
+
+        if self.base_depth_km is None:
+            base_r = mesh.r_outer - thickness_km / mesh.depth_scale
+        else:
+            base_r = mesh.r_outer - self.base_depth_km / mesh.depth_scale
+
+        result = radial_quintic_step(
+            r_target, base_r, self.width_km / mesh.depth_scale
+        )
+        if self.fade_ref_km is not None:
+            result = result * np.clip(
+                thickness_km / self.fade_ref_km, 0.0, 1.0
+            )
+        return result
+
+
+class GeothermERFOutput(OutputStrategy):
+    """Erf-based normalised oceanic geotherm.
+
+    Needs both per-point thickness (z_LAB) and seafloor age. Target nodes
+    with no nearby seed (``too_far``) are assigned ``too_far_age_myr`` as a
+    fallback so the erf profile flattens to ~linear over old, conduction-
+    dominated lithosphere. This is distinct from
+    ``LithosphereSource.default_continental_age_myr``, which sets the age
+    column carried by *tracked continental seeds* — that's a property of
+    the source data, not of the geotherm's fallback.
+    """
+
+    requires = frozenset({"thickness", "age"})
+
+    def __init__(
+        self,
+        kappa: float = 1e-6,
+        default_thickness_km: float = 100.0,
+        too_far_age_myr: float = 500.0,
+        geotherm: Callable | None = None,
+    ):
+        if kappa <= 0:
+            raise ValueError(f"kappa must be positive, got {kappa}")
+        if default_thickness_km <= 0:
+            raise ValueError(
+                f"default_thickness_km must be positive, "
+                f"got {default_thickness_km}"
+            )
+        if too_far_age_myr <= 0:
+            raise ValueError(
+                f"too_far_age_myr must be positive, got {too_far_age_myr}"
+            )
+        self.kappa = kappa
+        self.default_thickness_km = default_thickness_km
+        self.too_far_age_myr = too_far_age_myr
+        self._geotherm = geotherm or ocean_erf_normalized
+
+    def compute(self, interpolated, r_target, too_far, mesh):
+        thickness_km = interpolated["thickness"].copy()
+        age_myr = interpolated["age"].copy()
+        thickness_km[too_far] = self.default_thickness_km
+        age_myr[too_far] = self.too_far_age_myr
+
+        depth_m = (mesh.r_outer - r_target) * mesh.depth_scale * 1e3
+        z_lab_m = thickness_km * 1e3
+        T_norm = self._geotherm(depth_m, z_lab_m, age_myr, self.kappa)
+        return np.clip(T_norm, 0.0, 1.0)

--- a/gadopt/gplates/sources.py
+++ b/gadopt/gplates/sources.py
@@ -14,19 +14,175 @@ source points live and what properties do they carry at age X?", Outputs answer
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 
+import h5py
 import numpy as np
+import numpy.typing as npt
 from mpi4py import MPI
 
+from gtrack import PointCloud, PointRotator, PolygonFilter, SeafloorAgeTracker
+from gtrack.config import TracerConfig
+from gtrack.mesh import create_sphere_mesh_latlon
+
+from ..utility import log, DEBUG, INFO
+
 if TYPE_CHECKING:
-    from .gplates import pyGplatesConnector
+    from .gplates import pyGplatesConnector, PlateModelFiles
 
 
 # Minimum points to make any sphere-coverage source meaningful. Anything
 # below this and the kNN interpolator gives nonsense.
 SOURCE_MIN_POINTS = 100
+
+
+# ---------------------------------------------------------------------------
+# Source configs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LithosphereSourceConfig:
+    """Knobs for LithosphereSource — ocean tracker, checkpointing, data loading.
+
+    Mesh geometry (r_outer, depth_scale) lives on MeshConfig.
+    Interpolation (k_neighbors, kernel, ...) lives on InterpolationConfig.
+    Output knobs (transition_width, kappa, ...) live on the output strategy.
+
+    Checkpointing is enabled by setting ``checkpoint_interval_myr``;
+    ``checkpoint_dir`` then defaults to ``gtrack_checkpoints`` (resolved
+    against the cwd at construction time and created up front on rank 0).
+    """
+
+    time_step: float = 1.0
+    n_points: int = 10000
+    reinit_interval_myr: float = 50.0
+    property_name: str = "thickness"
+    gtrack_config: dict | None = None
+    checkpoint_interval_myr: float | None = None
+    checkpoint_dir: str | Path | None = None
+
+    def __post_init__(self):
+        if self.n_points < SOURCE_MIN_POINTS:
+            raise ValueError(
+                f"n_points must be at least {SOURCE_MIN_POINTS}, got {self.n_points}"
+            )
+        if self.time_step <= 0:
+            raise ValueError(f"time_step must be positive, got {self.time_step}")
+        if self.reinit_interval_myr <= 0:
+            raise ValueError(
+                f"reinit_interval_myr must be positive, "
+                f"got {self.reinit_interval_myr}"
+            )
+        if (self.checkpoint_interval_myr is not None
+                and self.checkpoint_interval_myr <= 0):
+            raise ValueError(
+                f"checkpoint_interval_myr must be positive or None, "
+                f"got {self.checkpoint_interval_myr}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Data-loading helpers (module-level — both Sources need them)
+# ---------------------------------------------------------------------------
+
+def _load_from_hdf5(filepath: str | Path, property_name: str) -> PointCloud:
+    """Read lat/lon/values from an HDF5 (or NetCDF) file into a PointCloud."""
+    with h5py.File(filepath, "r") as f:
+        lon = f["lon"][:]
+        lat = f["lat"][:]
+        if property_name in f:
+            values = f[property_name][:]
+        elif "z" in f:
+            values = f["z"][:]
+        else:
+            raise KeyError(
+                f"File must contain '{property_name}' or 'z'. "
+                f"Available datasets: {list(f.keys())}"
+            )
+
+    lon = np.where(lon > 180, lon - 360, lon)
+
+    if lon.ndim == 1 and lat.ndim == 1:
+        lon_grid, lat_grid = np.meshgrid(lon, lat)
+        latlon = np.column_stack([lat_grid.ravel(), lon_grid.ravel()])
+        values = values.ravel()
+    else:
+        latlon = np.column_stack([lat.ravel(), lon.ravel()])
+        values = values.ravel()
+
+    cloud = PointCloud.from_latlon(latlon)
+    cloud.add_property(property_name, values)
+    return cloud
+
+
+CloudDataType = PointCloud | tuple[npt.ArrayLike, npt.ArrayLike] | str | Path | int | float
+
+
+def _build_cloud(data: CloudDataType, property_name: str, n_points_fallback: int) -> PointCloud:
+    """Dispatch the input ``data`` to the right PointCloud constructor.
+
+    Accepts: an existing PointCloud, an HDF5 path, a (latlon, values) tuple,
+    or a scalar (broadcast onto a Fibonacci sphere mesh).
+    """
+    if isinstance(data, PointCloud):
+        return data
+    if isinstance(data, (str, Path)):
+        return _load_from_hdf5(data, property_name)
+    if isinstance(data, tuple) and len(data) == 2:
+        latlon, values = data
+        cloud = PointCloud.from_latlon(np.asarray(latlon))
+        cloud.add_property(property_name, np.asarray(values))
+        return cloud
+    if isinstance(data, (int, float)):
+        lats, lons = create_sphere_mesh_latlon(n_points_fallback)
+        latlon = np.column_stack([lats, lons])
+        cloud = PointCloud.from_latlon(latlon)
+        cloud.add_property(property_name, np.full(len(latlon), float(data)))
+        return cloud
+    raise TypeError(
+        f"Unsupported data type: {type(data)}. "
+        "Expected PointCloud, file path, (latlon, values) tuple, or scalar."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+# Matched against Path.stem, so no ".npz" suffix here; the suffix is
+# checked separately in _find_best_checkpoint.
+_CHECKPOINT_RE = re.compile(r"^ocean_checkpoint_(\d+)Ma$")
+
+
+def _find_best_checkpoint(checkpoint_dir: Path | None, target_age: float) -> Path | None:
+    """Return the checkpoint path whose age is the smallest value >= target_age.
+
+    Smallest-age-not-younger-than-target minimises forward stepping. Returns
+    None if the directory contains no matching files. The directory is
+    created at source construction time, so if it has disappeared since,
+    the resulting error propagates rather than being silenced.
+    """
+    if checkpoint_dir is None:
+        return None
+    best_path = None
+    best_age = None
+    for fname in checkpoint_dir.iterdir():
+        if fname.suffix != ".npz":
+            continue
+        m = _CHECKPOINT_RE.match(fname.stem)
+        if m is None:
+            continue
+        ckpt_age = int(m.group(1))
+        if ckpt_age < target_age:
+            continue
+        if best_age is None or ckpt_age < best_age:
+            best_age = ckpt_age
+            best_path = fname
+    return best_path
 
 
 # ---------------------------------------------------------------------------
@@ -36,15 +192,15 @@ SOURCE_MIN_POINTS = 100
 class Source(ABC):
     """Time-dependent source of (xyz, properties) on a sphere.
 
-    Subclasses expose a ``provides`` set listing the property keys (excluding
-    "xyz") that ``prepare(age)`` returns. ``provides`` is declared here as an
-    abstract property, which a subclass may satisfy either with a plain class
-    constant (the concrete sources do this, keeping class-level access like
-    ``LithosphereSource.provides``) or with an instance property (handy for
-    test doubles and dynamically-configured sources). The ABC implements a
-    per-age cache so that consumers sharing this Source can call ``prepare``
-    in any order and the underlying gtrack state advances at most once per
-    age.
+    Subclasses expose a ``provides`` set listing the keys (including "xyz")
+    that ``prepare(age)`` returns. ``provides`` is declared here as an
+    abstract property, which a subclass may satisfy either with a read-only
+    property (the concrete sources do this) or with a plain class constant
+    (handy for test doubles and dynamically-configured sources, and keeps
+    class-level access like ``SomeSource.provides`` working). The ABC
+    implements a per-age cache so that consumers sharing this Source can call
+    ``prepare`` in any order and the underlying gtrack state advances at most
+    once per age.
 
     ``prepare`` is collective across ``self.comm``. Subclasses implement
     ``_compute_sources(age)``, which runs on rank 0 only; the ABC handles
@@ -54,7 +210,7 @@ class Source(ABC):
     @property
     @abstractmethod
     def provides(self) -> frozenset[str]:
-        """The set of property keys (excluding 'xyz') that prepare(age) returns."""
+        """The set of keys (including 'xyz') that prepare(age) returns."""
         ...
 
     gplates_connector: "pyGplatesConnector"
@@ -81,8 +237,8 @@ class Source(ABC):
 
     @abstractmethod
     def _compute_sources(self, age: float) -> dict[str, np.ndarray]:
-        """Build the source-arrays dict on rank 0. Must include 'xyz' plus
-        every key in ``self.provides``."""
+        """Build the source-arrays dict on rank 0. Must include every key in
+        ``self.provides`` ('xyz' among them)."""
 
     def _load(self) -> None:
         """Rank-0 I/O: build the gtrack machinery and the present-day cloud.
@@ -175,3 +331,315 @@ class Source(ABC):
                 f"Requested age {age:.2f} Ma is negative (in the future). "
                 f"Ages must be >= 0 (present day)."
             )
+
+
+# ---------------------------------------------------------------------------
+# LithosphereSource
+# ---------------------------------------------------------------------------
+
+class LithosphereSource(Source):
+    """Combined oceanic + continental lithosphere source.
+
+    Oceanic seeds come from a forward-stepped SeafloorAgeTracker; their
+    thickness is derived from age via the user-supplied ``age_to_property``
+    (typically a half-space cooling rule). Continental seeds are present-day
+    thickness data back-rotated to the target age by a PointRotator.
+
+    The two sets are concatenated and returned together. Each seed carries
+    a thickness (km) and an age (Myr); the age key is needed by erf
+    geotherms and ignored by the tanh indicator.
+
+    The ocean tracker is the only stateful piece: it advances forward in
+    geological time (decreasing age) and cannot rewind. Per-age caching
+    on the base class guarantees one ``step_to`` per age regardless of how
+    many connectors share this source.
+
+    Forward-only contract: the first ``prepare`` across every connector that
+    shares this source sets the oldest reachable age, and every subsequent
+    request must be at that age or younger. When several connectors share one
+    source and update at different cadences, whichever one fires first would
+    otherwise silently fix the walk's ceiling. Declare ``walk_start_age`` to
+    pin the oldest age you intend to request up front, so an out-of-range
+    request fails immediately at wiring time rather than locking the walk at
+    the first touch. Declaring ``walk_start_age`` does NOT let you revisit
+    ages already stepped past — it only declares the oldest age you intend to
+    request.
+
+    Args:
+        gplates_connector: the `pyGplatesConnector` providing the rotation /
+            topology files and the age <-> non-dimensional time mapping.
+        continental_data: present-day continental thickness; anything
+            `_build_cloud` accepts (a PointCloud, an HDF5/NetCDF path, a
+            (latlon, values) tuple, or a scalar broadcast onto a sphere mesh).
+        age_to_property: callable mapping seafloor age (Myr) to the tracked
+            property (typically thickness in km via half-space cooling).
+        plate_files: `PlateModelFiles` carrying the continental and static
+            polygon paths (both mandatory for this source).
+        config: `LithosphereSourceConfig` with the ocean tracker, data-loading
+            and checkpointing knobs. Defaults to `LithosphereSourceConfig()`.
+        default_continental_age_myr: the age column assigned to continental
+            seeds (they carry no seafloor age of their own).
+        walk_start_age: the oldest age you will ever request; requests older
+            than this fail immediately rather than silently locking the
+            forward-only walk at the first touch. Does not enable revisiting
+            older ages once stepped past. Default None keeps the
+            pre-declaration behaviour (the first prepare fixes the ceiling).
+        comm: MPI communicator; gtrack work runs on rank 0 and results are
+            broadcast.
+    """
+
+    @property
+    def provides(self) -> frozenset[str]:
+        return frozenset({"xyz", "thickness", "age"})
+
+    def __init__(
+        self,
+        gplates_connector: "pyGplatesConnector",
+        continental_data: CloudDataType,
+        age_to_property: Callable[[np.ndarray], np.ndarray],
+        plate_files: "PlateModelFiles",
+        config: LithosphereSourceConfig | None = None,
+        *,
+        default_continental_age_myr: float = 500.0,
+        walk_start_age: float | None = None,
+        comm: MPI.Comm = MPI.COMM_WORLD,
+    ):
+        if plate_files.continental_polygons is None:
+            raise ValueError(
+                "plate_files.continental_polygons must be set. "
+                "Pass continental_polygons to PlateModelFiles."
+            )
+        if plate_files.static_polygons is None:
+            raise ValueError(
+                "plate_files.static_polygons must be set. "
+                "Pass static_polygons to PlateModelFiles."
+            )
+
+        self.gplates_connector = gplates_connector
+        self.age_to_property = age_to_property
+        self.config = config or LithosphereSourceConfig()
+        self._default_continental_age_myr = default_continental_age_myr
+        self.comm = comm
+        self._is_root = (comm.rank == 0)
+
+        if walk_start_age is not None and not (
+            0 <= walk_start_age <= self.oldest_age
+        ):
+            raise ValueError(
+                f"walk_start_age ({walk_start_age}) must be between 0 and the "
+                f"plate model's oldest age ({self.oldest_age:.2f} Ma)."
+            )
+        self._walk_start_age = walk_start_age
+
+        # Stashed for the lazy _load; not touched between here and prepare.
+        self._continental_data = continental_data
+        self._plate_files = plate_files
+
+        self._initialized = False
+        self._last_reinit_age: float | None = None
+        self._last_checkpoint_age: float | None = None
+        # Resolve and create the checkpoint directory up front (rank 0 only;
+        # all checkpoint I/O happens on root) so a typo'd path fails at wiring
+        # time rather than part-way through a simulation.
+        if self.config.checkpoint_interval_myr is not None:
+            self._checkpoint_dir = Path(
+                self.config.checkpoint_dir or "gtrack_checkpoints"
+            ).absolute()
+            if self._is_root:
+                self._checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            self._checkpoint_dir = None
+
+        # gtrack handles + present-day cloud are built lazily in _load (rank 0
+        # only). On non-root these stay None for the source's lifetime and are
+        # never read — all gtrack work happens on root.
+        self._ocean_tracker = None
+        self._rotator = None
+        self._continental_filter = None
+        self._continental_present = None
+
+    # Public properties (some tests / consumers want them)
+
+    @property
+    def is_root(self) -> bool:
+        return self._is_root
+
+    # Loading
+
+    def _load(self) -> None:
+        """Build the ocean tracker, rotators and present-day continental
+        cloud. Runs once on rank 0, driven by Source._ensure_loaded."""
+        gplates_connector = self.gplates_connector
+        plate_files = self._plate_files
+        tracer_kwargs = {
+            "time_step": self.config.time_step,
+            "default_mesh_points": self.config.n_points,
+        }
+        if self.config.gtrack_config is not None:
+            tracer_kwargs.update(self.config.gtrack_config)
+        tracer_config = TracerConfig(**tracer_kwargs)
+
+        self._ocean_tracker = SeafloorAgeTracker(
+            rotation_files=gplates_connector.rotation_filenames,
+            topology_files=gplates_connector.topology_filenames,
+            continental_polygons=plate_files.continental_polygons,
+            config=tracer_config,
+        )
+        self._rotator = PointRotator(
+            rotation_files=gplates_connector.rotation_filenames,
+            topology_files=gplates_connector.topology_filenames,
+            static_polygons=plate_files.static_polygons,
+        )
+        self._continental_filter = PolygonFilter(
+            polygon_files=plate_files.continental_polygons,
+            rotation_files=gplates_connector.rotation_filenames,
+        )
+        self._continental_present = self._load_continental(self._continental_data)
+
+    def _load_continental(self, data: CloudDataType) -> PointCloud:
+        cloud = _build_cloud(data, self.config.property_name, self.config.n_points)
+        n_before = cloud.n_points
+        cloud = self._continental_filter.filter_inside(cloud, at_age=0.0)
+        if n_before > 0:
+            log(f"LithosphereSource: continental data filtered "
+                f"{n_before} -> {cloud.n_points} points "
+                f"({100 * cloud.n_points / n_before:.1f}% retained).", level=DEBUG)
+        # No assign_plate_ids: the topological PointRotator advects every seed
+        # by whatever plate or network it sits in and no longer depends on
+        # plate ids, and this source emits no plate_ids downstream. The old
+        # remove_undefined=True silently dropped continental seeds whose
+        # static-polygon id had no rotation circuit — real data, biasing the
+        # kNN at exactly the passive margins we care about.
+        return cloud
+
+    # Age validation extension
+
+    def validate_age(self, age: float) -> None:
+        """Validate a requested age against the forward-only contract.
+
+        Two independent checks run after the base range / non-negative check
+        (which fires first). An age must pass both:
+
+        (a) Promise check: if ``walk_start_age`` was declared, the age must be
+            no older than it. This fires even before the first ``prepare``, so
+            an out-of-range request is caught at wiring time.
+        (b) Physical-floor check: once the tracker has actually stepped to some
+            age, an older age is unreachable (the walk is forward-only and
+            cannot rewind), regardless of any declaration.
+
+        Declaring ``walk_start_age`` does NOT let you revisit ages already
+        stepped past — it only declares the oldest age you intend to request.
+        """
+        super().validate_age(age)
+        # (a) Promise check — fires even before the first prepare.
+        if self._walk_start_age is not None and age > self._walk_start_age:
+            raise ValueError(
+                f"Requested age {age:.2f} Ma is older than the declared "
+                f"walk_start_age ({self._walk_start_age:.2f} Ma). Raise "
+                f"walk_start_age to the oldest age you will request, or request a "
+                f"younger age. The ocean tracker evolves forward only (decreasing age)."
+            )
+        # (b) Physical-floor check: once we've stepped to some age, we cannot
+        # go back to an older age. Check on all ranks (not just root) using
+        # the per-age cache, which is coherent.
+        if self._initialized and self._cached_age is not None:
+            if age > self._cached_age:
+                raise ValueError(
+                    f"Requested age {age:.2f} Ma is older than the last "
+                    f"computed age ({self._cached_age:.2f} Ma). The ocean "
+                    f"tracker can only evolve forward (decreasing age)."
+                )
+
+    # Computation (rank-0 only)
+
+    def _compute_sources(self, age: float) -> dict[str, np.ndarray]:
+        ocean_cloud = self._step_ocean_to(age)
+        ocean_ages = ocean_cloud.get_property("age")
+        ocean_cloud.add_property(
+            self.config.property_name, self.age_to_property(ocean_ages)
+        )
+
+        cont_cloud = self._rotator.rotate(
+            self._continental_present, from_age=0.0, to_age=age
+        )
+        cont_cloud.add_property(
+            "age", np.full(cont_cloud.n_points, self._default_continental_age_myr)
+        )
+
+        combined = PointCloud.concatenate([ocean_cloud, cont_cloud], warn=False)
+        # PointCloud.xyz / get_property return gtrack's internal arrays by
+        # reference (the accessors do not copy). The two-cloud concatenate
+        # vstacks into fresh arrays today, but we copy here regardless: the
+        # returned dict becomes the source's per-age _cached_dict, which is
+        # shared across sibling connectors and must survive the next step_to /
+        # rotate. The copy is a deliberate ownership boundary — it is cheap
+        # (~n_points elements) and does not rely on concatenate's freshness,
+        # which is an uncontracted gtrack implementation detail.
+        return {
+            "xyz": combined.xyz.copy(),
+            "thickness": combined.get_property(self.config.property_name).copy(),
+            "age": combined.get_property("age").copy(),
+        }
+
+    def _initialize_walk(self, age: float) -> None:
+        """First-call walk init: load the nearest checkpoint if one exists, else
+        initialize the tracker at the model's oldest age. Idempotent via the
+        _initialized latch. Distinct from Source._load (which builds the gtrack
+        objects); this initialises the forward age-walk state."""
+        if self._initialized:
+            return
+        loaded = False
+        best = _find_best_checkpoint(self._checkpoint_dir, age)
+        if best is not None:
+            try:
+                self._ocean_tracker.load_checkpoint(best)
+                loaded_age = self._ocean_tracker.current_age
+                log(f"LithosphereSource: loaded ocean checkpoint at "
+                    f"{loaded_age} Ma from {best}.", level=DEBUG)
+                self._last_reinit_age = loaded_age
+                self._last_checkpoint_age = loaded_age
+                loaded = True
+            except Exception as exc:
+                log(f"LithosphereSource: failed to load checkpoint "
+                    f"{best}: {exc}. Falling back to full init.", level=INFO)
+        if not loaded:
+            # pyGplates uses integer ages (Ma).
+            starting_age = int(self.gplates_connector.oldest_age)
+            log(f"LithosphereSource: initialising ocean tracker at "
+                f"{starting_age} Ma.", level=DEBUG)
+            self._ocean_tracker.initialize(starting_age=starting_age)
+            self._last_reinit_age = starting_age
+        self._initialized = True
+
+    def _step_ocean_to(self, age: float) -> PointCloud:
+        """Initialise (from checkpoint if available) and step the tracker to ``age``."""
+        self._initialize_walk(age)
+
+        if self._last_reinit_age is not None:
+            if abs(self._last_reinit_age - age) >= self.config.reinit_interval_myr:
+                log(f"LithosphereSource: reinitialising ocean tracker at "
+                    f"{age:.2f} Ma.", level=DEBUG)
+                self._ocean_tracker.reinitialize(n_points=self.config.n_points)
+                self._last_reinit_age = age
+
+        cloud = self._ocean_tracker.step_to(int(round(age)))
+        self._save_checkpoint_if_due(age)
+        return cloud
+
+    def _save_checkpoint_if_due(self, age: float) -> None:
+        if self._checkpoint_dir is None:
+            return
+        interval = self.config.checkpoint_interval_myr
+        if (self._last_checkpoint_age is not None
+                and abs(self._last_checkpoint_age - age) < interval):
+            return
+        rounded_age = int(round(age))
+        filepath = self._checkpoint_dir / f"ocean_checkpoint_{rounded_age}Ma.npz"
+        try:
+            self._ocean_tracker.save_checkpoint(filepath)
+            self._last_checkpoint_age = rounded_age
+            log(f"LithosphereSource: saved ocean checkpoint at "
+                f"{rounded_age} Ma -> {filepath}.", level=DEBUG)
+        except Exception as exc:
+            log(f"LithosphereSource: failed to save checkpoint at "
+                f"{rounded_age} Ma: {exc}", level=INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 demos = ["assess", "gadopt-demo-utils @ git+https://github.com/g-adopt/gadopt-demo-utils.git", "gmsh", "imageio", "jupytext", "openpyxl", "pyvista"]
 optimisation = ["pyroltrilinos"]
-gplates = ["gtrack", "pygplates"]
+gplates = ["gtrack>=0.4.0", "pygplates"]
 
 [tool.setuptools]
 packages = ["gadopt", "gadopt.gplates", "gadopt.demos"]

--- a/tests/unit/test_gplates.py
+++ b/tests/unit/test_gplates.py
@@ -1,9 +1,40 @@
 import pickle
 from pathlib import Path
 import numpy as np
+import pytest
 
 from gadopt import *
-from gadopt.gplates import GplatesVelocityFunction, pyGplatesConnector, ensure_reconstruction
+from gadopt.gplates import (
+    GplatesVelocityFunction,
+    PlateModelFiles,
+    pyGplatesConnector,
+    ensure_reconstruction,
+    ConnectorFactory,
+    LithosphereConnectorFactory,
+    LithosphereSource,
+    QuinticOutput,
+    GeothermERFOutput,
+)
+
+
+def test_connector_no_longer_carries_polygon_kwargs():
+    """pyGplatesConnector is velocity-only now: the polygon paths moved to
+    PlateModelFiles. The constructor must not accept the old kwargs, and the
+    new dataclass must carry them. No reconstruction data needed."""
+    import inspect
+
+    params = inspect.signature(pyGplatesConnector.__init__).parameters
+    assert "continental_polygons" not in params
+    assert "static_polygons" not in params
+
+    pf = PlateModelFiles(
+        continental_polygons="cont.gpml", static_polygons="static.gpml"
+    )
+    assert pf.continental_polygons == "cont.gpml"
+    assert pf.static_polygons == "static.gpml"
+    # Defaults are None so the source None-validation can fire.
+    assert PlateModelFiles().continental_polygons is None
+    assert PlateModelFiles().static_polygons is None
 
 
 def test_obtain_muller_2022_se():
@@ -11,7 +42,9 @@ def test_obtain_muller_2022_se():
     plate_reconstruction_files_with_path = ensure_reconstruction("Muller 2022 SE v1.2", gplates_data_path)
 
     # Check if the files are downloaded and accessible
-    for file_list in plate_reconstruction_files_with_path.values():
+    # Values can be lists (rotation/topology files) or strings (polygon files)
+    for files in plate_reconstruction_files_with_path.values():
+        file_list = files if isinstance(files, list) else [files]
         for file_path in file_list:
             assert Path(file_path).exists(), f"{file_path} does not exist."
 
@@ -75,3 +108,369 @@ def test_gplates(write_pvd=False):
         ref_surface_rms = pickle.load(file)
 
     np.testing.assert_allclose(surface_rms, ref_surface_rms)
+
+
+# =============================================================================
+# Age Validation Tests
+# =============================================================================
+
+def half_space_cooling(age_myr):
+    """Convert seafloor age (Myr) to lithospheric thickness (km)."""
+    age_sec = np.maximum(age_myr, 0) * 3.15576e13
+    return np.minimum(2.32 * np.sqrt(1e-6 * age_sec) / 1e3, 150.0)
+
+
+@pytest.fixture
+def plate_model_with_polygons():
+    """Create pyGplatesConnector for testing the indicator/geotherm path."""
+    gplates_data_path = Path(__file__).resolve().parents[2] / "demos/mantle_convection/gplates_global"
+    muller_files = ensure_reconstruction("Muller 2022 SE v1.2", gplates_data_path)
+
+    return pyGplatesConnector(
+        rotation_filenames=muller_files["rotation_filenames"],
+        topology_filenames=muller_files["topology_filenames"],
+        oldest_age=200,
+    )
+
+
+@pytest.fixture
+def plate_files():
+    """Polygon file paths for the indicator/geotherm sources."""
+    gplates_data_path = Path(__file__).resolve().parents[2] / "demos/mantle_convection/gplates_global"
+    muller_files = ensure_reconstruction("Muller 2022 SE v1.2", gplates_data_path)
+    return PlateModelFiles(
+        continental_polygons=muller_files.get("continental_polygons"),
+        static_polygons=muller_files.get("static_polygons"),
+    )
+
+
+@pytest.fixture
+def synthetic_data():
+    """Create synthetic thickness data for testing."""
+    latlon = np.array([[0, 0], [10, 10], [20, 20], [30, 30]])
+    values = np.array([100, 150, 200, 180])
+    return (latlon, values)
+
+
+@pytest.fixture
+def test_coords():
+    """Create test coordinates."""
+    return np.array([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]])
+
+
+class TestFindBestCheckpoint:
+    """The checkpoint-discovery helper matches on Path stems, so the filename
+    pattern and the suffix are checked independently — guard both."""
+
+    def test_picks_smallest_age_not_younger_than_target(self, tmp_path):
+        from gadopt.gplates.sources import _find_best_checkpoint
+
+        for age in (50, 100, 200):
+            (tmp_path / f"ocean_checkpoint_{age}Ma.npz").touch()
+        (tmp_path / "ocean_checkpoint_75Ma.txt").touch()  # wrong suffix
+        (tmp_path / "other_120Ma.npz").touch()  # wrong stem
+
+        best = _find_best_checkpoint(tmp_path, 80.0)
+        assert best == tmp_path / "ocean_checkpoint_100Ma.npz"
+
+    def test_none_dir_returns_none(self):
+        from gadopt.gplates.sources import _find_best_checkpoint
+
+        assert _find_best_checkpoint(None, 50.0) is None
+
+    def test_no_checkpoint_old_enough_returns_none(self, tmp_path):
+        from gadopt.gplates.sources import _find_best_checkpoint
+
+        (tmp_path / "ocean_checkpoint_50Ma.npz").touch()
+        assert _find_best_checkpoint(tmp_path, 80.0) is None
+
+    def test_vanished_dir_raises(self, tmp_path):
+        """The directory is created at source construction; if it disappears
+        mid-run the error must propagate, not be silenced."""
+        from gadopt.gplates.sources import _find_best_checkpoint
+
+        with pytest.raises(FileNotFoundError):
+            _find_best_checkpoint(tmp_path / "gone", 50.0)
+
+
+class TestConnectorFactory:
+    def test_cannot_construct_source_without_class(self):
+        factory = ConnectorFactory()
+        with pytest.raises(
+            TypeError, match="Do not know what kind of Source to construct!"
+        ):
+            factory.construct_source()
+
+    def test_cannot_construct_indicator_without_source_class(self):
+        factory = ConnectorFactory()
+        with pytest.raises(
+            RuntimeError,
+            match="A source must be either constructed or connected in order to construct the indicator",
+        ):
+            _ = factory.indicator
+
+    def test_exception_on_default_source(self):
+        factory = ConnectorFactory(source_class=LithosphereSource)
+        with pytest.raises(
+            RuntimeError,
+            match="A source must be either constructed or connected in order to construct the indicator",
+        ):
+            _ = factory.indicator
+
+    def test_constructed_source(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        factory = ConnectorFactory(source_class=LithosphereSource)
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+
+        assert isinstance(factory.source, LithosphereSource)
+
+    def test_inherited_source(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        factory1 = ConnectorFactory(source_class=LithosphereSource)
+        factory2 = ConnectorFactory()
+        factory1.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory2.source = factory1.source
+        assert factory1.source is factory2.source
+
+    def test_strictly_single_source(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        factory = ConnectorFactory(source_class=LithosphereSource)
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        source = LithosphereSource(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        with pytest.raises(RuntimeError, match="This factory already has a Source!"):
+            factory.source = source
+
+    def test_constructed_output(self):
+        factory = ConnectorFactory(output_class=QuinticOutput)
+        factory.construct_output()
+
+        assert isinstance(factory.output, QuinticOutput)
+
+    def test_inherited_output(self):
+        factory1 = ConnectorFactory(output_class=QuinticOutput)
+        factory2 = ConnectorFactory()
+        factory1.construct_output()
+        factory2.output = factory1.output
+        assert factory1.output is factory2.output
+
+    def test_strictly_single_output(self):
+        factory = ConnectorFactory(output_class=QuinticOutput)
+        factory.construct_output()
+        output = QuinticOutput()
+        with pytest.raises(
+            RuntimeError, match="This factory already has an indicator Output!"
+        ):
+            factory.output = output
+
+    def test_strictly_single_geotherm_output(self):
+        factory = ConnectorFactory(geotherm_output_class=GeothermERFOutput)
+        factory.construct_geotherm()
+        with pytest.raises(
+            RuntimeError, match="This factory already has a geotherm Output!"
+        ):
+            factory.geotherm_output = GeothermERFOutput()
+
+    def test_constructed_geotherm_output(self):
+        factory = ConnectorFactory(geotherm_output_class=GeothermERFOutput)
+        factory.construct_geotherm(kappa=2e-6)
+
+        assert isinstance(factory.geotherm_output, GeothermERFOutput)
+        assert factory.geotherm_output.kappa == 2e-6
+
+    def test_geotherm_requires_geotherm_output(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        factory = ConnectorFactory(source_class=LithosphereSource)
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        with pytest.raises(
+            RuntimeError,
+            match="A geotherm_output must be either constructed or connected in order to construct the geotherm",
+        ):
+            _ = factory.geotherm
+
+    def test_indicator_and_geotherm_share_source(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        """The whole point of the factory: both connectors hold the same
+        Source instance, so the forward-only ocean tracker advances once per
+        age no matter which connector updates first."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+        factory.construct_geotherm()
+
+        assert factory.indicator.source is factory.geotherm.source
+        assert factory.indicator is not factory.geotherm
+        assert isinstance(factory.indicator.output, QuinticOutput)
+        assert isinstance(factory.geotherm.output, GeothermERFOutput)
+
+    def test_connector_params_forwarded(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        """Typed connector-level parameters reach every connector the
+        factory creates."""
+        from gadopt.gplates import MeshConfig, InterpolationConfig
+
+        mesh_cfg = MeshConfig(r_outer=2.22, depth_scale=2890.0)
+        interp_cfg = InterpolationConfig(k_neighbors=8)
+        factory = LithosphereConnectorFactory(
+            mesh=mesh_cfg, interpolation=interp_cfg, gc_collect_frequency=3
+        )
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+        factory.construct_geotherm()
+
+        assert factory.indicator.gc_collect_frequency == 3
+        assert factory.geotherm.gc_collect_frequency == 3
+        assert factory.indicator.mesh is mesh_cfg
+        assert factory.geotherm.mesh is mesh_cfg
+        assert factory.indicator.interpolation is interp_cfg
+        assert factory.geotherm.interpolation is interp_cfg
+
+    def test_default_output_raises_exception(
+        self, plate_model_with_polygons, plate_files, synthetic_data
+    ):
+        factory = ConnectorFactory(source_class=LithosphereSource)
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        with pytest.raises(
+            RuntimeError,
+            match="An output must be either constructed or connected in order to construct the indicator",
+        ):
+            _ = factory.indicator
+
+
+class TestLithosphereConnectorAgeValidation:
+    """Test age validation in LithosphereConnector."""
+
+    def test_valid_age_works(self, plate_model_with_polygons, plate_files, synthetic_data, test_coords):
+        """Test that valid ages within bounds work correctly."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+
+        # Valid age within bounds
+        ndtime = plate_model_with_polygons.age2ndtime(100)
+        result = factory.indicator.get_indicator(test_coords, ndtime)
+
+        assert result.shape == (len(test_coords),)
+        assert np.all(np.isfinite(result))
+
+    def test_age_older_than_oldest_raises_error(self, plate_model_with_polygons, plate_files, synthetic_data, test_coords):
+        """Test that requesting age > oldest_age raises ValueError."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+
+        # Age older than oldest_age (200 Ma)
+        ndtime = plate_model_with_polygons.age2ndtime(250)
+
+        with pytest.raises(ValueError, match="older than the plate model's oldest age"):
+            factory.indicator.get_indicator(test_coords, ndtime)
+
+    def test_negative_age_raises_error(self, plate_model_with_polygons, plate_files, synthetic_data, test_coords):
+        """Test that requesting negative age (future) raises ValueError."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+
+        # Negative age (in the future)
+        ndtime = plate_model_with_polygons.age2ndtime(-10)
+
+        with pytest.raises(ValueError, match="negative.*future"):
+            factory.indicator.get_indicator(test_coords, ndtime)
+
+    def test_backward_step_raises_error(self, plate_model_with_polygons, plate_files, synthetic_data, test_coords):
+        """Test that going backward in ocean tracker raises ValueError."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+
+        # First step forward to 50 Ma
+        ndtime_50 = plate_model_with_polygons.age2ndtime(50)
+        factory.indicator.get_indicator(test_coords, ndtime_50)
+
+        # Now try to go backward to 150 Ma (should fail)
+        ndtime_150 = plate_model_with_polygons.age2ndtime(150)
+
+        with pytest.raises(ValueError, match="can only evolve forward"):
+            factory.indicator.get_indicator(test_coords, ndtime_150)
+
+    def test_forward_steps_work(self, plate_model_with_polygons, plate_files, synthetic_data, test_coords):
+        """Test that sequential forward steps (decreasing age) work."""
+        factory = LithosphereConnectorFactory()
+        factory.construct_source(
+            gplates_connector=plate_model_with_polygons,
+            continental_data=synthetic_data,
+            age_to_property=half_space_cooling,
+            plate_files=plate_files,
+        )
+        factory.construct_output()
+
+        # Sequential forward steps (decreasing age)
+        for age in [150, 100, 50, 0]:
+            ndtime = plate_model_with_polygons.age2ndtime(age)
+            result = factory.indicator.get_indicator(test_coords, ndtime)
+            assert result.shape == (len(test_coords),)

--- a/tests/unit/test_outputs.py
+++ b/tests/unit/test_outputs.py
@@ -1,14 +1,22 @@
-"""Validation tests for MeshConfig.
+"""Tests for OutputStrategy subclasses and MeshConfig.
 
 No reconstruction data needed; everything in this file constructs its inputs
-directly. The tests pin the defaults, check that input parameters are
-honoured, and reject invalid values. The downstream branches extend this file
-with the numerical behaviour of the OutputStrategy subclasses.
+directly. The tests check the numerical behaviour of the indicator and
+geotherm transformations, and the validation contracts of the small
+dataclasses: defaults are what we expect, input parameters are honoured,
+and invalid values are rejected.
 """
 
+import numpy as np
 import pytest
 
-from gadopt.gplates import MeshConfig
+from gadopt.gplates import (
+    GeothermERFOutput,
+    MeshConfig,
+    QuinticOutput,
+    ocean_erf_normalized,
+    radial_quintic_step,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -35,3 +43,496 @@ class TestMeshConfig:
     def test_rejects_nonpositive_depth_scale(self):
         with pytest.raises(ValueError, match="depth_scale must be positive"):
             MeshConfig(depth_scale=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Geotherm functions (pure math; carried over from the old test file with the
+# **kwargs/age=None branches removed)
+# ---------------------------------------------------------------------------
+
+class TestOceanErfNormalized:
+    def test_surface_is_zero(self):
+        z_lab = np.array([100e3, 50e3, 150e3])
+        depth = np.zeros_like(z_lab)
+        age = np.array([50.0, 100.0, 10.0])
+        result = ocean_erf_normalized(depth, z_lab, age_myr=age, kappa=1e-6)
+        np.testing.assert_allclose(result, 0.0, atol=1e-12)
+
+    def test_lab_is_one(self):
+        z_lab = np.array([100e3, 50e3, 150e3])
+        depth = z_lab.copy()
+        age = np.array([50.0, 100.0, 10.0])
+        result = ocean_erf_normalized(depth, z_lab, age_myr=age, kappa=1e-6)
+        np.testing.assert_allclose(result, 1.0, atol=1e-6)
+
+    def test_monotone_in_depth(self):
+        z_lab = 100e3
+        depths = np.linspace(0, z_lab, 50)
+        z_labs = np.full_like(depths, z_lab)
+        ages = np.full_like(depths, 80.0)
+        result = ocean_erf_normalized(depths, z_labs, age_myr=ages, kappa=1e-6)
+        assert np.all(np.diff(result) >= 0)
+
+    def test_clipped_to_unit_interval(self):
+        z_lab = np.array([100e3])
+        depth = np.array([200e3])  # deeper than LAB
+        age = np.array([80.0])
+        result = ocean_erf_normalized(depth, z_lab, age_myr=age, kappa=1e-6)
+        assert np.all((result >= 0.0) & (result <= 1.0))
+
+    def test_young_vs_old(self):
+        # Young ocean: steep erf, T at mid-depth > 0.5; old ocean: profile
+        # approaches linear, T at mid-depth ~ 0.5.
+        depth = np.array([50e3])
+        z_lab = np.array([100e3])
+        young = ocean_erf_normalized(depth, z_lab, age_myr=np.array([5.0]), kappa=1e-6)
+        old = ocean_erf_normalized(depth, z_lab, age_myr=np.array([200.0]), kappa=1e-6)
+        assert young[0] > old[0]
+
+    def test_zero_age_returns_finite(self):
+        # The internal safety floor (max(age_sec, 1.0)) means zero-age inputs
+        # still produce a valid number rather than a divide-by-zero.
+        depth = np.array([10e3])
+        z_lab = np.array([100e3])
+        age = np.array([0.0])
+        result = ocean_erf_normalized(depth, z_lab, age_myr=age, kappa=1e-6)
+        assert np.all(np.isfinite(result))
+        assert np.all((result >= 0.0) & (result <= 1.0))
+
+
+# ---------------------------------------------------------------------------
+# radial_quintic_step — shared radial primitive
+# ---------------------------------------------------------------------------
+
+class TestRadialQuinticStep:
+    """One-sided quintic step: exactly 1 for r >= base_r, exactly 0 for
+    r <= base_r - width, the smoothstep polynomial in between.
+
+    The transition sits entirely BELOW the base: the base itself reads 1
+    (the old tanh kernel read 0.5 there) and the 0.5-crossing is at
+    base_r - width/2. base_r may be a scalar (fixed base depth) or a
+    per-node array (variable base depth) and both broadcast correctly.
+    """
+
+    def test_exact_plateaus_and_midpoint(self):
+        base_r = 2.0
+        width = 0.01
+        # Exactly 1 at the base and everywhere above it.
+        assert radial_quintic_step(base_r, base_r, width) == 1.0
+        assert radial_quintic_step(base_r + 0.05, base_r, width) == 1.0
+        # Zero at base - width (up to round-off in forming base - width) and
+        # exactly 0 everywhere below the band (no tanh tail).
+        np.testing.assert_allclose(
+            radial_quintic_step(base_r - width, base_r, width), 0.0, atol=1e-30
+        )
+        assert radial_quintic_step(base_r - 0.05, base_r, width) == 0.0
+        # The 0.5-crossing sits at the middle of the band, base - width/2.
+        np.testing.assert_allclose(
+            radial_quintic_step(base_r - width / 2, base_r, width),
+            0.5, rtol=1e-12,
+        )
+        # Monotone increasing across the band.
+        rs = np.linspace(base_r - width, base_r, 50)
+        f = radial_quintic_step(rs, base_r, width)
+        assert np.all(np.diff(f) > 0)
+
+    def test_point_symmetry_about_band_midpoint(self):
+        # The smoothstep polynomial satisfies S(t) + S(1-t) == 1, so the step
+        # is point-symmetric about (base - width/2, 0.5).
+        base_r = 2.0
+        width = 0.02
+        mid = base_r - width / 2
+        d = np.array([0.001, 0.005, 0.009])
+        np.testing.assert_allclose(
+            radial_quintic_step(mid + d, base_r, width)
+            + radial_quintic_step(mid - d, base_r, width),
+            1.0, rtol=1e-12,
+        )
+
+    def test_flat_junctions(self):
+        # Zero slope at both ends of the band (C^1; the quintic is in fact
+        # C^2). The numerical slope just inside each junction is tiny
+        # compared to the mid-band slope.
+        base_r = 2.0
+        width = 0.02
+        eps = 1e-6 * width
+
+        def slope_at(r):
+            return (
+                radial_quintic_step(r + eps, base_r, width)
+                - radial_quintic_step(r - eps, base_r, width)
+            ) / (2 * eps)
+        mid_slope = slope_at(base_r - width / 2)
+        assert abs(slope_at(base_r - eps)) < 1e-6 * mid_slope
+        assert abs(slope_at(base_r - width + eps)) < 1e-6 * mid_slope
+
+    def test_scalar_and_array_base_broadcast(self):
+        # Scalar base_r and a per-node array base_r both broadcast against an
+        # array r_target. A constant array base must reproduce the scalar case.
+        r = np.array([2.0, 2.05, 2.1])
+        width = 0.02
+        scalar = radial_quintic_step(r, 2.05, width)
+        array = radial_quintic_step(r, np.full_like(r, 2.05), width)
+        np.testing.assert_allclose(scalar, array, rtol=1e-12)
+        # A genuinely per-node base shifts each band independently: each node
+        # sitting exactly on its own base reads exactly 1.
+        per_node_base = r.copy()
+        np.testing.assert_array_equal(
+            radial_quintic_step(r, per_node_base, width), 1.0
+        )
+
+    def test_narrower_width_is_steeper(self):
+        # Narrower transition width => larger gradient magnitude in the band.
+        base_r = 2.0
+        rs = np.linspace(base_r - 0.05, base_r + 0.05, 200)
+        narrow = radial_quintic_step(rs, base_r, 0.005)
+        wide = radial_quintic_step(rs, base_r, 0.05)
+        assert np.abs(np.gradient(narrow)).max() > np.abs(np.gradient(wide)).max()
+
+
+# ---------------------------------------------------------------------------
+# QuinticOutput — variable base, no fade (the old TanhOutput role)
+# ---------------------------------------------------------------------------
+
+class TestQuinticOutputVariableBase:
+    """Tests exercise QuinticOutput.compute directly with synthetic inputs.
+
+    Default configuration: per-node base depth from the thickness channel,
+    no lateral fade. The indicator is exactly 1 from the surface down to the
+    base, exactly 0 below base + width.
+    """
+
+    @staticmethod
+    def _interp(thickness_km, n_targets=1):
+        # Helper: a single interpolated thickness value broadcast to n_targets.
+        return {"thickness": np.full(n_targets, thickness_km, dtype=float)}
+
+    def test_validation_rejects_bad_args(self):
+        with pytest.raises(ValueError, match="width_km must be positive"):
+            QuinticOutput(width_km=0.0)
+        with pytest.raises(ValueError, match="width_km must be positive"):
+            QuinticOutput(width_km=-1.0)
+        with pytest.raises(ValueError, match="base_depth_km must be positive"):
+            QuinticOutput(base_depth_km=0.0)
+        with pytest.raises(ValueError, match="fade_ref_km must be positive"):
+            QuinticOutput(fade_ref_km=-5.0)
+        with pytest.raises(ValueError, match="default_thickness_km must be non-negative"):
+            QuinticOutput(default_thickness_km=-1.0)
+        # Zero is allowed (polygon mask-and-relabel uses default 0).
+        QuinticOutput(default_thickness_km=0.0)
+
+    def test_value_at_base_is_one(self):
+        # The target sitting exactly at r_outer - thickness/depth_scale reads
+        # exactly 1: the transition hangs entirely below the base (the old
+        # tanh kernel read 0.5 here).
+        mesh = MeshConfig(r_outer=2.208, depth_scale=2890.0)
+        out = QuinticOutput(width_km=10.0)
+        thickness = 100.0
+        interp = self._interp(thickness)
+        too_far = np.array([False])
+        r_target = np.array([mesh.r_outer - thickness / mesh.depth_scale])
+        result = out.compute(interp, r_target, too_far, mesh)
+        np.testing.assert_array_equal(result, 1.0)
+
+    def test_half_crossing_half_width_below_base(self):
+        mesh = MeshConfig()
+        width = 10.0
+        thickness = 100.0
+        out = QuinticOutput(width_km=width)
+        r_target = np.array(
+            [mesh.r_outer - (thickness + width / 2) / mesh.depth_scale]
+        )
+        result = out.compute(
+            self._interp(thickness), r_target, np.array([False]), mesh
+        )
+        np.testing.assert_allclose(result, 0.5, rtol=1e-10)
+
+    def test_value_inside_lithosphere_is_one_exact(self):
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0)
+        # 50 km depth, with lithosphere 200 km thick: well inside.
+        r_target = np.array([mesh.r_outer - 50.0 / mesh.depth_scale])
+        interp = self._interp(200.0)
+        result = out.compute(interp, r_target, np.array([False]), mesh)
+        np.testing.assert_array_equal(result, 1.0)
+
+    def test_value_below_transition_is_zero_exact(self):
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0)
+        # 400 km depth, with lithosphere 200 km thick: well below base+width.
+        r_target = np.array([mesh.r_outer - 400.0 / mesh.depth_scale])
+        interp = self._interp(200.0)
+        result = out.compute(interp, r_target, np.array([False]), mesh)
+        np.testing.assert_array_equal(result, 0.0)
+
+    def test_zero_thickness_surface_skin(self):
+        # Where thickness is exactly zero the base coincides with the surface
+        # and the SURFACE NODE reads 1 (the transition hangs just below it).
+        # This is the documented reason zero-outside polygon sources must pair
+        # the step with a lateral fade; one width below the surface the column
+        # is exactly 0 again.
+        mesh = MeshConfig()
+        width = 10.0
+        out = QuinticOutput(width_km=width)
+        surface = out.compute(
+            self._interp(0.0), np.array([mesh.r_outer]), np.array([False]), mesh
+        )
+        np.testing.assert_array_equal(surface, 1.0)
+        below = out.compute(
+            self._interp(0.0),
+            np.array([mesh.r_outer - width / mesh.depth_scale]),
+            np.array([False]), mesh,
+        )
+        np.testing.assert_allclose(below, 0.0, atol=1e-30)
+
+    def test_narrower_transition_steeper_gradient(self):
+        mesh = MeshConfig()
+        thickness = 100.0
+        # Sweep a range of radii crossing the transition band.
+        r_target = np.linspace(
+            mesh.r_outer - (thickness + 50.0) / mesh.depth_scale,
+            mesh.r_outer - (thickness - 50.0) / mesh.depth_scale,
+            100,
+        )
+        interp = {"thickness": np.full_like(r_target, thickness)}
+        too_far = np.zeros_like(r_target, dtype=bool)
+        narrow = QuinticOutput(width_km=1.0).compute(interp, r_target, too_far, mesh)
+        wide = QuinticOutput(width_km=20.0).compute(interp, r_target, too_far, mesh)
+        assert np.abs(np.gradient(narrow)).max() > np.abs(np.gradient(wide)).max()
+
+    def test_too_far_uses_default_thickness(self):
+        # Polygon-style use: default_thickness_km=0 means too-far targets
+        # read as "outside the region" (indicator -> 0 below the surface skin).
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0, default_thickness_km=0.0)
+        r_target = np.array([mesh.r_outer - 100.0 / mesh.depth_scale])
+        interp = self._interp(200.0)  # value ignored when too_far=True
+        too_far = np.array([True])
+        result = out.compute(interp, r_target, too_far, mesh)
+        np.testing.assert_array_equal(result, 0.0)
+
+        # Lithosphere-style use: default_thickness_km=100 means too-far
+        # targets get a sensible fill rather than zero.
+        out_lith = QuinticOutput(width_km=10.0, default_thickness_km=100.0)
+        # Target at 50 km depth, default 100 km -> well inside.
+        r_target_inside = np.array([mesh.r_outer - 50.0 / mesh.depth_scale])
+        result_inside = out_lith.compute(interp, r_target_inside, np.array([True]), mesh)
+        np.testing.assert_array_equal(result_inside, 1.0)
+
+    def test_does_not_mutate_input(self):
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0)
+        thickness = np.array([999.0, 10.0])
+        interp = {"thickness": thickness.copy()}
+        out.compute(interp, np.full(2, mesh.r_outer), np.array([True, False]), mesh)
+        np.testing.assert_array_equal(interp["thickness"], thickness)
+
+
+# ---------------------------------------------------------------------------
+# GeothermERFOutput
+# ---------------------------------------------------------------------------
+
+class TestGeothermERFOutput:
+    def test_requires_thickness_and_age(self):
+        assert GeothermERFOutput().requires == frozenset({"thickness", "age"})
+
+    def test_validation_rejects_nonpositive_kappa(self):
+        with pytest.raises(ValueError, match="kappa must be positive"):
+            GeothermERFOutput(kappa=0.0)
+
+    def test_validation_rejects_nonpositive_default_thickness(self):
+        with pytest.raises(ValueError, match="default_thickness_km must be positive"):
+            GeothermERFOutput(default_thickness_km=0.0)
+
+    def test_validation_rejects_nonpositive_too_far_age(self):
+        with pytest.raises(ValueError, match="too_far_age_myr must be positive"):
+            GeothermERFOutput(too_far_age_myr=-1.0)
+
+    def test_surface_is_zero_lab_is_one(self):
+        # Two target points: one at the surface, one at the LAB depth.
+        # The output should match the underlying erf geotherm.
+        mesh = MeshConfig(r_outer=2.208, depth_scale=2890.0)
+        out = GeothermERFOutput(kappa=1e-6)
+        thickness_km = 100.0
+        r_surface = mesh.r_outer
+        r_lab = mesh.r_outer - thickness_km / mesh.depth_scale
+        r_target = np.array([r_surface, r_lab])
+        interp = {
+            "thickness": np.full(2, thickness_km),
+            "age": np.full(2, 80.0),
+        }
+        result = out.compute(interp, r_target, np.array([False, False]), mesh)
+        assert result[0] < 1e-6
+        assert result[1] > 1.0 - 1e-3
+
+    def test_too_far_uses_fallback_age_and_thickness(self):
+        # too_far=True targets should pick up the fallback thickness and age
+        # rather than the interpolated values. Confirm by comparing against
+        # a direct call to ocean_erf_normalized at the same point.
+        mesh = MeshConfig()
+        fallback_thick = 100.0
+        fallback_age = 500.0
+        out = GeothermERFOutput(
+            kappa=1e-6,
+            default_thickness_km=fallback_thick,
+            too_far_age_myr=fallback_age,
+        )
+        r_target = np.array([mesh.r_outer - 50.0 / mesh.depth_scale])
+        interp = {
+            "thickness": np.array([999.0]),  # value ignored when too_far
+            "age": np.array([12345.0]),       # value ignored when too_far
+        }
+        result = out.compute(interp, r_target, np.array([True]), mesh)
+        depth_m = (mesh.r_outer - r_target[0]) * mesh.depth_scale * 1e3
+        expected = ocean_erf_normalized(
+            np.array([depth_m]),
+            np.array([fallback_thick * 1e3]),
+            age_myr=np.array([fallback_age]),
+            kappa=1e-6,
+        )
+        np.testing.assert_allclose(result, expected, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# QuinticOutput, fixed base — separable lateral-fade × fixed-depth radial step
+# ---------------------------------------------------------------------------
+
+class TestQuinticOutputFixedBase:
+    """I(r, x) = f_lat(x) * S(r) with f_lat = clip(thickness/fade_ref, 0, 1)
+    and a radial step whose base depth is FIXED (independent of thickness).
+    """
+
+    def test_separable_product(self):
+        # The whole field equals f_lat(x) * S(r) computed independently.
+        mesh = MeshConfig()
+        crust, w_r = 50.0, 10.0
+        out = QuinticOutput(width_km=w_r, base_depth_km=crust, fade_ref_km=crust)
+        thickness = np.array([10.0, 25.0, 50.0, 80.0])
+        r_target = mesh.r_outer - np.array([20.0, 40.0, 60.0, 100.0]) / mesh.depth_scale
+        too_far = np.zeros(4, dtype=bool)
+        result = out.compute({"thickness": thickness.copy()}, r_target, too_far, mesh)
+
+        f_lat = np.clip(thickness / crust, 0.0, 1.0)
+        base_r = mesh.r_outer - crust / mesh.depth_scale
+        S = radial_quintic_step(r_target, base_r, w_r / mesh.depth_scale)
+        np.testing.assert_allclose(result, f_lat * S, rtol=1e-12)
+
+    def test_fixed_base_depth_independent_of_thickness(self):
+        # The radial step does NOT move with thickness: at the fixed base_r,
+        # S = 1 exactly (one-sided step) for every thickness, so a saturated
+        # column reads exactly 1 there regardless of how thick it is.
+        mesh = MeshConfig()
+        crust = 50.0
+        out = QuinticOutput(width_km=10.0, base_depth_km=crust, fade_ref_km=crust)
+        base_r = mesh.r_outer - crust / mesh.depth_scale
+        for thickness in (50.0, 100.0, 300.0):
+            r_target = np.array([base_r])
+            result = out.compute(
+                {"thickness": np.array([thickness])}, r_target, np.array([False]), mesh
+            )
+            np.testing.assert_array_equal(result, 1.0)
+
+    def test_ocean_column_zeroed_vs_unfaded_surface_skin(self):
+        # too_far (or zero thickness) zeroes the entire column, surface
+        # included. Contrast: the UNFADED variable-base step on the same
+        # zero-thickness surface point reads exactly 1 — the surface skin
+        # that makes the fade mandatory for zero-outside sources.
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0, base_depth_km=50.0, fade_ref_km=50.0)
+        r_surface = np.array([mesh.r_outer])
+        # Zero thickness -> f_lat = 0 -> whole column 0 even at the surface.
+        zero = out.compute({"thickness": np.array([0.0])}, r_surface, np.array([False]), mesh)
+        np.testing.assert_allclose(zero, 0.0, atol=1e-15)
+        # too_far sets thickness to 0 with the same effect.
+        too_far = out.compute(
+            {"thickness": np.array([999.0])}, r_surface, np.array([True]), mesh
+        )
+        np.testing.assert_allclose(too_far, 0.0, atol=1e-15)
+        # Unfaded variable-base step at the same ocean surface point reads 1.
+        unfaded_surface = QuinticOutput(width_km=10.0, default_thickness_km=0.0).compute(
+            {"thickness": np.array([0.0])}, r_surface, np.array([False]), mesh
+        )
+        np.testing.assert_array_equal(unfaded_surface, 1.0)
+
+    def test_amplitude_scaling_and_saturation(self):
+        # The surface sits on the plateau of the fixed-base step (S = 1
+        # exactly), so the surface value IS f_lat: linear in thickness up to
+        # the fade reference, saturated at 1 beyond it.
+        mesh = MeshConfig()
+        crust = 50.0
+        out = QuinticOutput(width_km=10.0, base_depth_km=crust, fade_ref_km=crust)
+        r_surface = np.array([mesh.r_outer])
+        # thickness = crust -> f_lat = 1 -> full surface amplitude, exactly 1.
+        full = out.compute({"thickness": np.array([crust])}, r_surface, np.array([False]), mesh)
+        np.testing.assert_array_equal(full, 1.0)
+        # thickness = crust/2 -> f_lat = 0.5 -> exactly half amplitude.
+        half = out.compute({"thickness": np.array([crust / 2])}, r_surface, np.array([False]), mesh)
+        np.testing.assert_allclose(half, 0.5, rtol=1e-12)
+        # thickness = 4*crust -> f_lat saturates at 1, same as full.
+        sat = out.compute({"thickness": np.array([4 * crust])}, r_surface, np.array([False]), mesh)
+        np.testing.assert_allclose(sat, full, rtol=1e-12)
+
+    def test_does_not_mutate_input(self):
+        mesh = MeshConfig()
+        out = QuinticOutput(width_km=10.0, base_depth_km=50.0, fade_ref_km=50.0)
+        thickness = np.array([999.0, 10.0])
+        interp = {"thickness": thickness.copy()}
+        out.compute(interp, np.full(2, mesh.r_outer), np.array([True, False]), mesh)
+        np.testing.assert_array_equal(interp["thickness"], thickness)
+
+
+# ---------------------------------------------------------------------------
+# QuinticOutput, variable base + fade — both from one thickness channel
+# ---------------------------------------------------------------------------
+
+class TestQuinticOutputVariableFaded:
+    """I(r, x) = f_lat(x) * S(r; h(x)), with both the fade and the per-node
+    base depth derived from the SAME thickness channel.
+
+    Because the one-sided step reads exactly 1 at the surface for ANY base
+    depth, the surface value of this configuration is exactly f_lat — the
+    fade alone controls the surface, while the variable base depth controls
+    where the column decays at depth.
+    """
+
+    def test_surface_is_exactly_the_fade(self):
+        mesh = MeshConfig()
+        thickness_ref, w_r = 150.0, 10.0
+        out = QuinticOutput(width_km=w_r, fade_ref_km=thickness_ref)
+
+        thickness = np.array([0.0, thickness_ref / 2.0, 300.0])
+        r_surface = np.full(3, mesh.r_outer)
+        too_far = np.zeros(3, dtype=bool)
+        surf = out.compute({"thickness": thickness.copy()}, r_surface, too_far, mesh)
+
+        # S(surface) = 1 exactly for every thickness, so surface == f_lat:
+        # zero thickness gives exactly 0 (the faded-away surface skin),
+        # half-reference gives exactly 0.5, saturated gives exactly 1.
+        f_lat = np.clip(thickness / thickness_ref, 0.0, 1.0)
+        np.testing.assert_allclose(surf, f_lat, rtol=1e-12)
+        np.testing.assert_array_equal(surf[0], 0.0)
+        np.testing.assert_array_equal(surf[2], 1.0)
+
+    def test_variable_base_moves_with_thickness(self):
+        # Each column reads f_lat * 1 at its OWN thickness-defined base and
+        # f_lat * 0.5 half a width below it — the crossing radius differs per
+        # node, which a fixed-base configuration could not reproduce.
+        mesh = MeshConfig()
+        thickness_ref, w_r = 150.0, 10.0
+        out = QuinticOutput(width_km=w_r, fade_ref_km=thickness_ref)
+        thickness = np.array([75.0, 300.0])
+        too_far = np.zeros(2, dtype=bool)
+        f_lat = np.clip(thickness / thickness_ref, 0.0, 1.0)
+
+        r_at_base = mesh.r_outer - thickness / mesh.depth_scale
+        at_base = out.compute(
+            {"thickness": thickness.copy()}, r_at_base, too_far, mesh
+        )
+        np.testing.assert_allclose(at_base, f_lat, rtol=1e-12)
+
+        r_mid_band = mesh.r_outer - (thickness + w_r / 2) / mesh.depth_scale
+        mid_band = out.compute(
+            {"thickness": thickness.copy()}, r_mid_band, too_far, mesh
+        )
+        np.testing.assert_allclose(mid_band, 0.5 * f_lat, rtol=1e-10)
+        assert r_at_base[0] != r_at_base[1]  # crossing moves with thickness


### PR DESCRIPTION
The first concrete feature on top of the new core. `LithosphereSource` combines a forward-stepped `SeafloorAgeTracker` for the oceanic seeds with present-day continental thickness back-rotated by a `PointRotator`, concatenating the two into one cloud that carries both thickness and age. The ocean tracker is the only stateful piece, and the per-age cache on the base class keeps it to a single `step_to` per geological age no matter how many connectors share the source.

This is the PR that answers the "LithosphereGeotherm has me questioning the whole structure" note. The geotherm classes are gone: a normalised oceanic geotherm is now just `ScalarFieldConnector(LithosphereSource(...), GeothermERFOutput(...))`, sharing the same source as the indicator. The structural unease was the right instinct, and the Source/Output split in the previous PR is the answer.

A couple of robustness points worth flagging. The walk is forward-only and can't rewind, so an optional `walk_start_age` turns the old silently-locked ceiling into a declared, fail-fast contract checked up front. The first-call initialisation was lifted out of `_step_ocean_to` into `_initialize_walk` so the stepping path reads as a flat sequence, and `_find_best_checkpoint` is now a module-level helper rather than a private staticmethod. On the MPI side: I checked gtrack's source, and `step_to`, `reinitialize`, and the checkpoint calls are all rank-local with no internal collectives, so the rank-0-compute-then-broadcast pattern in `Source.prepare` is safe from deadlock.

Outputs gain `TanhOutput` (the smooth indicator) and `GeothermERFOutput` (the age-dependent oceanic geotherm). Two factories, `lithosphere_indicator` and `lithosphere_geotherm`, absorb the common wiring; to share one tracker between them you build the source once and pass it to both. The docstring-style, `gc_collect_frequency` placement, and `**kwargs`/spelling comments from the original review are addressed here.
