### PR TITLE
Doc fix for transpose

### DIFF
--- a/gadopt/transport_solver.py
+++ b/gadopt/transport_solver.py
@@ -270,7 +270,7 @@ class GenericTransportSolver(GenericTransportBase):
         | --------- | --------------------- | ----------------------------------------- |
         | advection | u                     | advective_velocity_scaling, su_nubar      |
         | diffusion | diffusivity           | reference_for_diffusion, interior_penalty |
-        | mass      | diffusivity           | mass_scaling                              |
+        | mass      | —                     | mass_scaling                              |
         | source    | source                |                                           |
         | sink      | sink_coeff            |                                           |
 


### PR DESCRIPTION
First of five PRs decomposing the Richards-equation foundation work (see `ANATOMY-BRANCHES.md` on `sghelichkhani/richards-core` for the full split). This is the equation-infrastructure piece; nothing Richards-specific lands here.

`Equation` gains two reserved `eq_attrs` (`solution` and `nonlinear_coefficients`) plus a new `resolve_coefficient` method that substitutes the equation's solution by the current trial via `ufl.replace`. Term implementations call `resolve_coefficient` instead of reading the attribute directly, so a single residual term can serve both linear and nonlinear coefficients (the substitution is a no-op when the expression does not contain the solution).

`scalar_equation.diffusion_term` is migrated to use the new mechanism. Existing callers that pass a solution-independent diffusivity see no behavioural change. New callers (e.g. Richards' `K(h)` in the follow-up PR) can declare the coefficient as a UFL expression in the equation's `solution` and list its attribute name in `nonlinear_coefficients`. The `Equation` constructor validates that the named attribute is a UFL expression actually containing `solution`, catching the common foot-gun of building the coefficient against a different `Function`.

About 70 lines across two files.
