### PR TITLE
Add Richards equation and core solver

### DIFF
--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -23,6 +23,11 @@ from .level_set_tools import (
 from .limiter import VertexBasedP1DGLimiter
 from .nullspaces import create_stokes_nullspace, rigid_body_modes
 from .preconditioners import FreeSurfaceMassInvPC, SPDAssembledPC
+from .richards_solver import (
+    RichardsSolver,
+    direct_richards_solver_parameters,
+    iterative_richards_solver_parameters,
+)
 from .soil_curves import (
     SoilCurve,
     HaverkampCurve,

--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -23,11 +23,7 @@ from .level_set_tools import (
 from .limiter import VertexBasedP1DGLimiter
 from .nullspaces import create_stokes_nullspace, rigid_body_modes
 from .preconditioners import FreeSurfaceMassInvPC, SPDAssembledPC
-from .richards_solver import (
-    RichardsSolver,
-    direct_richards_solver_parameters,
-    iterative_richards_solver_parameters,
-)
+from .richards_solver import RichardsSolver
 from .soil_curves import (
     SoilCurve,
     HaverkampCurve,

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -1,0 +1,157 @@
+r"""Richards equation terms for unsaturated flow.
+
+This module implements the individual terms for the Richards equation for
+variational unsaturated flow. The Richards equation describes movement of
+the wetting phase in a two-phase flow system, if we ignore the
+compressibility of the dry phase.
+
+All terms are considered as if they were on the left-hand side of the equation,
+leading to the following UFL expression returned by the ``Equation``'s
+``residual`` method:
+
+$$
+  \frac{\partial \theta}{\partial t} + F(h) = 0.
+$$
+
+The Richards equation in mixed form:
+
+$$
+  \frac{\partial \theta}{\partial t} + S_s S \frac{\partial h}{\partial t}
+  - \nabla \cdot (K \nabla h) - \nabla \cdot (K \nabla z) = 0
+$$
+
+where:
+- $h$ is the pressure head
+- $S_s$ is the specific storage coefficient
+- $S(h) = (\theta - \theta_r)/(\theta_s - \theta_r)$ is the effective saturation
+- $C(h) = d\theta/dh$ is the specific moisture capacity
+- $K(h)$ is the hydraulic conductivity
+- $z$ is the vertical coordinate (gravity term)
+
+"""
+
+from firedrake import *
+from irksome import Dt
+from ufl.indexed import Indexed
+
+from .equations import Equation
+from .utility import is_continuous
+
+__all__ = [
+    "richards_mass_term",
+    "richards_gravity_term",
+]
+
+
+def richards_mass_term(
+    eq: Equation, trial: Argument | Indexed | Function
+) -> Form:
+    r"""Richards equation mass term for moisture storage.
+
+    The mass term accounts for water storage changes and has two parts:
+
+    $$
+    \frac{\partial \theta}{\partial t} + S_s S \frac{\partial h}{\partial t}
+    $$
+
+    The moisture content change d(theta)/dt is expressed as Dt(theta(h)).
+    When used with a StageValueTimeStepper, this is automatically discretised
+    as a conservative finite difference (theta(h_new) - theta(h_old))/dt
+    rather than the chain-rule expansion C(h)*dh/dt, preserving exact mass
+    conservation for DG discretisations.
+
+    The specific storage term Ss*S*dh/dt uses Dt(h) since it is already
+    formulated directly in terms of h.
+
+    Args:
+        eq: G-ADOPT Equation instance
+        trial: Firedrake trial function for pressure head
+
+    Returns:
+        UFL form for the mass term
+    """
+    soil_curve = eq.soil_curve
+
+    # Moisture content change: d(theta)/dt
+    F = inner(eq.test, Dt(soil_curve.moisture_content(trial))) * eq.dx
+
+    # Specific storage: Ss * S * dh/dt (standard Dt, linear in h for given S).
+    # Only include when Ss is nonzero to avoid polluting the form with a
+    # zero-coefficient TimeDerivative that can confuse the nonlinear solver.
+    if float(soil_curve.Ss) != 0.0:
+        theta = soil_curve.moisture_content(trial)
+        S = (theta - soil_curve.theta_r) / (soil_curve.theta_s - soil_curve.theta_r)
+        F += inner(eq.test, soil_curve.Ss * S * Dt(trial)) * eq.dx
+
+    return F
+
+
+def richards_gravity_term(
+    eq: Equation, trial: Argument | Indexed | Function
+) -> Form:
+    r"""Richards gravity term for gravity-driven flow with upwinding.
+
+    The gravity term represents gravity-driven water flow:
+
+    $$
+    \\nabla \\cdot (K \\nabla z) = \\frac{\\partial K}{\\partial z}
+    $$
+
+    where $z$ is the vertical coordinate. For DG discretizations, we use upwinding
+    on interior facets to ensure stability.
+
+    The weak form is:
+
+    $$
+    \\int_\\Omega K \\frac{\\partial \\phi}{\\partial z} dx
+    - \\int_{\\mathcal{I}} \\text{jump}(\\phi) \\cdot (q_n^+ - q_n^-) dS
+    $$
+
+    where $q_n = 0.5(q \\cdot n + |q \\cdot n|)$ is the upwinded flux and
+    $q = K \\nabla z$ is the gravity-driven flux.
+
+    Args:
+        eq: G-ADOPT Equation instance
+        trial: Firedrake trial function for pressure head
+
+    Returns:
+        UFL form for the gravity term
+    """
+    soil_curve = eq.soil_curve
+
+    # Evaluate hydraulic conductivity at trial function
+    K = soil_curve.hydraulic_conductivity(trial)
+
+    # Get mesh dimension and spatial coordinates
+    dim = eq.mesh.geometric_dimension
+    x = SpatialCoordinate(eq.mesh)
+
+    # Gradient in vertical direction (last coordinate)
+    # grad(z) = e_z, where e_z is the unit vector in z-direction
+    n_down = grad(x[dim - 1])
+
+    # Volume integral: \int K * \partial v/\partial z dx = \int K * \grad z \cdot \grad v dx
+    F = inner(K * n_down, grad(eq.test)) * eq.dx
+
+    # Upwinding on interior facets for DG
+    if not is_continuous(eq.trial_space):
+        # Gravity-driven flux
+        q = K * n_down
+
+        # Upwinded flux: take the value from the upwind side
+        # q\cdot n > 0 means flow from '-' to '+', so use '-' side (upwind)
+        # q\cdot n < 0 means flow from '+' to '-', so use '+' side (upwind)
+        q_n = 0.5 * (dot(q, eq.n) + abs(dot(q, eq.n)))
+
+        # Add upwind flux term
+        F -= jump(eq.test) * (q_n('+') - q_n('-')) * eq.dS
+
+    return F
+
+
+# Set required and optional attributes for each term
+richards_mass_term.required_attrs = {'soil_curve'}
+richards_mass_term.optional_attrs = set()
+
+richards_gravity_term.required_attrs = {'soil_curve'}
+richards_gravity_term.optional_attrs = set()

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -28,19 +28,43 @@ where:
 - $K(h)$ is the hydraulic conductivity
 - $z$ is the vertical coordinate (gravity term)
 
+The discretisation deliberately carries the mass term as the conservative
+$\partial \theta / \partial t$ form rather than expanding it via the chain rule
+into $C(h)\,\partial h/\partial t$. With the stage-value stepper this yields the
+exact finite difference $(\theta_{new} - \theta_{old})/\Delta t$, which keeps mass
+balance exact for DG. As a consequence $C(h) = d\theta/dh$ is the physical moisture
+capacity listed above but never appears explicitly in the residual.
+
 """
+
+import numbers
 
 from firedrake import *
 from irksome import Dt
 from ufl.indexed import Indexed
 
 from .equations import Equation
-from .utility import is_continuous
+from .utility import is_continuous, upward_normal
 
 __all__ = [
     "richards_mass_term",
     "richards_gravity_term",
 ]
+
+
+def _is_scalar_zero(value) -> bool:
+    """Return True only when ``value`` is provably the scalar zero.
+
+    A plain Python number or a scalar ``Constant`` can be safely evaluated to a
+    float and compared against zero. Anything else (most importantly a ``Function``
+    or ``Function(R)``, which must never be float()'d) is treated as non-zero so
+    that a spatially varying coefficient or an inversion control is never dropped.
+    """
+    if isinstance(value, numbers.Real):
+        return float(value) == 0.0
+    if isinstance(value, Constant):
+        return float(value) == 0.0
+    return False
 
 
 def richards_mass_term(
@@ -76,9 +100,13 @@ def richards_mass_term(
     F = inner(eq.test, Dt(soil_curve.moisture_content(trial))) * eq.dx
 
     # Specific storage: Ss * S * dh/dt (standard Dt, linear in h for given S).
-    # Only include when Ss is nonzero to avoid polluting the form with a
-    # zero-coefficient TimeDerivative that can confuse the nonlinear solver.
-    if float(soil_curve.Ss) != 0.0:
+    # We skip this term when Ss is identically zero, to avoid polluting the form
+    # with a zero-coefficient TimeDerivative that can confuse the nonlinear solver.
+    # That skip is only safe for values we can provably evaluate to the scalar
+    # zero: a plain Python number or a scalar Constant. A Function or Function(R)
+    # (e.g. a spatially varying storage, or an inversion control) must never be
+    # float()'d, so we always include the term for those and never silently drop it.
+    if not _is_scalar_zero(soil_curve.Ss):
         theta = soil_curve.moisture_content(trial)
         S = (theta - soil_curve.theta_r) / (soil_curve.theta_s - soil_curve.theta_r)
         F += inner(eq.test, soil_curve.Ss * S * Dt(trial)) * eq.dx
@@ -91,24 +119,27 @@ def richards_gravity_term(
 ) -> Form:
     r"""Richards gravity term for gravity-driven flow with upwinding.
 
-    The gravity term represents gravity-driven water flow:
+    The gravity term represents the gravity-driven water flux:
 
     $$
-    \\nabla \\cdot (K \\nabla z) = \\frac{\\partial K}{\\partial z}
+    \nabla \cdot (K \nabla z)
     $$
 
-    where $z$ is the vertical coordinate. For DG discretizations, we use upwinding
+    where $z$ is the elevation (upward coordinate); $\nabla z$ is supplied by
+    ``upward_normal``, so the term is correct both in a Cartesian box and on the
+    sphere. (In a Cartesian box with $z$ the vertical coordinate this reduces to
+    the familiar $\partial K/\partial z$.) For DG discretizations, we use upwinding
     on interior facets to ensure stability.
 
     The weak form is:
 
     $$
-    \\int_\\Omega K \\frac{\\partial \\phi}{\\partial z} dx
-    - \\int_{\\mathcal{I}} \\text{jump}(\\phi) \\cdot (q_n^+ - q_n^-) dS
+    \int_\Omega K \frac{\partial \phi}{\partial z} dx
+    - \int_{\mathcal{I}} \text{jump}(\phi) \cdot (q_n^+ - q_n^-) dS
     $$
 
-    where $q_n = 0.5(q \\cdot n + |q \\cdot n|)$ is the upwinded flux and
-    $q = K \\nabla z$ is the gravity-driven flux.
+    where $q_n = 0.5(q \cdot n + |q \cdot n|)$ is the upwinded flux and
+    $q = K \nabla z$ is the gravity-driven flux.
 
     Args:
         eq: G-ADOPT Equation instance
@@ -122,25 +153,24 @@ def richards_gravity_term(
     # Evaluate hydraulic conductivity at trial function
     K = soil_curve.hydraulic_conductivity(trial)
 
-    # Get mesh dimension and spatial coordinates
-    dim = eq.mesh.geometric_dimension
-    x = SpatialCoordinate(eq.mesh)
-
-    # Gradient in vertical direction (last coordinate)
-    # grad(z) = e_z, where e_z is the unit vector in z-direction
-    n_down = grad(x[dim - 1])
+    # Upward unit vector grad(z) = e_z; upward_normal gives the last Cartesian
+    # basis vector in a box and X/r on the sphere, so this also works on a sphere.
+    k = upward_normal(eq.mesh)
 
     # Volume integral: \int K * \partial v/\partial z dx = \int K * \grad z \cdot \grad v dx
-    F = inner(K * n_down, grad(eq.test)) * eq.dx
+    F = inner(K * k, grad(eq.test)) * eq.dx
 
     # Upwinding on interior facets for DG
     if not is_continuous(eq.trial_space):
         # Gravity-driven flux
-        q = K * n_down
+        q = K * k
 
-        # Upwinded flux: take the value from the upwind side
-        # q\cdot n > 0 means flow from '-' to '+', so use '-' side (upwind)
-        # q\cdot n < 0 means flow from '+' to '-', so use '+' side (upwind)
+        # n has no fixed direction: n('+') and n('-') each point outward from
+        # their own cell. So q.n > 0 on a given side means q exits there, i.e.
+        # that side is the upwind side, and only one of q_n('+'), q_n('-') is
+        # nonzero. The minus sign on jump(eq.test) below is needed because jump
+        # gives test_+ - test_-, whereas we want test_up - test_down; when '-'
+        # is the upwind side that extra minus sign corrects the orientation.
         q_n = 0.5 * (dot(q, eq.n) + abs(dot(q, eq.n)))
 
         # Add upwind flux term

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -136,12 +136,24 @@ def richards_gravity_term(
     $$
     \int_\Omega K \frac{\partial \phi}{\partial z} dx
     - \int_{\mathcal{I}} \text{jump}(\phi) \cdot (q_n^+ - q_n^-) dS
+    - \int_{\partial \Omega_D} \phi \, K \, \nabla z \cdot n \, ds
     $$
 
     where $q_n = 0.5(q \cdot n - |q \cdot n|)$ is the upwinded flux and
     $q = K \nabla z$ is the gravity-driven flux. The negative part selects the
     upstream trace of $K$ from the cell *above* the facet: gravity-driven
     information propagates downward, so the upwind side is the upper cell.
+
+    The last integral runs over boundaries carrying a weakly imposed Dirichlet
+    head. There, the total flux is $K \nabla(h + z)$, but the Nitsche
+    consistency term supplied by ``scalar_equation.diffusion_term`` is built
+    from $h$ alone, so its gravity half has to be contributed here. Without it
+    the scheme is inconsistent on those boundaries: the residual retains a
+    spurious $\int_{\partial \Omega_D} \phi \, K \, \nabla z \cdot n \, ds$,
+    which is precisely the free-drainage flux that should be crossing them.
+    Flux boundaries and unspecified boundaries need no such term — for those,
+    carrying no gravity boundary integral is exactly the right natural
+    condition — so this is applied only on the Dirichlet path.
 
     Args:
         eq: G-ADOPT Equation instance
@@ -182,6 +194,21 @@ def richards_gravity_term(
 
         # Add upwind flux term
         F -= jump(eq.test) * (q_n('+') - q_n('-')) * eq.dS
+
+    # Gravity half of the flux on weakly imposed Dirichlet head boundaries.
+    # `scalar_equation.diffusion_term` keys those off 'q' (RichardsSolver
+    # translates the user-facing 'h' in `set_boundary_conditions`), and its
+    # consistency term carries K grad(h).n only, so the K grad(z).n part is
+    # added here to complete the total flux. K is taken from the interior
+    # trace, which makes the pair a single Nitsche treatment of the potential
+    # h + z, and is identical to what setting `reference_for_diffusion = z`
+    # on the diffusion term would produce. Deliberately outside the DG branch
+    # above: it applies wherever a weak Dirichlet head exists, though in
+    # practice RichardsSolver only generates those for discontinuous spaces
+    # (continuous ones get a strong DirichletBC instead).
+    for bc_id, bc in eq.bcs.items():
+        if 'q' in bc:
+            F -= eq.test * K * dot(k, eq.n) * eq.ds(bc_id)
 
     return F
 

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -138,8 +138,10 @@ def richards_gravity_term(
     - \int_{\mathcal{I}} \text{jump}(\phi) \cdot (q_n^+ - q_n^-) dS
     $$
 
-    where $q_n = 0.5(q \cdot n + |q \cdot n|)$ is the upwinded flux and
-    $q = K \nabla z$ is the gravity-driven flux.
+    where $q_n = 0.5(q \cdot n - |q \cdot n|)$ is the upwinded flux and
+    $q = K \nabla z$ is the gravity-driven flux. The negative part selects the
+    upstream trace of $K$ from the cell *above* the facet: gravity-driven
+    information propagates downward, so the upwind side is the upper cell.
 
     Args:
         eq: G-ADOPT Equation instance
@@ -165,13 +167,18 @@ def richards_gravity_term(
         # Gravity-driven flux
         q = K * k
 
-        # n has no fixed direction: n('+') and n('-') each point outward from
-        # their own cell. So q.n > 0 on a given side means q exits there, i.e.
-        # that side is the upwind side, and only one of q_n('+'), q_n('-') is
-        # nonzero. The minus sign on jump(eq.test) below is needed because jump
-        # gives test_+ - test_-, whereas we want test_up - test_down; when '-'
-        # is the upwind side that extra minus sign corrects the orientation.
-        q_n = 0.5 * (dot(q, eq.n) + abs(dot(q, eq.n)))
+        # Gravity drives drainage downward. Writing the elevation-head part as a
+        # conservation law d(theta)/dt + d_z(Phi) = 0 with flux Phi = -K, the
+        # characteristic speed is dPhi/dtheta = -K'(theta) < 0 (K increases with
+        # theta), so information propagates downward and the upstream (upwind)
+        # side of a facet is the cell ABOVE it. We therefore take the NEGATIVE
+        # part of q.n, which selects the upper trace of K (verified for both
+        # facet orientations): with n('+') and n('-') each pointing outward from
+        # their own cell, only the side whose outward normal points downward
+        # contributes, and that is the upper cell. The minus sign on
+        # jump(eq.test) below accounts for jump giving test('+') - test('-'),
+        # whereas we want test_up - test_down.
+        q_n = 0.5 * (dot(q, eq.n) - abs(dot(q, eq.n)))
 
         # Add upwind flux term
         F -= jump(eq.test) * (q_n('+') - q_n('-')) * eq.dS

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -37,8 +37,6 @@ capacity listed above but never appears explicitly in the residual.
 
 """
 
-import numbers
-
 from firedrake import *
 from irksome import Dt
 from ufl.indexed import Indexed
@@ -50,21 +48,6 @@ __all__ = [
     "richards_mass_term",
     "richards_gravity_term",
 ]
-
-
-def _is_scalar_zero(value) -> bool:
-    """Return True only when ``value`` is provably the scalar zero.
-
-    A plain Python number or a scalar ``Constant`` can be safely evaluated to a
-    float and compared against zero. Anything else (most importantly a ``Function``
-    or ``Function(R)``, which must never be float()'d) is treated as non-zero so
-    that a spatially varying coefficient or an inversion control is never dropped.
-    """
-    if isinstance(value, numbers.Real):
-        return float(value) == 0.0
-    if isinstance(value, Constant):
-        return float(value) == 0.0
-    return False
 
 
 def richards_mass_term(
@@ -102,14 +85,14 @@ def richards_mass_term(
     # Specific storage: Ss * S * dh/dt (standard Dt, linear in h for given S).
     # We skip this term when Ss is identically zero, to avoid polluting the form
     # with a zero-coefficient TimeDerivative that can confuse the nonlinear solver.
-    # That skip is only safe for values we can provably evaluate to the scalar
-    # zero: a plain Python number or a scalar Constant. A Function or Function(R)
-    # (e.g. a spatially varying storage, or an inversion control) must never be
-    # float()'d, so we always include the term for those and never silently drop it.
-    if not _is_scalar_zero(soil_curve.Ss):
+    # SoilCurve always wraps Ss, so it is either a Constant we can evaluate, or a
+    # Function (a spatially varying storage, or an inversion control) that must
+    # never be float()'d and so always keeps the term.
+    Ss = soil_curve.Ss
+    if not (isinstance(Ss, Constant) and float(Ss) == 0.0):
         theta = soil_curve.moisture_content(trial)
         S = (theta - soil_curve.theta_r) / (soil_curve.theta_s - soil_curve.theta_r)
-        F += inner(eq.test, soil_curve.Ss * S * Dt(trial)) * eq.dx
+        F += inner(eq.test, Ss * S * Dt(trial)) * eq.dx
 
     return F
 

--- a/gadopt/richards_equation.py
+++ b/gadopt/richards_equation.py
@@ -184,8 +184,13 @@ def richards_gravity_term(
     # consistency term carries K grad(h).n only, so the K grad(z).n part is
     # added here to complete the total flux. K is taken from the interior
     # trace, which makes the pair a single Nitsche treatment of the potential
-    # h + z, and is identical to what setting `reference_for_diffusion = z`
-    # on the diffusion term would produce. Deliberately outside the DG branch
+    # h + z: the symmetry and penalty terms need no change, because
+    # (h + z) - (h_D + z) = h - h_D. For this boundary consistency term alone
+    # it matches what `reference_for_diffusion = z` would produce; setting that
+    # attribute globally is not equivalent, since it would also add
+    # K grad(z).grad(phi) to the volume integral, duplicating the term above,
+    # and would replace the upwinded interior-facet gravity flux with a centred
+    # average. Deliberately outside the DG branch
     # above: it applies wherever a weak Dirichlet head exists, though in
     # practice RichardsSolver only generates those for discontinuous spaces
     # (continuous ones get a strong DirichletBC instead).

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -1,0 +1,462 @@
+"""Solver class for the Richards equation governing variably saturated flow.
+
+This module provides the `RichardsSolver` class for solving the Richards equation,
+which describes movement of fluid phase in a two-phase flow system, if we ignore the
+compressibility of the dry phase. The solver uses time integrators and together with
+soil curve models for hydraulic properties.
+
+Typical usage:
+    >>> from gadopt import *
+    >>> # Define soil curve
+    >>> soil_params = {
+    ...     'theta_r': 0.102, 'theta_s': 0.368,
+    ...     'alpha': 0.0335, 'n': 2.0,
+    ...     'Ks': 0.00922, 'Ss': 1e-5
+    ... }
+    >>> soil_curve = VanGenuchtenCurve(soil_params)
+    >>> # Setup solver
+    >>> richards_solver = RichardsSolver(
+    ...     h, soil_curve, delta_t, DIRK22,
+    ...     bcs={1: {'h': 0.0}, 2: {'flux': -0.01}}
+    ... )
+    >>> # Time loop
+    >>> richards_solver.solve()
+"""
+
+from collections.abc import Mapping
+from numbers import Number
+from typing import Any
+from warnings import warn
+
+from firedrake import *
+
+from . import richards_equation as richards_eq
+from . import scalar_equation as scalar_eq
+from .equations import Equation, cell_edge_integral_ratio
+from .solver_options_manager import SolverConfigurationMixin, ConfigType
+from .soil_curves import SoilCurve
+from .time_stepper import IrksomeIntegrator
+from .utility import DEBUG, INFO, is_continuous, log_level
+
+__all__ = [
+    "RichardsSolver",
+    "direct_richards_solver_parameters",
+    "iterative_richards_solver_parameters",
+]
+
+
+_newton_common: dict[str, Any] = {
+    "snes_type": "newtonls",
+    "snes_linesearch_type": "bt",
+    "snes_rtol": 1e-8,
+    "snes_atol": 1e-8,
+    "snes_max_it": 50,
+}
+
+
+direct_richards_solver_parameters: dict[str, Any] = {
+    "mat_type": "aij",
+    "snes_type": "newtonls",
+    "snes_linesearch_type": "bt",
+    "ksp_type": "preonly",
+    "pc_type": "lu",
+    "pc_factor_mat_solver_type": "mumps",
+    "snes_atol": 1e-15,
+}
+"""Direct solver preset: LU factorisation via MUMPS.
+
+G-ADOPT uses this preset by default in 2-D.
+"""
+
+
+iterative_richards_solver_parameters: dict[str, Any] = {
+    "mat_type": "aij",
+    "ksp_type": "gmres",
+    "snes_linesearch_type": "bt",
+    "ksp_rtol": 1e-5,
+    "ksp_max_it": 200,
+    "ksp_gmres_restart": 30,
+
+    # BoomerAMG via Hypre -- strong classical AMG for scalar elliptic
+    # operators. Requires PETSc to be built with --download-hypre (or
+    # equivalent). If Hypre is unavailable, RichardsSolver raises an
+    # informative error before the solve starts.
+    "pc_type": "hypre",
+    "pc_hypre_type": "boomeramg",
+    "pc_hypre_boomeramg_strong_threshold": 0.7,
+    "pc_hypre_boomeramg_agg_nl": 1,
+    "pc_hypre_boomeramg_agg_num_paths": 2,
+    "pc_hypre_boomeramg_coarsen_type": "HMIS",
+    "pc_hypre_boomeramg_interp_type": "ext+i",
+    "pc_hypre_boomeramg_relax_type_all": "symmetric-SOR/Jacobi",
+    **_newton_common,
+}
+"""Iterative solver preset: Newton + GMRES + BoomerAMG (Hypre).
+
+G-ADOPT uses this preset by default in 3-D. Requires PETSc to be built with
+Hypre support; otherwise an informative error is raised at solve time.
+"""
+
+
+class RichardsSolver(SolverConfigurationMixin):
+    """Advances Richards equation in time for variably saturated flow.
+
+    The Richards equation describes water movement in variably saturated porous media:
+
+    $$
+    (S_s S + C) \\frac{\\partial h}{\\partial t} - \\nabla \\cdot (K \\nabla h) - \\nabla \\cdot (K \\nabla z) = 0
+    $$
+
+    where:
+    - $h$ is the pressure head
+    - $S_s$ is the specific storage coefficient (from soil curve)
+    - $S(h)$ is the effective saturation
+    - $C(h) = d\\theta/dh$ is the specific moisture capacity
+    - $K(h)$ is the hydraulic conductivity
+    - $z$ is the vertical coordinate
+
+    **Note**: The solution field is updated in place.
+
+    Args:
+      solution:
+        Firedrake function for pressure head $h$
+      soil_curve:
+        gadopt.SoilCurve instance defining hydraulic properties (from soil_curves module)
+      delta_t:
+        Simulation time step
+      timestepper:
+        Runge-Kutta time integrator for an implicit or explicit numerical scheme
+      bcs:
+        Dictionary specifying boundary conditions (identifier, type, and value)
+      source_term:
+        Volumetric source/sink (positive = water added) in units of $\theta$
+        per second. Either a UFL expression, a Firedrake ``Function``, or a
+        constant. Defaults to ``0``.
+      solver_parameters:
+        Dictionary of solver parameters or a string specifying a default configuration
+        provided to PETSc
+      solver_parameters_extra:
+        Dictionary of PETSc solver options used to update the default G-ADOPT options
+      quad_degree:
+        Integer specifying the quadrature degree. If omitted, it is set to `2p + 1`,
+        where p is the polynomial degree of the trial space. For Richards the soil
+        curves are non-polynomial (`K(h) = K_s exp(alpha h)` for the exponential
+        model, rational/power forms for Haverkamp and van Genuchten), and Newton
+        line search can fail at higher polynomial degrees if the bilinear form is
+        under-integrated. The Tracy benchmark (`tests/richards/tracy_2d.py`) uses
+        `2 * degree + 4` as a safe rule of thumb for the exponential curve;
+        Haverkamp/van Genuchten typically need less. If Newton diverges with
+        DIVERGED_LINE_SEARCH at the start of a run, raise this value.
+      interior_penalty:
+        Safety-factor multiplier for the SIPG penalty in DG discretisations.
+        Default is 2.0; the theoretical coercivity floor is 1.0. Setting it
+        below 1.0 will give a non-coercive bilinear form and Newton may fail.
+      nullspace:
+        ``VectorSpaceBasis`` spanning the nullspace of the Jacobian. Relevant
+        for pure-Neumann problems (all fluxes specified, no Dirichlet on h),
+        where the constant is a true nullspace.
+      transpose_nullspace:
+        Nullspace of the transposed Jacobian. Usually equal to ``nullspace``
+        for Richards because the advective part is small.
+      near_nullspace:
+        Near-nullspace basis passed to the AMG preconditioner. For scalar
+        Richards the near-nullspace is the constants, so if left ``None``
+        on an iterative preset ``RichardsSolver`` auto-builds it.
+      timestepper_kwargs:
+        Dictionary of additional keyword arguments passed to the timestepper constructor.
+        Useful for parameterized schemes (e.g., {'order': 5} for IrksomeRadauIIA).
+
+    ### Valid keys for boundary conditions
+    |  Condition  |  Type  |              Description               |
+    | :---------- | :----- | :------------------------------------: |
+    | h           | Strong | Pressure head (Dirichlet)              |
+    | flux        | Weak   | Total flux (Neumann)                   |
+
+    Examples:
+        >>> # Dirichlet BC: fixed pressure head at top
+        >>> bcs = {'top': {'h': 0.0}}
+        >>> # Neumann BC: prescribed flux at bottom
+        >>> bcs = {'bottom': {'flux': -0.01}}
+        >>> # Mixed BCs
+        >>> bcs = {'top': {'h': 0.0}, 'bottom': {'flux': -0.01}}
+    """
+
+    name = "Richards"
+
+    def __init__(
+        self,
+        solution: Function,
+        soil_curve: SoilCurve,
+        /,
+        delta_t: Constant,
+        timestepper: type[IrksomeIntegrator],
+        *,
+        bcs: dict[int | str, dict[str, Number]] = {},
+        source_term: Any = 0,
+        solver_parameters: ConfigType | str | None = None,
+        solver_parameters_extra: ConfigType | None = None,
+        quad_degree: int | None = None,
+        interior_penalty: float | None = None,
+        nullspace: "VectorSpaceBasis | None" = None,
+        transpose_nullspace: "VectorSpaceBasis | None" = None,
+        near_nullspace: "VectorSpaceBasis | None" = None,
+        timestepper_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        self.solution = solution
+        self.soil_curve = soil_curve
+        self.delta_t = delta_t
+        self.timestepper = timestepper
+        self.bcs = bcs
+        self.source_term = source_term
+        self.quad_degree = quad_degree
+        self.interior_penalty = interior_penalty
+        self.nullspace = nullspace
+        self.transpose_nullspace = transpose_nullspace
+        self.near_nullspace = near_nullspace
+        self.timestepper_kwargs = timestepper_kwargs or {}
+        self._preset_name: str | None = None
+
+        # Default to stage_type="value" for mass-conservative time discretisation.
+        # The stage value stepper discretises Dt(theta(h)) as the exact finite
+        # difference (theta(h_new) - theta(h_old))/dt rather than applying the
+        # chain rule C(h)*dh/dt, which introduces systematic mass balance error.
+        # Conservation now holds for both stiffly-accurate tableaux (where the
+        # update u_new = U_s copies the per-stage finite difference directly)
+        # and non-stiffly-accurate ones (where Irksome routes through a
+        # conservative variational update; requires Irksome PR #226 or later).
+        if 'stage_type' not in self.timestepper_kwargs:
+            self.timestepper_kwargs['stage_type'] = 'value'
+        elif self.timestepper_kwargs.get('stage_type', None) != 'value':
+            warn(
+                "RichardsSolver is not using stage_type='value'. Mass will not "
+                "be conserved exactly. The nonlinear mass term Dt(theta(h)) will "
+                "be discretised via the chain rule C(h)*dh/dt, which introduces "
+                "systematic mass balance error that accumulates over time. To "
+                "enable mass conservation, use stage_type='value' with any "
+                "Butcher tableau (Irksome's conservative-update path handles "
+                "both stiffly-accurate and non-stiffly-accurate methods).",
+                stacklevel=2,
+            )
+
+        self.solution_space = solution.function_space()
+        self.mesh = self.solution_space.mesh()
+        self.test = TestFunction(self.solution_space)
+
+        self.continuous_solution = is_continuous(self.solution)
+
+        self.set_boundary_conditions()
+        self.set_equation()
+        self.set_solver_options(solver_parameters, solver_parameters_extra)
+        self.setup_solver()
+
+    def set_boundary_conditions(self) -> None:
+        """Sets up strong and weak boundary conditions."""
+        self.strong_bcs = []
+        self.weak_bcs = {}
+
+        for bc_id, bc in self.bcs.items():
+            weak_bc = {}
+
+            for bc_type, value in bc.items():
+                if bc_type == 'h':
+                    # Pressure head BC
+                    if self.continuous_solution:
+                        # Strong Dirichlet for CG
+                        strong_bc = DirichletBC(self.solution_space, value, bc_id)
+                        self.strong_bcs.append(strong_bc)
+                    else:
+                        # Weak Dirichlet for DG. scalar_equation.diffusion_term
+                        # expects the Dirichlet value under key 'q'; the public
+                        # Richards BC vocabulary stays 'h' (pressure head).
+                        weak_bc['q'] = value
+                elif bc_type == 'flux':
+                    # Flux BC (always weak)
+                    weak_bc['flux'] = value
+                else:
+                    raise ValueError(
+                        f"Unknown boundary condition type: {bc_type}. "
+                        f"Valid types are 'h' (pressure head) and 'flux'."
+                    )
+
+            if weak_bc:
+                self.weak_bcs[bc_id] = weak_bc
+
+    def set_equation(self) -> None:
+        """Sets up the Richards equation with all terms."""
+        # K(h) is built against `self.solution`; Irksome's `TimeStepper`
+        # substitutes `solution` for the stage unknowns across the whole
+        # residual, so we don't need a per-coefficient replace mechanism.
+        eq_attrs = {
+            'soil_curve': self.soil_curve,
+            'diffusivity': self.soil_curve.hydraulic_conductivity(self.solution),
+            'source': self.source_term,
+        }
+
+        # scalar_equation.diffusion_term uses interior_penalty_factor(eq, shift=-1),
+        # i.e. the Shahbazi / Epshteyn-Rivière sharp bound with C(p-1). Richards
+        # is assembled against the looser Hillewaert form (C(p)) to match the
+        # momentum equation and the pre-refactor bespoke Richards term; the
+        # extra margin over the Shahbazi floor is useful in practice because
+        # K(h) can vary by orders of magnitude across the wetting front, even
+        # though Hillewaert's coercivity proof itself assumes bounded
+        # diffusivity. Absorb the C(p)/C(p-1) ratio into the safety factor so
+        # the assembled penalty matches the Hillewaert convention; the
+        # user-facing `interior_penalty` stays a bare safety factor.
+        #
+        # Flipping scalar_equation to shift=0 would let us delete this block,
+        # but would force regenerating stored reference data on every DG scalar
+        # diffusion test (viscoplastic_case_DG, multi_material,
+        # 2d_cylindrical_TALA_DG, adjoint_2d_cylindrical, and the adjoint
+        # mantle-convection demos).
+        alpha = self.interior_penalty if self.interior_penalty is not None else 2.0
+        degree = self.solution_space.ufl_element().degree()
+        if not isinstance(degree, int):
+            degree = max(degree)
+        if degree >= 1:
+            ratio = (cell_edge_integral_ratio(self.mesh, degree)
+                     / cell_edge_integral_ratio(self.mesh, degree - 1))
+            eq_attrs['interior_penalty'] = alpha * ratio
+        else:
+            # degree == 0: interior_penalty_factor short-circuits to sigma=1.0
+            # and ignores alpha entirely; pass alpha through unchanged.
+            eq_attrs['interior_penalty'] = alpha
+
+        self.equation = Equation(
+            self.test,
+            self.solution_space,
+            residual_terms=[
+                richards_eq.richards_mass_term,
+                scalar_eq.diffusion_term,
+                scalar_eq.source_term,
+                richards_eq.richards_gravity_term,
+            ],
+            eq_attrs=eq_attrs,
+            bcs=self.weak_bcs,
+            quad_degree=self.quad_degree,
+        )
+
+    _PRESETS: dict[str, dict[str, Any]] = {
+        "direct": direct_richards_solver_parameters,
+        "iterative": iterative_richards_solver_parameters,
+    }
+
+    def set_solver_options(
+        self,
+        solver_preset: ConfigType | str | None,
+        solver_extras: ConfigType | None = None,
+    ) -> None:
+        """Sets PETSc solver parameters."""
+        if isinstance(solver_preset, Mapping):
+            self._preset_name = None
+            self.add_to_solver_config(solver_preset)
+            self.add_to_solver_config(solver_extras)
+            self.register_update_callback(self.setup_solver)
+            return
+
+        if solver_preset is None:
+            solver_preset = self._auto_select_preset()
+
+        if solver_preset not in self._PRESETS:
+            valid = "', '".join(self._PRESETS)
+            raise ValueError(
+                f"Unknown solver_parameters preset '{solver_preset}'. "
+                f"Valid options: '{valid}'."
+            )
+
+        self._preset_name = solver_preset
+        self._validate_preset(solver_preset)
+        self.add_to_solver_config(self._PRESETS[solver_preset])
+
+        if DEBUG >= log_level:
+            self.add_to_solver_config({"ksp_monitor": None, "snes_monitor": None})
+        elif INFO >= log_level:
+            self.add_to_solver_config({"ksp_converged_reason": None, "snes_converged_reason": None})
+
+        self.add_to_solver_config(solver_extras)
+        self.register_update_callback(self.setup_solver)
+
+    def _auto_select_preset(self) -> str:
+        """Pick a default preset based on mesh type.
+
+        * 2-D: ``"direct"`` (MUMPS LU).
+        * 3-D: ``"iterative"`` (BoomerAMG).
+        """
+        if self.mesh.topological_dimension == 2:
+            return "direct"
+        return "iterative"
+
+    def _validate_preset(self, name: str) -> None:
+        """Fail fast for presets whose structural prerequisites aren't met."""
+        if name == "iterative":
+            # BoomerAMG needs PETSc built with Hypre.
+            from firedrake.petsc import PETSc as _PETSc
+            if not _PETSc.Sys.hasExternalPackage("hypre"):
+                raise RuntimeError(
+                    "solver_parameters='iterative' requires PETSc to be "
+                    "built with Hypre (BoomerAMG). This PETSc build does "
+                    "not include Hypre. Rebuild PETSc with --download-hypre "
+                    "or choose a different preset (e.g. 'direct')."
+                )
+
+    def setup_near_nullspace(self) -> "VectorSpaceBasis":
+        """Build the constant near-nullspace for AMG.
+
+        For scalar Richards the near-nullspace is the constants -- the
+        single mode the diffusion operator nearly annihilates. Providing
+        it to BoomerAMG / vlumping's coarse AMG ensures the prolongation
+        preserves constants, which is critical for optimal AMG convergence.
+        """
+        ones = Function(self.solution_space).assign(1.0)
+        basis = VectorSpaceBasis([ones])
+        basis.orthonormalize()
+        return basis
+
+    def setup_solver(self) -> None:
+        """Sets up the timestepper using specified parameters."""
+        # Auto-build the constant near-nullspace on iterative presets if
+        # the user hasn't supplied one. The constant is the only non-
+        # trivial near-nullspace mode for scalar Richards, so there is no
+        # ambiguity in the default.
+        if self.near_nullspace is None and self._preset_name == "iterative":
+            self.near_nullspace = self.setup_near_nullspace()
+
+        if self.nullspace is not None:
+            self.timestepper_kwargs.setdefault('nullspace', self.nullspace)
+        if self.transpose_nullspace is not None:
+            self.timestepper_kwargs.setdefault('transpose_nullspace', self.transpose_nullspace)
+        if self.near_nullspace is not None:
+            self.timestepper_kwargs.setdefault('near_nullspace', self.near_nullspace)
+
+        # Reuse stage solver parameters for the conservative update solve.
+        if self.timestepper_kwargs.get('stage_type') == 'value':
+            self.timestepper_kwargs.setdefault(
+                'update_solver_parameters', self.solver_parameters,
+            )
+
+        self.ts = self.timestepper(
+            self.equation,
+            self.solution,
+            self.delta_t,
+            solver_parameters=self.solver_parameters,
+            strong_bcs=self.strong_bcs,
+            **self.timestepper_kwargs,
+        )
+
+    @property
+    def solver(self):
+        """Underlying Firedrake NonlinearVariationalSolver.
+
+        Convenience accessor that reaches through the Irksome stepper to
+        the SNES/KSP plumbing, used by tests and diagnostics that need
+        to inspect the preconditioner tree after a solve.
+        """
+        return self.ts.stepper.solver
+
+    def solve(self, t: float | None = None) -> None:
+        """Advances solver in time.
+
+        Args:
+          t:
+            Current simulation time (optional)
+        """
+        return self.ts.advance(t)

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -2,7 +2,7 @@
 
 This module provides the `RichardsSolver` class for solving the Richards equation,
 which describes movement of fluid phase in a two-phase flow system, if we ignore the
-compressibility of the dry phase. The solver uses time integrators and together with
+compressibility of the dry phase. The solver uses time integrators together with
 soil curve models for hydraulic properties.
 
 Typical usage:
@@ -49,19 +49,18 @@ _newton_common: dict[str, Any] = {
     "snes_type": "newtonls",
     "snes_linesearch_type": "bt",
     "snes_rtol": 1e-8,
-    "snes_atol": 1e-8,
+    "snes_atol": 1e-12,
+    "snes_stol": 1e-8,
     "snes_max_it": 50,
 }
 
 
 direct_richards_solver_parameters: dict[str, Any] = {
     "mat_type": "aij",
-    "snes_type": "newtonls",
-    "snes_linesearch_type": "bt",
     "ksp_type": "preonly",
     "pc_type": "lu",
     "pc_factor_mat_solver_type": "mumps",
-    "snes_atol": 1e-15,
+    **_newton_common,
 }
 """Direct solver preset: LU factorisation via MUMPS.
 
@@ -77,10 +76,13 @@ iterative_richards_solver_parameters: dict[str, Any] = {
     "ksp_max_it": 200,
     "ksp_gmres_restart": 30,
 
-    # BoomerAMG via Hypre -- strong classical AMG for scalar elliptic
-    # operators. Requires PETSc to be built with --download-hypre (or
-    # equivalent). If Hypre is unavailable, RichardsSolver raises an
-    # informative error before the solve starts.
+    # BoomerAMG via Hypre. Richards is degenerate parabolic rather than
+    # elliptic (transient; K(h) can collapse toward zero in dry regions
+    # and the mass coefficient C(h) = dtheta/dh flattens near saturation),
+    # but each Newton step solves a diffusion-dominated linearised Jacobian
+    # that classical AMG preconditions well. Requires PETSc built with
+    # --download-hypre (or equivalent); if Hypre is unavailable,
+    # RichardsSolver raises an informative error before the solve starts.
     "pc_type": "hypre",
     "pc_hypre_type": "boomeramg",
     "pc_hypre_boomeramg_strong_threshold": 0.7,
@@ -99,21 +101,28 @@ Hypre support; otherwise an informative error is raised at solve time.
 
 
 class RichardsSolver(SolverConfigurationMixin):
-    """Advances Richards equation in time for variably saturated flow.
+    r"""Advances Richards equation in time for variably saturated flow.
 
     The Richards equation describes water movement in variably saturated porous media:
 
     $$
-    (S_s S + C) \\frac{\\partial h}{\\partial t} - \\nabla \\cdot (K \\nabla h) - \\nabla \\cdot (K \\nabla z) = 0
+    (S_s S + C) \frac{\partial h}{\partial t} - \nabla \cdot (K \nabla h) - \nabla \cdot (K \nabla z) = 0
     $$
 
     where:
     - $h$ is the pressure head
     - $S_s$ is the specific storage coefficient (from soil curve)
     - $S(h)$ is the effective saturation
-    - $C(h) = d\\theta/dh$ is the specific moisture capacity
+    - $C(h) = d\theta/dh$ is the specific moisture capacity
     - $K(h)$ is the hydraulic conductivity
     - $z$ is the vertical coordinate
+
+    The form above writes the moisture storage as $C\,\partial h/\partial t$ for
+    readability, but the discretisation deliberately carries the conservative
+    $\partial \theta/\partial t$ form instead. With the stage-value stepper this
+    gives the exact finite difference $(\theta_{new} - \theta_{old})/\Delta t$ and
+    keeps mass balance exact for DG, so $C(h)$ is the physical moisture capacity
+    listed here but is never assembled directly.
 
     **Note**: The solution field is updated in place.
 
@@ -159,9 +168,11 @@ class RichardsSolver(SolverConfigurationMixin):
         Nullspace of the transposed Jacobian. Usually equal to ``nullspace``
         for Richards because the advective part is small.
       near_nullspace:
-        Near-nullspace basis passed to the AMG preconditioner. For scalar
-        Richards the near-nullspace is the constants, so if left ``None``
-        on an iterative preset ``RichardsSolver`` auto-builds it.
+        Near-nullspace basis forwarded to the preconditioner if supplied.
+        Defaults to ``None`` and is not auto-built: BoomerAMG (the iterative
+        preset) ignores an attached near-nullspace unless ``nodal_coarsen`` and
+        ``vec_interp_variant`` are set, while gamg/elasticity-style uses would
+        supply one explicitly.
       timestepper_kwargs:
         Dictionary of additional keyword arguments passed to the timestepper constructor.
         Useful for parameterized schemes (e.g., {'order': 5} for IrksomeRadauIIA).
@@ -191,7 +202,7 @@ class RichardsSolver(SolverConfigurationMixin):
         delta_t: Constant,
         timestepper: type[IrksomeIntegrator],
         *,
-        bcs: dict[int | str, dict[str, Number]] = {},
+        bcs: dict[int | str, dict[str, Number]] | None = None,
         source_term: Any = 0,
         solver_parameters: ConfigType | str | None = None,
         solver_parameters_extra: ConfigType | None = None,
@@ -206,7 +217,7 @@ class RichardsSolver(SolverConfigurationMixin):
         self.soil_curve = soil_curve
         self.delta_t = delta_t
         self.timestepper = timestepper
-        self.bcs = bcs
+        self.bcs = bcs or {}
         self.source_term = source_term
         self.quad_degree = quad_degree
         self.interior_penalty = interior_penalty
@@ -214,7 +225,11 @@ class RichardsSolver(SolverConfigurationMixin):
         self.transpose_nullspace = transpose_nullspace
         self.near_nullspace = near_nullspace
         self.timestepper_kwargs = timestepper_kwargs or {}
-        self._preset_name: str | None = None
+        # Remember whether the user supplied their own update_solver_parameters,
+        # so we never clobber it when auto-tracking the stage solver parameters.
+        self._user_update_solver_parameters = (
+            'update_solver_parameters' in self.timestepper_kwargs
+        )
 
         # Default to stage_type="value" for mass-conservative time discretisation.
         # The stage value stepper discretises Dt(theta(h)) as the exact finite
@@ -292,22 +307,12 @@ class RichardsSolver(SolverConfigurationMixin):
             'source': self.source_term,
         }
 
-        # scalar_equation.diffusion_term uses interior_penalty_factor(eq, shift=-1),
-        # i.e. the Shahbazi / Epshteyn-Rivière sharp bound with C(p-1). Richards
-        # is assembled against the looser Hillewaert form (C(p)) to match the
-        # momentum equation and the pre-refactor bespoke Richards term; the
-        # extra margin over the Shahbazi floor is useful in practice because
-        # K(h) can vary by orders of magnitude across the wetting front, even
-        # though Hillewaert's coercivity proof itself assumes bounded
-        # diffusivity. Absorb the C(p)/C(p-1) ratio into the safety factor so
-        # the assembled penalty matches the Hillewaert convention; the
-        # user-facing `interior_penalty` stays a bare safety factor.
-        #
-        # Flipping scalar_equation to shift=0 would let us delete this block,
-        # but would force regenerating stored reference data on every DG scalar
-        # diffusion test (viscoplastic_case_DG, multi_material,
-        # 2d_cylindrical_TALA_DG, adjoint_2d_cylindrical, and the adjoint
-        # mantle-convection demos).
+        # scalar_equation.diffusion_term builds the SIPG penalty with shift=-1
+        # (the sharper C(p-1) trace constant), but we want C(p), which appears commonly
+        # in the literature (shift=0), as used by the momentum equation. As a stopgap we
+        # scale the safety factor by C(p)/C(p-1) here to cancel the shift back
+        # out. This is a hack; the proper fix is to default scalar diffusion to
+        # shift=0, deferred for now because it forces regenerating DG reference data.
         alpha = self.interior_penalty if self.interior_penalty is not None else 2.0
         degree = self.solution_space.ufl_element().degree()
         if not isinstance(degree, int):
@@ -347,7 +352,6 @@ class RichardsSolver(SolverConfigurationMixin):
     ) -> None:
         """Sets PETSc solver parameters."""
         if isinstance(solver_preset, Mapping):
-            self._preset_name = None
             self.add_to_solver_config(solver_preset)
             self.add_to_solver_config(solver_extras)
             self.register_update_callback(self.setup_solver)
@@ -363,7 +367,6 @@ class RichardsSolver(SolverConfigurationMixin):
                 f"Valid options: '{valid}'."
             )
 
-        self._preset_name = solver_preset
         self._validate_preset(solver_preset)
         self.add_to_solver_config(self._PRESETS[solver_preset])
 
@@ -398,28 +401,8 @@ class RichardsSolver(SolverConfigurationMixin):
                     "or choose a different preset (e.g. 'direct')."
                 )
 
-    def setup_near_nullspace(self) -> "VectorSpaceBasis":
-        """Build the constant near-nullspace for AMG.
-
-        For scalar Richards the near-nullspace is the constants -- the
-        single mode the diffusion operator nearly annihilates. Providing
-        it to BoomerAMG / vlumping's coarse AMG ensures the prolongation
-        preserves constants, which is critical for optimal AMG convergence.
-        """
-        ones = Function(self.solution_space).assign(1.0)
-        basis = VectorSpaceBasis([ones])
-        basis.orthonormalize()
-        return basis
-
     def setup_solver(self) -> None:
         """Sets up the timestepper using specified parameters."""
-        # Auto-build the constant near-nullspace on iterative presets if
-        # the user hasn't supplied one. The constant is the only non-
-        # trivial near-nullspace mode for scalar Richards, so there is no
-        # ambiguity in the default.
-        if self.near_nullspace is None and self._preset_name == "iterative":
-            self.near_nullspace = self.setup_near_nullspace()
-
         if self.nullspace is not None:
             self.timestepper_kwargs.setdefault('nullspace', self.nullspace)
         if self.transpose_nullspace is not None:
@@ -428,10 +411,14 @@ class RichardsSolver(SolverConfigurationMixin):
             self.timestepper_kwargs.setdefault('near_nullspace', self.near_nullspace)
 
         # Reuse stage solver parameters for the conservative update solve.
-        if self.timestepper_kwargs.get('stage_type') == 'value':
-            self.timestepper_kwargs.setdefault(
-                'update_solver_parameters', self.solver_parameters,
-            )
+        # setup_solver is an update callback that re-runs on every config change,
+        # and add_to_solver_config reassigns self.solver_parameters to a fresh
+        # dict each time, so we must assign unconditionally to track the current
+        # parameters rather than setdefault'ing a one-off stale reference. A
+        # user-supplied update_solver_parameters is still respected.
+        if (self.timestepper_kwargs.get('stage_type') == 'value'
+                and not self._user_update_solver_parameters):
+            self.timestepper_kwargs['update_solver_parameters'] = self.solver_parameters
 
         self.ts = self.timestepper(
             self.equation,
@@ -452,11 +439,16 @@ class RichardsSolver(SolverConfigurationMixin):
         """
         return self.ts.stepper.solver
 
-    def solve(self, t: float | None = None) -> None:
+    def solve(self, t: float | None = None) -> tuple[float, float] | None:
         """Advances solver in time.
 
         Args:
           t:
             Current simulation time (optional)
+
+        Returns:
+          Whatever the underlying integrator's ``advance`` returns: ``None`` for
+          a non-adaptive step, or ``(adapt_error, adapt_dt)`` when adaptive
+          timestepping is enabled.
         """
         return self.ts.advance(t)

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -71,7 +71,6 @@ G-ADOPT uses this preset by default in 2-D.
 iterative_richards_solver_parameters: dict[str, Any] = {
     "mat_type": "aij",
     "ksp_type": "gmres",
-    "snes_linesearch_type": "bt",
     "ksp_rtol": 1e-5,
     "ksp_max_it": 200,
     "ksp_gmres_restart": 30,
@@ -161,12 +160,23 @@ class RichardsSolver(SolverConfigurationMixin):
         Default is 2.0; the theoretical coercivity floor is 1.0. Setting it
         below 1.0 will give a non-coercive bilinear form and Newton may fail.
       nullspace:
-        ``VectorSpaceBasis`` spanning the nullspace of the Jacobian. Relevant
-        for pure-Neumann problems (all fluxes specified, no Dirichlet on h),
-        where the constant is a true nullspace.
+        ``VectorSpaceBasis`` spanning the nullspace of the Jacobian. Never
+        built automatically, and normally not needed: the time derivative
+        contributes $(C + S_s S)/\Delta t$ times the mass matrix, which keeps
+        the constant out of the kernel even under pure Neumann conditions. The
+        exception is the degenerate steady case, where all three of the
+        following hold at once: the domain is fully saturated (so $C$ is
+        clamped to zero and $K$ to $K_s$, hence the gravity term is also
+        h-independent), $S_s = 0$ (so the storage term is dropped), and every
+        boundary carries a flux condition. That reduces to steady saturated
+        Darcy flow, for which the constant is a genuine kernel and the boundary
+        fluxes must sum to zero. Supply a nullspace only in that case; attaching
+        one to a non-singular Jacobian removes a legitimate constant component
+        of the solution at every iteration.
       transpose_nullspace:
-        Nullspace of the transposed Jacobian. Usually equal to ``nullspace``
-        for Richards because the advective part is small.
+        Nullspace of the transposed Jacobian. In the degenerate case above the
+        Jacobian is the symmetric SIPG diffusion operator, so this equals
+        ``nullspace``.
       near_nullspace:
         Near-nullspace basis forwarded to the preconditioner if supplied.
         Defaults to ``None`` and is not auto-built: BoomerAMG (the iterative
@@ -182,6 +192,11 @@ class RichardsSolver(SolverConfigurationMixin):
     | :---------- | :----- | :------------------------------------: |
     | h           | Strong | Pressure head (Dirichlet)              |
     | flux        | Weak   | Total flux (Neumann)                   |
+
+    ``flux`` prescribes the total flux $K \nabla (h + z) \cdot n$, which is minus
+    the outward Darcy flux, so a positive value drives water into the domain. A
+    boundary left out of ``bcs`` gets the natural zero-total-flux (no-flow)
+    condition.
 
     Examples:
         >>> # Dirichlet BC: fixed pressure head at top

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -340,6 +340,19 @@ class RichardsSolver(SolverConfigurationMixin):
             # degree == 0: interior_penalty_factor short-circuits to sigma=1.0
             # and ignores alpha entirely; pass alpha through unchanged.
             eq_attrs['interior_penalty'] = alpha
+            # The element-wise gradient of a degree-0 function vanishes, so three
+            # of the four SIPG terms drop out and only the penalty term survives.
+            # With sigma=1.0 that is exactly the classical two-point-flux (TPFA)
+            # finite-volume Laplacian, whose transmissibility is the arithmetic
+            # mean of 1/h rather than the correct harmonic mean.
+            warn(
+                "RichardsSolver is running at degree 0, where the interior "
+                "penalty form reduces to a two-point-flux finite-volume scheme. "
+                "This is accurate only on orthogonal, locally uniform "
+                "quadrilateral or hexahedral cells. On simplicial, "
+                "non-orthogonal or graded meshes it may not converge.",
+                stacklevel=2,
+            )
 
         self.equation = Equation(
             self.test,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-demos = ["assess", "gadopt-demo-utils @ git+https://github.com/g-adopt/gadopt-demo-utils.git", "gmsh", "imageio", "jupytext", "openpyxl", "pyvista"]
+demos = ["assess", "gadopt-demo-utils @ git+https://github.com/g-adopt/gadopt-demo-utils.git", "gmsh", "gwassess>=1.0.0", "imageio", "jupytext", "openpyxl", "pyvista"]
 optimisation = ["pyroltrilinos"]
 gplates = ["gtrack", "pygplates"]
 

--- a/tests/richards/.gitignore
+++ b/tests/richards/.gitignore
@@ -1,0 +1,7 @@
+*.csv
+*.pvd
+*.err
+*.out
+errors*.dat
+tracy_h_*
+tracy_analytical_*

--- a/tests/richards/meta.py
+++ b/tests/richards/meta.py
@@ -1,0 +1,21 @@
+from .richards import cases
+
+steps = {}
+
+for l1, v1 in cases.items():
+    for l2, v2 in v1.items():
+        for l3, config in v2.items():
+            case_name = f"{l1}_{l2}_{l3}"
+            for nodes, cores in zip(config["levels"], config["cores"]):
+                degree = config["degree"]
+                bc_type = config["bc_type"]
+                step_key = f"{case_name}-nodes{nodes}-dq{degree}"
+
+                steps[step_key] = {
+                    "entrypoint": "richards.py",
+                    "args": f"{case_name} {nodes} {degree} {bc_type}",
+                    "cores": cores,
+                    "outputs": [f"errors-{step_key}.dat"],
+                }
+
+pytest = "local"

--- a/tests/richards/meta.py
+++ b/tests/richards/meta.py
@@ -2,13 +2,12 @@ from .richards import cases
 
 steps = {}
 
-for l1, v1 in cases.items():
-    for l2, v2 in v1.items():
-        for l3, config in v2.items():
-            case_name = f"{l1}_{l2}_{l3}"
+for module_name, bc_dict in cases.items():
+    for bc_type, degree_dict in bc_dict.items():
+        for degree_key, config in degree_dict.items():
+            case_name = f"{module_name}_{bc_type}_{degree_key}"
             for nodes, cores in zip(config["levels"], config["cores"]):
                 degree = config["degree"]
-                bc_type = config["bc_type"]
                 step_key = f"{case_name}-nodes{nodes}-dq{degree}"
 
                 steps[step_key] = {

--- a/tests/richards/richards.py
+++ b/tests/richards/richards.py
@@ -1,0 +1,81 @@
+import argparse
+import importlib
+
+cases = {
+    "tracy_2d": {
+        "specified_head": {
+            "dg0": {
+                "levels": [51, 101, 201, 401],
+                "cores": [1, 1, 4, 16],
+                "degree": 0,
+                "bc_type": "specified_head",
+            },
+            "dg1": {
+                "levels": [51, 101, 201, 401],
+                "cores": [1, 1, 4, 16],
+                "degree": 1,
+                "bc_type": "specified_head",
+            },
+            "dg2": {
+                "levels": [76, 151, 301],
+                "cores": [2, 2, 8],
+                "degree": 2,
+                "bc_type": "specified_head",
+            },
+        },
+        "no_flux": {
+            "dg1": {
+                "levels": [51, 101, 201, 401],
+                "cores": [1, 1, 4, 16],
+                "degree": 1,
+                "bc_type": "no_flux",
+            },
+        },
+    },
+}
+
+
+def get_case(cases, name):
+    """Look up (module_name, config) by flat name, e.g. 'tracy_2d_specified_head_dg1'.
+
+    The cases dict is nested as cases[tracy_2d][specified_head][dg1]. Rather than
+    parsing the flat name (which is fragile because '_' is both the separator and
+    appears inside the module/BC/degree keys), match it against the names the
+    nesting actually produces.
+    """
+    for module_name, bc_dict in cases.items():
+        for bc_type, degree_dict in bc_dict.items():
+            for degree_key, config in degree_dict.items():
+                if f"{module_name}_{bc_type}_{degree_key}" == name:
+                    return module_name, config
+    raise KeyError(f"unknown case {name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="richards",
+        description="Run Richards equation benchmark cases",
+    )
+    parser.add_argument("case")
+    parser.add_argument("nodes", type=int)
+    parser.add_argument("degree", type=int)
+    parser.add_argument("bc_type", type=str)
+
+    args = parser.parse_args()
+
+    from mpi4py import MPI
+
+    # Resolve the module the case lives in (e.g. tracy_2d) without parsing.
+    module_name, _ = get_case(cases, args.case)
+    try:
+        model = importlib.import_module(module_name).model
+    except ModuleNotFoundError:
+        raise ValueError(f"unknown case {args.case} (module {module_name} not found)")
+
+    errors = model(args.nodes, degree=args.degree, bc_type=args.bc_type)
+
+    if MPI.COMM_WORLD.rank == 0:
+        errfile = f"errors-{args.case}-nodes{args.nodes}-dq{args.degree}.dat"
+        with open(errfile, "w") as f:
+            f.write(" ".join(str(x) for x in errors))
+        print(f"Wrote {errfile}")

--- a/tests/richards/test_gravity_upwind.py
+++ b/tests/richards/test_gravity_upwind.py
@@ -1,0 +1,168 @@
+"""Regression tests for the interior-facet gravity upwind direction.
+
+The gravity (elevation-head) term ``richards_gravity_term`` upwinds ``K`` on
+interior facets. Gravity drives drainage downward, so the upstream side of a
+facet is the cell *above* it and the numerical flux must select the *upper*
+trace of ``K`` (the negative part of ``q.n``). Selecting the lower trace (the
+positive part) is the classic sign bug: it is masked by every smooth benchmark
+because the two traces coincide wherever ``jump(K) -> 0`` (well-resolved DG, or
+a continuous ``K``), and only bites where ``K`` jumps sharply across a facet.
+
+Two guards:
+
+* ``test_gravity_upwind_selects_upper_trace`` -- an assembly-level check on a
+  two-cell mesh with a prescribed ``K`` jump. It exercises the *installed*
+  ``richards_gravity_term`` and asserts the facet flux equals the upper (not the
+  lower) ``K`` trace, for both an h-induced jump and a material ``Ks`` jump.
+
+* ``test_gravity_upwind_transient_drainage`` -- a DG0 solve in a two-layer
+  column with uniform initial head (so the capillary flux ``K grad(h)`` is zero
+  and transport at t=0 is pure gravity). The correct (upper-trace) upwind pushes
+  more water down across the conductivity interface than the wrong (lower-trace)
+  choice; the shipped solver must match the correct one.
+"""
+import math
+
+import numpy as np
+from firedrake import (
+    RectangleMesh, FunctionSpace, Function, SpatialCoordinate, TestFunction,
+    Constant, conditional, assemble, inner, grad, dot, jump, dx,
+)
+
+from gadopt import ExponentialCurve, RichardsSolver, BackwardEuler
+from gadopt import richards_equation as richards_eq
+from gadopt.equations import Equation
+from gadopt.utility import upward_normal, is_continuous
+
+# The installed (production) gravity term, captured before any monkeypatching.
+_INSTALLED_GRAVITY_TERM = richards_eq.richards_gravity_term
+
+
+def _make_gravity_term(sign):
+    """Build a gravity term whose facet flux uses q_n = 0.5*(q.n + sign*|q.n|).
+
+    ``sign = -1`` is the correct (upper-trace) upwind; ``sign = +1`` is the
+    lower-trace sign bug. Used to construct explicit reference behaviours in the
+    transient test.
+    """
+    def term(eq, trial):
+        K = eq.soil_curve.hydraulic_conductivity(trial)
+        k = upward_normal(eq.mesh)
+        F = inner(K * k, grad(eq.test)) * eq.dx
+        if not is_continuous(eq.trial_space):
+            q = K * k
+            q_n = 0.5 * (dot(q, eq.n) + sign * abs(dot(q, eq.n)))
+            F -= jump(eq.test) * (q_n('+') - q_n('-')) * eq.dS
+        return F
+
+    term.required_attrs = {'soil_curve'}
+    term.optional_attrs = set()
+    return term
+
+
+def _installed_facet_trace(V, h, soil):
+    """Magnitude of the facet gravity flux produced by the *installed* term.
+
+    On a DG0 space grad(test) = 0, so the volume integral vanishes and the term
+    reduces to its interior-facet contribution -jump(test)*(q_n+ - q_n-)*dS.
+    Assembled against the DG0 test basis this gives +/-(q_n+ - q_n-)*|facet| per
+    cell, whose magnitude equals the selected K trace (|e_z.n| = 1, |facet| = 1).
+    """
+    test = TestFunction(V)
+    eq = Equation(test, V, residual_terms=[richards_eq.richards_gravity_term],
+                  eq_attrs={'soil_curve': soil})
+    facet_flux = assemble(richards_eq.richards_gravity_term(eq, h))
+    return float(np.abs(facet_flux.dat.data_ro).max())
+
+
+def test_gravity_upwind_selects_upper_trace():
+    # Two DG0 cells stacked in y, one interior horizontal facet at y = 1.
+    mesh = RectangleMesh(1, 2, 1.0, 2.0, quadrilateral=True)
+    mesh.cartesian = True
+    _, y = SpatialCoordinate(mesh)
+    V = FunctionSpace(mesh, "DQ", 0)
+
+    Ks, alpha = 1.0, 1.0
+
+    # (a) h-induced jump: wet (h=0, K=Ks) above, dry (h=-10, K~0) below.
+    soil = ExponentialCurve(theta_r=0.15, theta_s=0.45, Ks=Ks, Ss=0.0, alpha=alpha)
+    h = Function(V).interpolate(conditional(y > 1.0, 0.0, -10.0))
+    K_above = Ks * math.exp(alpha * 0.0)     # wet cell, on top
+    K_below = Ks * math.exp(alpha * -10.0)   # dry cell, below
+    sel = _installed_facet_trace(V, h, soil)
+    assert math.isclose(sel, K_above, rel_tol=1e-9), (
+        f"gravity facet flux selected {sel:.3e}; expected upper trace "
+        f"K_above={K_above:.3e} (lower trace K_below={K_below:.3e} is the bug)"
+    )
+
+    # (b) material Ks jump: uniform h, discontinuous DG0 Ks (top 1, bottom 0.01).
+    Ks_field = Function(V).interpolate(conditional(y > 1.0, 1.0, 0.01))
+    soil_h = ExponentialCurve(theta_r=0.15, theta_s=0.45, Ks=Ks_field, Ss=0.0,
+                              alpha=alpha)
+    h_uniform = Function(V).interpolate(Constant(-0.3))
+    kr = math.exp(alpha * -0.3)
+    sel_h = _installed_facet_trace(V, h_uniform, soil_h)
+    assert math.isclose(sel_h, 1.0 * kr, rel_tol=1e-9), (
+        f"material-jump facet flux selected {sel_h:.3e}; expected upper trace "
+        f"Ks_top*kr={1.0 * kr:.3e} (lower trace {0.01 * kr:.3e} is the bug)"
+    )
+
+
+def _water_below_interface(gravity_term, *, z_iface=1.0, nsteps=3):
+    """Water that has moved below the conductivity interface after ``nsteps``.
+
+    Two-layer DG0 column, hard 100x Ks jump at ``z_iface`` (aligned to a facet),
+    uniform initial head so the capillary flux is zero at t=0 and the early
+    transport across the interface is pure gravity. ``gravity_term`` is swapped
+    into the equation module for the duration of the run.
+    """
+    H, nz, alpha = 2.0, 40, 4.0
+    Ks_top, Ks_bot, h0 = 1.0, 0.01, -0.2
+
+    saved = richards_eq.richards_gravity_term
+    richards_eq.richards_gravity_term = gravity_term
+    try:
+        mesh = RectangleMesh(3, nz, 0.15, H, quadrilateral=True)
+        mesh.cartesian = True
+        _, z = SpatialCoordinate(mesh)
+        V = FunctionSpace(mesh, "DQ", 0)
+        Ks = Function(V).interpolate(conditional(z > z_iface, Ks_top, Ks_bot))
+        soil = ExponentialCurve(theta_r=0.06, theta_s=0.40, Ks=Ks, Ss=0.0,
+                                alpha=alpha)
+        h = Function(V).interpolate(Constant(h0))       # uniform -> pure gravity
+        theta = soil.moisture_content(h)
+        below = conditional(z < z_iface, 1.0, 0.0)
+        m0 = assemble(theta * below * dx)
+
+        solver = RichardsSolver(
+            h, soil, delta_t=Constant(0.01), timestepper=BackwardEuler,
+            bcs=None, solver_parameters="direct", quad_degree=4,
+            interior_penalty=2.0,
+        )
+        for _ in range(nsteps):
+            solver.solve()
+        return assemble(theta * below * dx) - m0
+    finally:
+        richards_eq.richards_gravity_term = saved
+
+
+def test_gravity_upwind_transient_drainage():
+    below_buggy = _water_below_interface(_make_gravity_term(+1.0))   # lower trace
+    below_fixed = _water_below_interface(_make_gravity_term(-1.0))   # upper trace
+    below_installed = _water_below_interface(_INSTALLED_GRAVITY_TERM)
+
+    # Both upwind choices move some water down, but the correct (upper-trace)
+    # one moves distinctly more across the conductivity interface.
+    assert below_buggy > 0.0 and below_fixed > 0.0
+    assert below_fixed > 1.3 * below_buggy, (
+        f"upper-trace upwind moved {below_fixed:.3e} below the interface, only "
+        f"{below_fixed / below_buggy:.2f}x the lower-trace {below_buggy:.3e}; "
+        f"expected a clear (>1.3x) gravity-driven separation"
+    )
+
+    # The shipped solver must behave as the correct (upper-trace) upwind.
+    assert math.isclose(below_installed, below_fixed, rel_tol=1e-6), (
+        f"installed gravity term moved {below_installed:.3e} below the "
+        f"interface but the correct upper-trace upwind moves {below_fixed:.3e}; "
+        f"the shipped term is not using the upper (upstream) K trace"
+    )

--- a/tests/richards/test_hydrostatic_dirichlet.py
+++ b/tests/richards/test_hydrostatic_dirichlet.py
@@ -1,0 +1,162 @@
+"""Regression tests for the gravity flux on weakly imposed Dirichlet head boundaries.
+
+The total flux is ``K grad(h + z)``, but ``scalar_equation.diffusion_term`` builds
+its Nitsche consistency term from ``h`` alone, so ``richards_gravity_term`` has to
+contribute the ``K grad(z).n`` half on any boundary carrying a weak Dirichlet head.
+Omitting it leaves a spurious ``+int K grad(z).n v ds`` in the residual -- exactly
+the free-drainage flux that should be crossing that boundary -- and the scheme is
+inconsistent there.
+
+Hydrostatic equilibrium is the guard. With ``h = C - z`` the total potential is
+constant, so ``q = -K grad(h + z) = 0`` identically and this is an exact steady
+solution for *any* soil curve, with no reference data and no special functions
+needed. A consistent scheme must return a zero residual at that field, and a
+steady solve started from it must stay there.
+
+Two controls run alongside: an unspecified (natural) boundary and ``flux = 0``.
+Both are already correct without any gravity boundary term -- for them, carrying
+none is precisely the right natural condition ``q.n = 0`` -- so they guard against
+a "fix" that adds the term unconditionally on every boundary.
+
+Continuous spaces are not covered here: ``RichardsSolver`` imposes a head boundary
+on them with a strong ``DirichletBC``, so no weak boundary term is generated and
+none is needed. The boundary rows never see the residual.
+"""
+import numpy as np
+import pytest
+from firedrake import (
+    RectangleMesh, FunctionSpace, Function, SpatialCoordinate, TestFunction,
+    Constant, assemble, dx,
+)
+
+from gadopt import ExponentialCurve, RichardsSolver, BackwardEuler
+from gadopt import richards_equation as richards_eq
+from gadopt import scalar_equation as scalar_eq
+from gadopt.equations import Equation, cell_edge_integral_ratio
+
+# h = C - z on a 1 x 2 m column. C is well into the unsaturated range so K(h)
+# stays far from Ks and the exponential curve is exercised away from its cap.
+C = -5.0
+LX, LZ = 1.0, 2.0
+ALPHA, KS = 0.25, 1.0e-5
+
+
+def _soil():
+    return ExponentialCurve(theta_r=0.15, theta_s=0.45, alpha=ALPHA, Ks=KS, Ss=0.0)
+
+
+def _K_scale():
+    """K at the driest point of the boundary, used to normalise the residual.
+
+    The residual scales with K, so the raw number tracks Ks and tells you nothing
+    on its own. Dividing by this makes the tolerance independent of the soil.
+    """
+    return KS * np.exp(ALPHA * (C - LZ))
+
+
+def _setup(nodes, family, degree):
+    mesh = RectangleMesh(nodes, nodes, LX, LZ, quadrilateral=True)
+    mesh.cartesian = True
+    _, z = SpatialCoordinate(mesh)
+    V = FunctionSpace(mesh, family, degree)
+    exact = C - z
+    return mesh, V, exact, Function(V).interpolate(exact)
+
+
+def _bcs(mode, exact):
+    """Boundary dictionaries in `diffusion_term` vocabulary ('q', not 'h').
+
+    RichardsSolver translates the user-facing 'h' into 'q' in
+    `set_boundary_conditions`; assembling the Equation directly means using the
+    internal key.
+    """
+    ids = (1, 2, 3, 4)
+    return {
+        "natural": {},
+        "flux_zero": {i: {"flux": 0.0} for i in ids},
+        "dirichlet": {i: {"q": exact} for i in ids},
+    }[mode]
+
+
+def _residual(nodes, family, degree, mode):
+    """max |residual| at the exact hydrostatic field, normalised by boundary K."""
+    mesh, V, exact, h = _setup(nodes, family, degree)
+
+    # Mirrors the penalty RichardsSolver builds: scalar diffusion uses shift=-1,
+    # rescaled to the shift=0 constant. See RichardsSolver.set_equation.
+    penalty = 2.0 * (
+        cell_edge_integral_ratio(mesh, max(degree, 1))
+        / cell_edge_integral_ratio(mesh, max(degree - 1, 0))
+    )
+    soil = _soil()
+    eq = Equation(
+        TestFunction(V), V,
+        residual_terms=[scalar_eq.diffusion_term, richards_eq.richards_gravity_term],
+        eq_attrs={
+            "soil_curve": soil,
+            "diffusivity": soil.hydraulic_conductivity(h),
+            "interior_penalty": penalty,
+        },
+        bcs=_bcs(mode, exact),
+    )
+    residual = assemble(eq.residual(h))
+    return float(np.abs(residual.dat.data_ro).max()) / _K_scale()
+
+
+@pytest.mark.parametrize("degree", [0, 1, 2])
+@pytest.mark.parametrize("mode", ["natural", "flux_zero", "dirichlet"])
+def test_hydrostatic_residual_vanishes(degree, mode):
+    """The hydrostatic field is an exact steady solution, so its residual is zero.
+
+    DQ0 cannot represent the linear field h = C - z, so it carries a
+    representation error that is not the boundary term under test; it is checked
+    only for consistency across the three boundary configurations, which is what
+    isolates the Dirichlet path.
+    """
+    got = _residual(8, "DQ", degree, mode)
+
+    if degree == 0:
+        natural = _residual(8, "DQ", 0, "natural")
+        assert got == pytest.approx(natural, rel=1e-6), (
+            f"DQ0 {mode} residual {got:.3e} differs from the natural-boundary "
+            f"value {natural:.3e}; all three configurations must agree, since "
+            f"what remains at DQ0 is representation error, not a boundary defect"
+        )
+    else:
+        assert got < 1e-10, (
+            f"DQ{degree} {mode}: max|residual|/K = {got:.3e} at the exact "
+            f"hydrostatic field. A consistent scheme returns zero here; a "
+            f"non-zero value on 'dirichlet' is the missing gravity boundary "
+            f"flux, and one on 'natural'/'flux_zero' means the term is being "
+            f"applied where it does not belong"
+        )
+
+
+@pytest.mark.parametrize("degree", [1, 2])
+def test_hydrostatic_steady_solve_stays_put(degree):
+    """Started at the exact answer with Dirichlet data, the solve must not move.
+
+    With the boundary term missing this drifts to a mesh-scale error that is
+    independent of K -- the missing flux and the Nitsche penalty both carry K,
+    so it cancels -- and converges at about 1.5 regardless of degree, capping
+    the attainable order wherever a Dirichlet head is active.
+    """
+    _, _, exact, h = _setup(8, "DQ", degree)
+    dt = Constant(1.0e4)
+    solver = RichardsSolver(
+        h, _soil(), delta_t=dt, timestepper=BackwardEuler,
+        bcs={i: {"h": exact} for i in (1, 2, 3, 4)},
+        solver_parameters="direct",
+        quad_degree=2 * degree + 4,
+        interior_penalty=2.0,
+    )
+    for _ in range(20):
+        solver.solve()
+        dt.assign(float(dt) * 1.5)
+
+    error = np.sqrt(assemble((h - exact) ** 2 * dx(
+        metadata={"quadrature_degree": 2 * degree + 4})))
+    assert error < 1e-12, (
+        f"DQ{degree}: hydrostatic solve drifted to L2 error {error:.3e} m from "
+        f"an exact initial state; expected it to stay at machine precision"
+    )

--- a/tests/richards/test_richards.py
+++ b/tests/richards/test_richards.py
@@ -1,0 +1,77 @@
+"""Pytest tests for Richards equation benchmarks.
+
+Follows the same pattern as tests/analytical_comparisons: reads
+errors-{case}-nodes{N}-dq{p}.dat files produced by richards.py,
+computes convergence rates across mesh refinements, and checks
+against expected theoretical rates.
+"""
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from .richards import cases, get_case
+
+
+# Expected convergence rates: DQ theory gives O(h^{p+1})
+expected_rates = {
+    0: {"rate": 1.0, "rtol": 0.1},
+    1: {"rate": 2.0, "rtol": 0.1},
+    2: {"rate": 3.0, "rtol": 0.1},
+}
+
+# Cases to test and whether they are longtests
+enabled_cases = {
+    "tracy_2d_specified_head_dg0": {},
+    "tracy_2d_specified_head_dg1": {},
+    "tracy_2d_specified_head_dg2": {},
+    "tracy_2d_no_flux_dg1": {},
+}
+
+param_list = []
+for name, opts in enabled_cases.items():
+    marks = opts.get("marks")
+    if marks:
+        param_list.append(pytest.param(name, marks=marks))
+    else:
+        param_list.append(name)
+
+
+@pytest.mark.parametrize("case_name", param_list)
+def test_convergence_rate(case_name):
+    """Verify spatial convergence rate across mesh refinements."""
+    b = Path(__file__).parent.resolve()
+    _, config = get_case(cases, case_name)
+    levels = config["levels"]
+    degree = config["degree"]
+
+    cols = ["l2error_h", "l2error_theta", "l2anal_h", "l2anal_theta"]
+
+    dats = []
+    for nodes in levels:
+        datfile = b / f"errors-{case_name}-nodes{nodes}-dq{degree}.dat"
+        if not datfile.exists():
+            raise FileNotFoundError(
+                f"Missing {datfile.name}. Run: python richards.py {case_name} {nodes} {degree} {config['bc_type']}"
+            )
+        dats.append(pd.read_csv(datfile, sep=" ", header=None))
+
+    dat = pd.concat(dats)
+    dat.columns = cols
+    dat.insert(0, "nodes", levels)
+    dat = dat.set_index("nodes")
+
+    # Compute relative errors
+    rel_errors = dat["l2error_h"] / dat["l2anal_h"]
+
+    # Compute convergence rates between successive levels
+    rates = np.log2(rel_errors.values[:-1] / rel_errors.values[1:])
+
+    # Check that the finest-mesh rate meets the theoretical expectation
+    expected = expected_rates[degree]
+    finest_rate = rates[-1]
+    assert finest_rate >= expected["rate"] * (1 - expected["rtol"]), (
+        f"{case_name}: finest convergence rate {finest_rate:.2f} below "
+        f"expected {expected['rate']:.1f} (with {expected['rtol']*100:.0f}% tolerance)"
+    )

--- a/tests/richards/tracy_2d.py
+++ b/tests/richards/tracy_2d.py
@@ -1,0 +1,129 @@
+from gadopt import *
+import numpy as np
+import gwassess
+
+
+def model(nodes, degree=1, bc_type='specified_head'):
+    """Tracy 2D Richards equation benchmark with analytical solution.
+
+    Solves to steady state on a square domain using BackwardEuler with
+    dt ramp-up, then computes L2 error against Tracy (2006) analytical
+    solution. Parameters match Morrow et al. (2026), Section 4.1.
+
+    Args:
+        nodes: Number of cells per spatial dimension.
+        degree: DQ polynomial degree (0, 1, or 2).
+        bc_type: 'specified_head' or 'no_flux'.
+
+    Returns:
+        Tuple of (l2error_h, l2error_theta, l2anal_h, l2anal_theta).
+    """
+
+    L = 15.24
+    alpha = 0.25
+    hr = -L
+    theta_r = 0.15
+    theta_s = 0.45
+    Ks = 1.0e-05
+
+    tracy_solution = gwassess.TracyRichardsSolution2D(
+        alpha=alpha, hr=hr, L=L,
+        theta_r=theta_r, theta_s=theta_s, Ks=Ks,
+    )
+
+    soil_curve = ExponentialCurve(
+        theta_r=theta_r, theta_s=theta_s,
+        Ks=Ks, Ss=0.0, alpha=alpha,
+    )
+
+    mesh = RectangleMesh(nodes, nodes, L, L, name="mesh", quadrilateral=True)
+    mesh.cartesian = True
+    X = SpatialCoordinate(mesh)
+
+    V = FunctionSpace(mesh, "DQ", degree)
+
+    # Boundary conditions
+    h0_val = 1 - exp(alpha * hr)
+    boundary_ids = get_boundary_ids(mesh)
+
+    if bc_type == 'specified_head':
+        richards_bcs = {
+            boundary_ids.left: {'h': hr},
+            boundary_ids.right: {'h': hr},
+            boundary_ids.bottom: {'h': hr},
+            boundary_ids.top: {'h': (1/alpha) * ln(exp(alpha*hr) + h0_val * sin(pi*X[0]/L))},
+        }
+    elif bc_type == 'no_flux':
+        richards_bcs = {
+            boundary_ids.left: {'flux': 0.0},
+            boundary_ids.right: {'flux': 0.0},
+            boundary_ids.bottom: {'h': hr},
+            boundary_ids.top: {'h': (1/alpha) * ln(exp(alpha*hr) + (h0_val/2) * (1 - cos(2*pi*X[0]/L)))},
+        }
+    else:
+        raise ValueError("bc_type must be 'specified_head' or 'no_flux'")
+
+    # Initial condition from analytical solution at t_offset
+    t_offset = 2000.0
+    V_coords = VectorFunctionSpace(mesh, "DQ", degree)
+    coords = Function(V_coords).interpolate(as_vector([X[0], X[1]]))
+
+    h = Function(V, name="PressureHead")
+    h.dat.data[:] = [
+        tracy_solution.pressure_head_cartesian([xy[0], xy[1]], t_offset, bc_type=bc_type)
+        for xy in coords.dat.data
+    ]
+
+    # Solve to steady state with BackwardEuler and dt ramp-up
+    t_final = 2.5e6
+    dt = Constant(5e4)
+
+    # Quadrature degree scales with polynomial degree so the non-polynomial
+    # K(h) = K_s exp(alpha h) factor in the bilinear form is integrated
+    # accurately enough to keep the Newton iteration stable. Under-quadrature
+    # at DG2 caused DIVERGED_LINE_SEARCH on the first step.
+    quad_degree = max(3, 2 * degree + 4)
+
+    richards_solver = RichardsSolver(
+        h, soil_curve, delta_t=dt,
+        timestepper=BackwardEuler,
+        bcs=richards_bcs,
+        solver_parameters="direct",
+        quad_degree=quad_degree,
+        interior_penalty=2.0,
+    )
+
+    time = 0.0
+    while time < t_final:
+        richards_solver.solve()
+        time += float(dt)
+        dt.assign(min(float(dt) * 1.05, t_final / 10))
+
+    # Compute L2 errors against analytical solution at t_offset + time
+    dx_quad = dx(metadata={"quadrature_degree": quad_degree})
+
+    h_anal = Function(V, name="AnalyticalPressureHead")
+    h_anal.dat.data[:] = [
+        tracy_solution.pressure_head_cartesian([xy[0], xy[1]], t_offset + time, bc_type=bc_type)
+        for xy in coords.dat.data
+    ]
+
+    theta_anal = Function(V, name="AnalyticalMoistureContent")
+    theta_anal.dat.data[:] = [
+        tracy_solution.moisture_content(h_val)
+        for h_val in h_anal.dat.data
+    ]
+
+    theta_num = Function(V)
+    theta_num.interpolate(soil_curve.moisture_content(h))
+
+    l2error_h = np.sqrt(assemble((h - h_anal)**2 * dx_quad))
+    l2error_theta = np.sqrt(assemble((theta_num - theta_anal)**2 * dx_quad))
+    l2anal_h = np.sqrt(assemble(h_anal**2 * dx_quad))
+    l2anal_theta = np.sqrt(assemble(theta_anal**2 * dx_quad))
+
+    log(f"L2 error (h): {l2error_h:.4e} | L2 analytical (h): {l2anal_h:.4e} | "
+        f"Relative: {l2error_h/l2anal_h:.4e} | "
+        f"nodes = {nodes} | DQ{degree} | DOFs = {V.dim()}")
+
+    return l2error_h, l2error_theta, l2anal_h, l2anal_theta


### PR DESCRIPTION
Third of five PRs decomposing the Richards-equation foundation work. **This is the headline PR**: equations, solver, and a real end-to-end test. Stacked on #522.

The Richards equation governs water movement in variably saturated porous media,

```
(S_s * S(h) + C(h)) * dh/dt - div(K(h) * grad h) - div(K(h) * grad z) = 0
```

with `h` the pressure head, `theta(h)` the moisture content, `K(h)` the hydraulic conductivity, and `z` the vertical coordinate.

**`gadopt.richards_equation`** provides the Richards-specific residual terms (mass and gravity) as plain UFL callables. Diffusion and source are reused from `scalar_equation` via the `nonlinear_coefficients` mechanism from #521: `K(h)` is built as a UFL expression in the equation's `solution` and is resolved against each Irksome stage's trial via `ufl.replace`.

**`gadopt.RichardsSolver`** drives the equation in time. Two PETSc presets cover the common geometries:

- `direct_richards_solver_parameters`: MUMPS LU, the 2-D default.
- `iterative_richards_solver_parameters`: Newton + GMRES + BoomerAMG via Hypre, the 3-D default. Fails fast at construction if PETSc was not built with Hypre.

The default time discretisation uses Irksome's stage-value stepper (`stage_type='value'`), which treats the nonlinear mass term `Dt(theta(h))` as the exact finite difference rather than applying the chain rule. Mass-conservative for any Butcher tableau, both stiffly- and non-stiffly-accurate (the latter via Irksome's conservative-update path). Users who opt out get a runtime warning that the chain-rule discretisation accumulates mass-balance error.

The SIPG penalty assembly uses Hillewaert's `C(p)` trace constant to match the momentum equation. Because `scalar_equation.diffusion_term` assembles with the Shahbazi `C(p-1)` form internally, `RichardsSolver` multiplies the user-facing safety factor by the `C(p)/C(p-1)` ratio so the assembled penalty matches the Hillewaert convention. Flipping `scalar_equation` to `shift=0` would let us delete this compensation, but would force regenerating stored reference data on every DG scalar diffusion test (`viscoplastic_case_DG`, `multi_material`, `2d_cylindrical_TALA_DG`, `adjoint_2d_cylindrical`, and the adjoint mantle-convection demos), so the compensation lives in `RichardsSolver` instead.

**Tracy (2006) 2-D infiltration benchmark** lands under `tests/richards/`. Tracy provides a closed-form steady-state solution for the exponential-K model; the test verifies L2 convergence at DQ degrees 0, 1, 2 (expected `O(h^(p+1))`) for both Dirichlet specified-head and no-flux boundary configurations.
