### PR TITLE
Add vertically lumped preconditioners and presets for Richards

### DIFF
--- a/gadopt/__init__.py
+++ b/gadopt/__init__.py
@@ -22,7 +22,10 @@ from .level_set_tools import (
 )
 from .limiter import VertexBasedP1DGLimiter
 from .nullspaces import create_stokes_nullspace, rigid_body_modes
-from .preconditioners import FreeSurfaceMassInvPC, SPDAssembledPC
+from .preconditioners import (
+    FreeSurfaceMassInvPC, SPDAssembledPC,
+    VerticallyLumpedPC, VerticallyLumpedHMGPC,
+)
 from .richards_solver import RichardsSolver
 from .soil_curves import (
     SoilCurve,

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -1,10 +1,26 @@
 r"""This module contains classes that augment default Firedrake preconditioners.
 
+Includes preconditioners for:
+- Stokes: FreeSurfaceMassInvPC, SPDAssembledPC
+- Richards: VerticallyLumpedPC, VerticallyLumpedHMGPC
+
 """
 
 import firedrake as fd
-from ufl.indexed import Indexed
+from firedrake import (
+    FiniteElement,
+    FunctionSpace,
+    MixedFunctionSpace,
+    PCBase,
+    TensorProductElement,
+    TrialFunction,
+)
+from firedrake.assemble import assemble
+from firedrake.dmhooks import get_function_space
+from firedrake.interpolation import interpolate
+from firedrake.mg.utils import get_level
 from firedrake.petsc import PETSc
+from ufl.indexed import Indexed
 from .utility import InteriorBC
 
 
@@ -64,3 +80,320 @@ class SPDAssembledPC(fd.AssembledPC):
         super().initialize(pc)
         mat = self.P.petscmat
         mat.setOption(mat.Option.SPD, True)
+
+
+# =========================================================================
+# Richards equation preconditioners
+# =========================================================================
+
+
+class VerticallyLumpedPC(PCBase):
+    """Two-level MG that collapses the vertical dimension on the coarse level.
+
+    A preconditioner specifically designed for high-aspect-ratio extruded
+    meshes, inspired by Kramer et al. (2010, doi:10.1016/j.ocemod.2010.08.001)
+    and the ocean modelling community. The idea:
+
+        Fine level   : V = V_horiz x V_vert  (full 3D tensor-product space)
+        Coarse level : V_c = V_horiz x R     (vertically constant)
+
+    The prolongation P is the natural injection from V_c into V (a coarse
+    DOF is replicated along its column). The coarse operator is formed by
+    Galerkin projection, A_c = P^T A P, collapsing the entire vertical
+    dimension onto a 2D-like problem solvable cheaply with MUMPS or GAMG.
+
+    Solver options for the coarse level use the prefix ``lumped_mg_coarse_``
+    and the fine-level smoother uses ``lumped_mg_levels_``.
+    """
+
+    def initialize(self, pc):
+        options_prefix = pc.getOptionsPrefix()
+        A, P = pc.getOperators()
+        V = get_function_space(pc.getDM())
+
+        # Handle both scalar and mixed spaces
+        if len(V) == 1:
+            V = FunctionSpace(V.mesh(), V.ufl_element())
+        else:
+            V = MixedFunctionSpace([V_ for V_ in V])
+
+        # Build vertically constant function space (V_horiz x R)
+        mesh = V.mesh()
+        _, vcell = mesh.ufl_cell().sub_cells
+        hele, _ = V.ufl_element().factor_elements
+        vele = FiniteElement("R", vcell, 0)
+        ele = TensorProductElement(hele, vele)
+        V_coarse = FunctionSpace(mesh, ele)
+
+        # Build prolongation: interpolation from V_coarse to V
+        trial = TrialFunction(V_coarse)
+        Prol = assemble(interpolate(trial, V)).petscmat
+
+        # Set up 2-level multigrid
+        self.pc = PETSc.PC().create(comm=pc.comm)
+        self.pc.setOptionsPrefix(options_prefix + "lumped_")
+        self.pc.incrementTabLevel(1, parent=pc)
+        # Propagate the outer DM so level smoothers (e.g. ASMLinesmoothPC)
+        # can resolve the fine function space.
+        self.pc.setDM(pc.getDM())
+
+        # Enable Galerkin coarse operator: A_c = P^T A P.
+        # petsc4py has no setMGGalerkin() binding, so we go via the options DB.
+        options = PETSc.Options()
+        options[options_prefix + "lumped_pc_mg_galerkin"] = "both"
+
+        self.pc.setOperators(A, P)
+        self.pc.setType("mg")
+        self.pc.setMGLevels(2)
+        self.pc.setMGInterpolation(1, Prol)
+        self.pc.setFromOptions()
+        self.pc.setUp()
+        self.update(pc)
+
+    def update(self, pc):
+        # Firedrake reassembles the Jacobian in-place every Newton iteration;
+        # the inner PCMG holds a reference to the same Mat but needs setUp()
+        # to recompute the Galerkin coarse operator A_c = P^T A P from the
+        # updated state.
+        self.pc.setUp()
+
+    def apply(self, pc, X, Y):
+        self.pc.apply(X, Y)
+
+    def applyTranspose(self, pc, X, Y):
+        self.pc.applyTranspose(X, Y)
+
+    def destroy(self, pc):
+        if hasattr(self, "pc"):
+            self.pc.destroy()
+
+    def view(self, pc, viewer=None):
+        super().view(pc, viewer)
+        if viewer is None:
+            return
+        if viewer.getType() != PETSc.Viewer.Type.ASCII:
+            return
+        viewer.pushASCIITab()
+        viewer.printfASCII(
+            "Vertically lumped MG: collapses vertical dimension on "
+            "coarse level (cf. Kramer et al. 2010)\n"
+        )
+        self.pc.view(viewer)
+
+
+class VerticallyLumpedHMGPC(PCBase):
+    """Two-level MG with the coarse level on the fine mesh's 2D base.
+
+    Same idea as ``VerticallyLumpedPC``, but the coarse level is built on
+    the fine mesh's 2D base (via ``mesh._base_mesh``) rather than on the
+    extruded mesh with an R-element vertically. The coarse KSP descends
+    a full geometric multigrid on the 2D base ``MeshHierarchy``, giving
+    optimal complexity for very large horizontal problems.
+
+    Fine space : V         = hele x vele     (full 3D tensor-product)
+    Coarse     : V_coarse  = hele on base_2d (same horizontal element)
+
+    The prolongation V_coarse -> V is built as a composition
+    ``Prol = Q . I`` where:
+
+    * ``I`` : V_coarse -> V_R is a DOF permutation from the 2D base to a
+      3D tensor space ``V_R = hele x R`` (one value per horizontal DOF
+      replicated over the column).
+    * ``Q`` : V_R -> V is the same-mesh interpolation used by the plain
+      ``VerticallyLumpedPC``.
+
+    Requires the fine mesh's base mesh to live in a ``MeshHierarchy``; if
+    not, ``initialize`` raises ``RuntimeError``.
+    """
+
+    def initialize(self, pc):
+        options_prefix = pc.getOptionsPrefix() or ""
+        A, P = pc.getOperators()
+        V = get_function_space(pc.getDM())
+
+        # Handle both scalar and mixed spaces.
+        if len(V) == 1:
+            V = FunctionSpace(V.mesh(), V.ufl_element())
+        else:
+            V = MixedFunctionSpace([V_ for V_ in V])
+
+        mesh = V.mesh()
+
+        base_mesh = getattr(mesh, "_base_mesh", None)
+        if base_mesh is None:
+            raise RuntimeError(
+                "VerticallyLumpedHMGPC requires an extruded fine mesh "
+                "(mesh._base_mesh not found). Use VerticallyLumpedPC for "
+                "non-extruded meshes."
+            )
+
+        hierarchy, level = get_level(base_mesh)
+        if hierarchy is None or level is None:
+            raise RuntimeError(
+                "VerticallyLumpedHMGPC requires the fine mesh's base mesh "
+                "to be part of a MeshHierarchy so the coarse PCMG can "
+                "descend a geometric hierarchy. Build the mesh with "
+                "ExtrudedMeshHierarchy(MeshHierarchy(base, L), ...) with "
+                "L >= 1, or fall back to VerticallyLumpedPC."
+            )
+
+        hele, _ = V.ufl_element().factor_elements
+        V_coarse = FunctionSpace(base_mesh, hele)
+        self.V_coarse = V_coarse
+
+        # Compose the prolongation Prol = Q . I (see class docstring).
+        vcell = mesh.ufl_cell().sub_cells[1]
+        vele_R = FiniteElement("R", vcell, 0)
+        V_R = FunctionSpace(mesh, TensorProductElement(hele, vele_R))
+
+        trial_R = TrialFunction(V_R)
+        Q = assemble(interpolate(trial_R, V)).petscmat
+        I = self._build_identity_coarse_to_R(V_coarse, V_R)
+        Prol = Q.matMult(I)
+        self.Prol = Prol
+
+        # Set up the 2-level MG.
+        self.pc = PETSc.PC().create(comm=pc.comm)
+        self.pc.setOptionsPrefix(options_prefix + "lumped_")
+        self.pc.incrementTabLevel(1, parent=pc)
+        self.pc.setDM(pc.getDM())
+
+        # Galerkin coarse operator: A_c = P^T A P.
+        options = PETSc.Options()
+        options[options_prefix + "lumped_pc_mg_galerkin"] = "both"
+
+        self.pc.setOperators(A, P)
+        self.pc.setType("mg")
+        self.pc.setMGLevels(2)
+        self.pc.setMGInterpolation(1, Prol)
+
+        # Build the chain of horizontal interpolations along the base
+        # MeshHierarchy (coarsest level is 0, V_coarse is at `level`).
+        base_interp_mats = self._build_base_hierarchy_interpolations(
+            hierarchy, level, hele
+        )
+        self._base_interp_mats = base_interp_mats
+
+        # Explicit base-mesh interpolations + galerkin coarsening side-step
+        # the DM-based coarsen hook, which would require a coarsened UFL
+        # appctx we don't have.
+        if base_interp_mats:
+            coarse_ksp = self.pc.getMGCoarseSolve()
+            coarse_pc = coarse_ksp.getPC()
+            coarse_pc.setType("mg")
+            nlevels_coarse = len(base_interp_mats) + 1
+            coarse_pc.setMGLevels(nlevels_coarse)
+            for i, Pi in enumerate(base_interp_mats):
+                coarse_pc.setMGInterpolation(i + 1, Pi)
+            coarse_pc.setOptionsPrefix(
+                options_prefix + "lumped_mg_coarse_"
+            )
+            options = PETSc.Options()
+            options[options_prefix + "lumped_mg_coarse_pc_mg_galerkin"] = "both"
+
+        self.pc.setFromOptions()
+        self.pc.setUp()
+        self.update(pc)
+
+    @staticmethod
+    def _build_base_hierarchy_interpolations(hierarchy, fine_level, hele):
+        """Assemble horizontal interpolation matrices for the base MG."""
+        mats = []
+        for k in range(1, fine_level + 1):
+            mesh_c = hierarchy[k - 1]
+            mesh_f = hierarchy[k]
+            V_c = FunctionSpace(mesh_c, hele)
+            V_f = FunctionSpace(mesh_f, hele)
+            trial = TrialFunction(V_c)
+            P_k = assemble(interpolate(trial, V_f)).petscmat
+            mats.append(P_k)
+        return mats
+
+    @staticmethod
+    def _build_identity_coarse_to_R(V_coarse, V_R):
+        """Build the V_coarse -> V_R permutation matrix, parallel-safe.
+
+        ``cell_node_map().values_with_halo`` holds local DOF indices for
+        this rank (including ghost entries from halo cells). To insert
+        into a parallel PETSc Mat we translate local indices to global
+        via the ``dof_dset`` LGMap and only write rows this rank owns;
+        off-rank rows are covered by their owning rank.
+        """
+        import numpy as np
+
+        Vc_cnm = V_coarse.cell_node_map().values_with_halo
+        VR_cnm = V_R.cell_node_map().values_with_halo
+        if Vc_cnm.shape != VR_cnm.shape:
+            raise RuntimeError(
+                "VerticallyLumpedHMGPC: V_coarse and V_R cell_node_maps "
+                "have different shapes; cannot assemble identity "
+                f"prolongation (Vc={Vc_cnm.shape}, VR={VR_cnm.shape})."
+            )
+
+        n_c_owned = V_coarse.dof_dset.size
+        n_R_owned = V_R.dof_dset.size
+        if n_c_owned != n_R_owned:
+            raise RuntimeError(
+                f"VerticallyLumpedHMGPC: V_coarse owned dim ({n_c_owned}) "
+                f"does not match V_R owned dim ({n_R_owned})."
+            )
+
+        lg_R = np.asarray(V_R.dof_dset.lgmap.indices)
+        lg_c = np.asarray(V_coarse.dof_dset.lgmap.indices)
+
+        comm = V_coarse.mesh().comm
+        I = PETSc.Mat().create(comm=comm)
+        I.setSizes(((n_R_owned, None), (n_c_owned, None)))
+        I.setType("aij")
+        I.setPreallocationNNZ(1)
+
+        row_start, row_end = I.getOwnershipRange()
+
+        owned_pairs = {}
+        for c in range(Vc_cnm.shape[0]):
+            for k in range(Vc_cnm.shape[1]):
+                glob_R = int(lg_R[int(VR_cnm[c, k])])
+                glob_c = int(lg_c[int(Vc_cnm[c, k])])
+                if not (row_start <= glob_R < row_end):
+                    continue
+                prev = owned_pairs.get(glob_R)
+                if prev is None:
+                    owned_pairs[glob_R] = glob_c
+                elif prev != glob_c:
+                    raise RuntimeError(
+                        "VerticallyLumpedHMGPC: inconsistent "
+                        "coarse<->R DOF permutation at global row "
+                        f"{glob_R} (got {prev} and {glob_c})."
+                    )
+
+        for glob_R, glob_c in owned_pairs.items():
+            I.setValue(glob_R, glob_c, 1.0)
+        I.assemble()
+        return I
+
+    def update(self, pc):
+        self.pc.setUp()
+
+    def apply(self, pc, X, Y):
+        self.pc.apply(X, Y)
+
+    def applyTranspose(self, pc, X, Y):
+        self.pc.applyTranspose(X, Y)
+
+    def destroy(self, pc):
+        if hasattr(self, "pc"):
+            self.pc.destroy()
+
+    def view(self, pc, viewer=None):
+        super().view(pc, viewer)
+        if viewer is None:
+            return
+        if viewer.getType() != PETSc.Viewer.Type.ASCII:
+            return
+        viewer.pushASCIITab()
+        viewer.printfASCII(
+            "Vertically lumped MG (HMG variant): coarse level built on "
+            "the 2D base of an ExtrudedMeshHierarchy, coarse solve is "
+            "geometric MG on the base hierarchy.\n"
+        )
+        self.pc.view(viewer)

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -9,6 +9,7 @@ Includes preconditioners for:
 import firedrake as fd
 from firedrake import (
     FiniteElement,
+    Function,
     FunctionSpace,
     MixedFunctionSpace,
     PCBase,
@@ -193,14 +194,12 @@ class VerticallyLumpedHMGPC(PCBase):
     Fine space : V         = hele x vele     (full 3D tensor-product)
     Coarse     : V_coarse  = hele on base_2d (same horizontal element)
 
-    The prolongation V_coarse -> V is built as a composition
-    ``Prol = Q . I`` where:
-
-    * ``I`` : V_coarse -> V_R is a DOF permutation from the 2D base to a
-      3D tensor space ``V_R = hele x R`` (one value per horizontal DOF
-      replicated over the column).
-    * ``Q`` : V_R -> V is the same-mesh interpolation used by the plain
-      ``VerticallyLumpedPC``.
+    The prolongation V_coarse -> V is the same-mesh interpolation from the
+    vertically-constant 3D space ``V_R = hele x R`` into ``V``. No explicit
+    V_coarse -> V_R relabelling is needed: a ``hele x Real`` space and the
+    horizontal ``hele`` space on the base share an identical PETSc DOF layout,
+    so that interpolation matrix already has the right column space (see the
+    detailed note in ``initialize``).
 
     Requires the fine mesh's base mesh to live in a ``MeshHierarchy``; if
     not, ``initialize`` raises ``RuntimeError``.
@@ -241,16 +240,43 @@ class VerticallyLumpedHMGPC(PCBase):
         V_coarse = FunctionSpace(base_mesh, hele)
         self.V_coarse = V_coarse
 
-        # Compose the prolongation Prol = Q . I (see class docstring).
+        # Prolongation V_coarse (hele on the 2D base) -> V (full 3D).
+        #
+        # We build it as the same-mesh interpolation V_R -> V, where
+        # V_R = hele x Real is the vertically-constant 3D space. That matrix
+        # *is already* the prolongation we want: V_R and V_coarse share an
+        # identical PETSc layout (owned size, ownership range, and lgmap
+        # including ghost order), so no V_coarse -> V_R relabelling is needed.
+        #
+        # This is structural, not coincidental. An ExtrudedMeshTopology reuses
+        # the base mesh's topology_dm, _dm_renumbering and _entity_classes, and
+        # for a hele x Real element the section and node-class computations
+        # collapse the vertical extent away (create_section on_base=True;
+        # node_classes real_tensorproduct=True; zero dof offset), so V_R's
+        # global numbering is the same computation over the same DM as
+        # V_coarse's. Note a base<->extruded relabelling cannot be expressed as
+        # cross-mesh interpolation anyway: that requires matching geometric
+        # dimension (2D base vs 3D extruded).
         vcell = mesh.ufl_cell().sub_cells[1]
         vele_R = FiniteElement("R", vcell, 0)
         V_R = FunctionSpace(mesh, TensorProductElement(hele, vele_R))
-
-        trial_R = TrialFunction(V_R)
-        Q = assemble(interpolate(trial_R, V)).petscmat
-        I = self._build_identity_coarse_to_R(V_coarse, V_R)
-        Prol = Q.matMult(I)
+        Prol = assemble(interpolate(TrialFunction(V_R), V)).petscmat
         self.Prol = Prol
+
+        # Guard the layout assumption. If V_R and V_coarse ever stop sharing a
+        # layout, a pure size mismatch would surface later as a cryptic PETSc
+        # MatMatMult error in the galerkin setup; a same-size reordering would
+        # be worse still (a silently wrong coarse operator). Fail fast here.
+        with Function(V_coarse).dat.vec_ro as cvec:
+            coarse_owned = cvec.getLocalSize()
+        prol_cols_owned = Prol.getLocalSize()[1]
+        if coarse_owned != prol_cols_owned:
+            raise RuntimeError(
+                "VerticallyLumpedHMGPC: prolongation column layout "
+                f"({prol_cols_owned} owned) does not match the coarse space "
+                f"V_coarse ({coarse_owned} owned). The hele x Real "
+                "layout-collapse assumption has been violated."
+            )
 
         # Set up the 2-level MG.
         self.pc = PETSc.PC().create(comm=pc.comm)
@@ -308,68 +334,6 @@ class VerticallyLumpedHMGPC(PCBase):
             P_k = assemble(interpolate(trial, V_f)).petscmat
             mats.append(P_k)
         return mats
-
-    @staticmethod
-    def _build_identity_coarse_to_R(V_coarse, V_R):
-        """Build the V_coarse -> V_R permutation matrix, parallel-safe.
-
-        ``cell_node_map().values_with_halo`` holds local DOF indices for
-        this rank (including ghost entries from halo cells). To insert
-        into a parallel PETSc Mat we translate local indices to global
-        via the ``dof_dset`` LGMap and only write rows this rank owns;
-        off-rank rows are covered by their owning rank.
-        """
-        import numpy as np
-
-        Vc_cnm = V_coarse.cell_node_map().values_with_halo
-        VR_cnm = V_R.cell_node_map().values_with_halo
-        if Vc_cnm.shape != VR_cnm.shape:
-            raise RuntimeError(
-                "VerticallyLumpedHMGPC: V_coarse and V_R cell_node_maps "
-                "have different shapes; cannot assemble identity "
-                f"prolongation (Vc={Vc_cnm.shape}, VR={VR_cnm.shape})."
-            )
-
-        n_c_owned = V_coarse.dof_dset.size
-        n_R_owned = V_R.dof_dset.size
-        if n_c_owned != n_R_owned:
-            raise RuntimeError(
-                f"VerticallyLumpedHMGPC: V_coarse owned dim ({n_c_owned}) "
-                f"does not match V_R owned dim ({n_R_owned})."
-            )
-
-        lg_R = np.asarray(V_R.dof_dset.lgmap.indices)
-        lg_c = np.asarray(V_coarse.dof_dset.lgmap.indices)
-
-        comm = V_coarse.mesh().comm
-        I = PETSc.Mat().create(comm=comm)
-        I.setSizes(((n_R_owned, None), (n_c_owned, None)))
-        I.setType("aij")
-        I.setPreallocationNNZ(1)
-
-        row_start, row_end = I.getOwnershipRange()
-
-        owned_pairs = {}
-        for c in range(Vc_cnm.shape[0]):
-            for k in range(Vc_cnm.shape[1]):
-                glob_R = int(lg_R[int(VR_cnm[c, k])])
-                glob_c = int(lg_c[int(Vc_cnm[c, k])])
-                if not (row_start <= glob_R < row_end):
-                    continue
-                prev = owned_pairs.get(glob_R)
-                if prev is None:
-                    owned_pairs[glob_R] = glob_c
-                elif prev != glob_c:
-                    raise RuntimeError(
-                        "VerticallyLumpedHMGPC: inconsistent "
-                        "coarse<->R DOF permutation at global row "
-                        f"{glob_R} (got {prev} and {glob_c})."
-                    )
-
-        for glob_R, glob_c in owned_pairs.items():
-            I.setValue(glob_R, glob_c, 1.0)
-        I.assemble()
-        return I
 
     def update(self, pc):
         self.pc.setUp()

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -270,38 +270,43 @@ class _AutoRichardsonMixin:
     def _omega_apply(smoother, omega):
         """Make the smoother a Richardson iteration with this damping factor.
 
-        The options database is the only route. petsc4py has no binding for
-        KSPRichardsonSetScale. The type must go through the database as well,
-        because the preset already holds an entry for the smoother's ksp_type
-        and setFromOptions would otherwise restore it.
+        The options database is the only route, because petsc4py has no
+        binding for KSPRichardsonSetScale, and the type must go through it as
+        well, because the preset holds its own entry for the smoother's
+        ksp_type that setFromOptions would otherwise restore.
+
+        The database is global and Firedrake reuses an options prefix across
+        solver instances, so every key this method writes is removed again
+        before it returns. KSPSetFromOptions has already copied the values
+        into the KSP by then.
         """
         options = PETSc.Options()
         prefix = smoother.getOptionsPrefix() or ""
-        options[prefix + "ksp_type"] = "richardson"
-        options[prefix + "ksp_richardson_scale"] = omega
 
-        # KSPSetFromOptions also runs PCSetFromOptions. For a Python
-        # preconditioner that re-reads -pc_python_type and builds a new
-        # object, which discards everything initialize() set up. The HMG
-        # preset uses ASMLinesmoothPC on this level, so hide the key while
-        # the smoother reads its own options.
         # PCMG gives a level its own prefix, "mg_levels_1_", while a preset
         # usually writes the option against the generic "mg_levels_" prefix.
-        # Both must be hidden.
+        # Both must be hidden. Use getAll() rather than hasName(), because
+        # hasName() follows PETSc's alias and answers yes for a
+        # level-specific key that does not exist; restoring such a key would
+        # create it.
         candidates = {prefix, re.sub(r"\d+_$", "", prefix)}
-        # getAll() rather than hasName(), because hasName() follows PETSc's
-        # "mg_levels_" alias and answers yes for a level-specific key that
-        # does not exist. Restoring such a key would create it.
         present = options.getAll()
         saved = {}
         for candidate in candidates:
-            key = candidate + "pc_python_type"
-            if key in present:
-                saved[key] = present[key]
-                options.delValue(key)
+            for suffix in ("pc_python_type", "ksp_type"):
+                key = candidate + suffix
+                if key in present:
+                    saved[key] = present[key]
+                    options.delValue(key)
+
+        written = (prefix + "ksp_type", prefix + "ksp_richardson_scale")
+        options[written[0]] = "richardson"
+        options[written[1]] = omega
         try:
             smoother.setFromOptions()
         finally:
+            for key in written:
+                options.delValue(key)
             for key, value in saved.items():
                 options[key] = value
 

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -6,6 +6,8 @@ Includes preconditioners for:
 
 """
 
+import re
+
 import firedrake as fd
 from firedrake import (
     FiniteElement,
@@ -87,6 +89,253 @@ class SPDAssembledPC(fd.AssembledPC):
 # =========================================================================
 
 
+class _AutoRichardsonMixin:
+    """Derive the Richardson damping factor from the measured spectrum.
+
+    A Chebyshev smoother makes PETSc estimate the extreme eigenvalues of
+    ``B^-1 A`` on every Newton step, because Firedrake reassembles the
+    Jacobian in place and the operator state changes each time. Each estimate
+    costs ten preconditioned GMRES iterations and ten global reductions, and
+    on an extruded basin problem that is the largest single item in the setup
+    budget.
+
+    A Richardson smoother needs one number instead, the damping factor
+    ``omega``. This mixin measures it the same way PETSc does, with a short
+    GMRES run over the level smoother's own preconditioner, but it does the
+    measurement rarely instead of every Newton step.
+
+    Set ``vlumping_omega_auto`` to enable it. The fine-level smoother then
+    becomes Richardson, whatever the preset asked for, and ``omega`` follows
+    the measured spectrum.
+
+    The rule is the classical optimum of a stationary iteration over the
+    measured interval, ``omega = 2/(lmin + lmax)``. It matters that this
+    tracks both ends. The spectrum of ``B^-1 A`` is a tight cluster when the
+    mass term dominates and spreads by more than a factor of ten when the
+    stiffness term does, and the best damping factor moves by about a factor
+    of two between those regimes. ``vlumping_omega_safety`` scales the result
+    for a coarser or a more aggressive setting. The value is clamped so that
+    the iteration contracts on every measured eigenvalue, including the
+    complex ones that the gravity-advection term produces.
+
+    Two conditions re-measure the spectrum. Both must be cheap to test,
+    because the test itself runs on every Newton step.
+
+    The first condition is a change in the balance of the operator. The
+    Jacobian is about ``(C(h)/dt) M + K(h)``, so the spectrum of ``B^-1 A``
+    depends on how much of the operator lies off the diagonal. The mixin
+    tracks ``||A||_F / ||diag A||_2``, which is invariant under a rescaling
+    of the whole operator and moves when the mass term and the stiffness term
+    change their relative weight. An adaptive time step is the usual cause: a
+    ramp from 60 s to 43200 s moves lmax from 1.04 to 1.42 on the Cockett
+    box. A sharp wetting front is the other cause.
+
+    The second condition is a rise in the linear iteration count. The mixin
+    counts its own applications, which equal the outer Krylov iterations, and
+    compares the last Newton step against the count that followed the last
+    measurement. This catches a drift that the operator balance does not see.
+
+    Options, all with the outer preconditioner's prefix:
+
+    ``vlumping_omega_auto``
+        Boolean. Off by default.
+    ``vlumping_omega_safety``
+        Scale factor on the derived damping factor. Default 1.0.
+    ``vlumping_omega_esteig_steps``
+        GMRES iterations for one measurement. Default 20.
+    ``vlumping_omega_balance_ratio``
+        Re-measure when the operator balance moves by this factor in either
+        direction. Default 1.1. This condition is the early one: it fires
+        when the operator changes, before the iteration count degrades.
+    ``vlumping_omega_iter_growth``
+        Re-measure when the linear iteration count of one Newton step exceeds
+        the reference count by this factor. Default 1.5.
+    """
+
+    def _omega_initialize(self, pc):
+        """Read the options and take the first measurement."""
+        opts = PETSc.Options()
+        prefix = pc.getOptionsPrefix() or ""
+        self.omega_auto = opts.getBool(prefix + "vlumping_omega_auto", False)
+        self.omega = None
+        self._omega_applies = 0
+        self._omega_applies_seen = 0
+        self._omega_iter_reference = None
+        self._omega_balance = None
+        self._omega_estimates = 0
+        if not self.omega_auto:
+            return
+        self.omega_safety = opts.getReal(prefix + "vlumping_omega_safety", 1.0)
+        self.omega_esteig_steps = opts.getInt(
+            prefix + "vlumping_omega_esteig_steps", 20
+        )
+        self.omega_balance_ratio = opts.getReal(
+            prefix + "vlumping_omega_balance_ratio", 1.1
+        )
+        self.omega_iter_growth = opts.getReal(
+            prefix + "vlumping_omega_iter_growth", 1.5
+        )
+        self._omega_estimate(pc, "startup")
+
+    def _omega_smoother(self):
+        """The fine-level smoother of the two-level cycle."""
+        return self.pc.getMGSmoother(1)
+
+    @staticmethod
+    def _omega_operator_balance(A):
+        """Weight of the off-diagonal part, invariant under a rescaling."""
+        diag = A.createVecLeft()
+        A.getDiagonal(diag)
+        diag_norm = diag.norm()
+        diag.destroy()
+        if diag_norm == 0.0:
+            return None
+        return A.norm(PETSc.NormType.FROBENIUS) / diag_norm
+
+    def _omega_estimate(self, pc, reason):
+        """Measure the spectrum once and set the damping factor from it."""
+        smoother = self._omega_smoother()
+        A, _ = smoother.getOperators()
+
+        # Mirror KSPSetUp_Chebyshev: a short GMRES run over the smoother's own
+        # preconditioner, with a random right-hand side. The estimator borrows
+        # the preconditioner and never owns it, so it must not set operators
+        # of its own. A KSP reads its operators from its PC.
+        est = PETSc.KSP().create(comm=pc.comm)
+        est.setType(PETSc.KSP.Type.GMRES)
+        est.setComputeEigenvalues(True)
+        est.setTolerances(rtol=1e-12, max_it=self.omega_esteig_steps)
+        est.setPC(smoother.getPC())
+        b = A.createVecLeft()
+        x = A.createVecLeft()
+        b.setRandom()
+        est.solve(b, x)
+        eigenvalues = est.computeEigenvalues()
+        est.destroy()
+        b.destroy()
+        x.destroy()
+
+        self._omega_estimates += 1
+        self._omega_balance = self._omega_operator_balance(A)
+        self._omega_iter_reference = None
+
+        if eigenvalues.size == 0:
+            PETSc.Sys.Print(
+                "VLumping omega: the estimator returned no eigenvalues, "
+                "keeping the previous damping factor"
+            )
+            return
+
+        real = eigenvalues.real
+        lmax = float(real.max())
+        if lmax <= 0.0:
+            PETSc.Sys.Print(
+                "VLumping omega: the measured spectrum has no positive real "
+                "part, keeping the previous damping factor"
+            )
+            return
+
+        # Classical optimum of a stationary iteration over the measured
+        # interval. A short Arnoldi run resolves the top of the spectrum well
+        # and the bottom badly, so fall back to PETSc's own assumption,
+        # lmin = 0.1 lmax, when the measured lower end is not positive.
+        lmin = float(real.min())
+        if lmin <= 0.0:
+            lmin = 0.1 * lmax
+        omega = self.omega_safety * 2.0 / (lmin + lmax)
+
+        # Richardson contracts while |1 - omega * lambda| < 1, which is a disk
+        # rather than an interval. For one eigenvalue that bounds omega by
+        # 2 Re(lambda) / |lambda|^2. Take the tightest bound over the measured
+        # spectrum and keep a margin, which matters only when the
+        # gravity-advection term makes the spectrum complex.
+        bounds = [
+            2.0 * e.real / abs(e) ** 2
+            for e in eigenvalues
+            if e.real > 0.0 and abs(e) > 0.0
+        ]
+        if bounds:
+            omega = min(omega, 0.95 * min(bounds))
+
+        self.omega = omega
+        self._omega_apply(smoother, omega)
+
+        PETSc.Sys.Print(
+            f"VLumping omega: measurement {self._omega_estimates} ({reason}), "
+            f"spectrum = [{lmin:.4f}, {lmax:.4f}], omega = {omega:.4f}, "
+            f"balance = {self._omega_balance:.4f}"
+        )
+
+    @staticmethod
+    def _omega_apply(smoother, omega):
+        """Make the smoother a Richardson iteration with this damping factor.
+
+        The options database is the only route. petsc4py has no binding for
+        KSPRichardsonSetScale. The type must go through the database as well,
+        because the preset already holds an entry for the smoother's ksp_type
+        and setFromOptions would otherwise restore it.
+        """
+        options = PETSc.Options()
+        prefix = smoother.getOptionsPrefix() or ""
+        options[prefix + "ksp_type"] = "richardson"
+        options[prefix + "ksp_richardson_scale"] = omega
+
+        # KSPSetFromOptions also runs PCSetFromOptions. For a Python
+        # preconditioner that re-reads -pc_python_type and builds a new
+        # object, which discards everything initialize() set up. The HMG
+        # preset uses ASMLinesmoothPC on this level, so hide the key while
+        # the smoother reads its own options.
+        # PCMG gives a level its own prefix, "mg_levels_1_", while a preset
+        # usually writes the option against the generic "mg_levels_" prefix.
+        # Both must be hidden.
+        candidates = {prefix, re.sub(r"\d+_$", "", prefix)}
+        # getAll() rather than hasName(), because hasName() follows PETSc's
+        # "mg_levels_" alias and answers yes for a level-specific key that
+        # does not exist. Restoring such a key would create it.
+        present = options.getAll()
+        saved = {}
+        for candidate in candidates:
+            key = candidate + "pc_python_type"
+            if key in present:
+                saved[key] = present[key]
+                options.delValue(key)
+        try:
+            smoother.setFromOptions()
+        finally:
+            for key, value in saved.items():
+                options[key] = value
+
+    def _omega_update(self, pc):
+        """Re-measure when the operator balance or the iteration count moves."""
+        if not self.omega_auto:
+            return
+
+        iterations = self._omega_applies - self._omega_applies_seen
+        self._omega_applies_seen = self._omega_applies
+
+        reason = None
+        balance = self._omega_operator_balance(self._omega_smoother().getOperators()[0])
+        if balance is not None and self._omega_balance:
+            ratio = balance / self._omega_balance
+            if ratio > self.omega_balance_ratio or ratio < 1.0 / self.omega_balance_ratio:
+                reason = f"operator balance moved by {ratio:.2f}"
+
+        if reason is None and iterations > 0:
+            if self._omega_iter_reference is None:
+                self._omega_iter_reference = iterations
+            elif iterations > self.omega_iter_growth * self._omega_iter_reference:
+                reason = (
+                    f"linear iterations rose from {self._omega_iter_reference} "
+                    f"to {iterations}"
+                )
+
+        if reason is not None:
+            self._omega_estimate(pc, reason)
+
+    def _omega_count_apply(self):
+        self._omega_applies += 1
+
+
 class _LaggedOperatorMixin:
     """Hold a private snapshot of the operator for the inner multigrid.
 
@@ -114,12 +363,24 @@ class _LaggedOperatorMixin:
     Set the lag with the integer option ``<prefix>vlumping_lag``. The default
     is 1, which refreshes on every Newton step and reproduces the unlagged
     behaviour exactly. The snapshot costs one extra copy of the Jacobian.
+
+    The boolean option ``<prefix>vlumping_lag_smoother`` decides whether the
+    fine smoother reads the snapshot as well. The default is on, which is the
+    coherent setting described above. Turn it off and the smoother keeps the
+    live Jacobian, so the multigrid cycle approximates the inverse of the
+    current operator with a stale smoother. On the cases measured so far that
+    is faster, about 17% against 9%, and it costs no extra iterations. It is
+    not the default because it evaluates ``B_old^-1 A_live``, which has no
+    guarantee of contraction once a front moves the spectrum.
     """
 
     def _lag_initialize(self, pc, P):
         """Read the lag option and bind the inner PC to the snapshot."""
         prefix = pc.getOptionsPrefix() or ""
         self.lag = PETSc.Options().getInt(prefix + "vlumping_lag", 1)
+        self.lag_smoother = PETSc.Options().getBool(
+            prefix + "vlumping_lag_smoother", True
+        )
         self._nupdate = 0
         if self.lag <= 1:
             self._Alag = None
@@ -131,6 +392,22 @@ class _LaggedOperatorMixin:
         # state of Amat and of Pmat, so a live Amat re-triggers the estimate
         # and defeats the lag.
         self.pc.setOperators(self._Alag, self._Alag)
+
+        # The fine smoother needs the snapshot as well, and it needs it
+        # explicitly. PCSetUp_MG binds the operators of the finest smoother
+        # only while they still match the operators of the PC
+        # (src/ksp/pc/impls/mg/mg.c:888-892). The first setup bound them to
+        # the live Jacobian, so the guard is now false and the smoother would
+        # keep the live operator for the whole run. It would then evaluate
+        # B_old^-1 A_live, which is the combination that loses the guarantee
+        # of contraction during a sharp front.
+        #
+        # The multigrid residual callback cannot be corrected the same way.
+        # PCMGSetResidual takes a permanent reference on the first setup
+        # (mgfunc.c:151-156) and petsc4py has no binding for it, so the
+        # mid-cycle residual keeps the live operator.
+        if self.lag_smoother:
+            self.pc.getMGSmoother(1).setOperators(self._Alag, self._Alag)
 
     def _lag_update(self, pc):
         """Refresh the snapshot when the lag interval is complete."""
@@ -149,7 +426,7 @@ class _LaggedOperatorMixin:
             self._Alag = None
 
 
-class VerticallyLumpedPC(_LaggedOperatorMixin, PCBase):
+class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
     """Two-level MG that collapses the vertical dimension on the coarse level.
 
     This preconditioner targets extruded meshes of high aspect ratio. It
@@ -237,6 +514,9 @@ class VerticallyLumpedPC(_LaggedOperatorMixin, PCBase):
         # This runs after the first setUp, so the multigrid residual callback
         # keeps the live operator. See _LaggedOperatorMixin.
         self._lag_initialize(pc, P)
+        # Derive the Richardson damping factor when the user asks for it. The
+        # first measurement needs a preconditioner that is already set up.
+        self._omega_initialize(pc)
         self.update(pc)
 
     def update(self, pc):
@@ -245,9 +525,11 @@ class VerticallyLumpedPC(_LaggedOperatorMixin, PCBase):
         # setUp() to recompute the Galerkin coarse operator A_c = P^T A P from
         # the updated state.
         self._lag_update(pc)
+        self._omega_update(pc)
         self.pc.setUp()
 
     def apply(self, pc, X, Y):
+        self._omega_count_apply()
         self.pc.apply(X, Y)
 
     def applyTranspose(self, pc, X, Y):
@@ -272,7 +554,7 @@ class VerticallyLumpedPC(_LaggedOperatorMixin, PCBase):
         self.pc.view(viewer)
 
 
-class VerticallyLumpedHMGPC(_LaggedOperatorMixin, PCBase):
+class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
     """Two-level MG with the coarse level on the fine mesh's 2D base.
 
     This preconditioner uses the same two levels as ``VerticallyLumpedPC``.
@@ -424,6 +706,7 @@ class VerticallyLumpedHMGPC(_LaggedOperatorMixin, PCBase):
         self.pc.setFromOptions()
         self.pc.setUp()
         self._lag_initialize(pc, P)
+        self._omega_initialize(pc)
         self.update(pc)
 
     @staticmethod
@@ -441,9 +724,11 @@ class VerticallyLumpedHMGPC(_LaggedOperatorMixin, PCBase):
 
     def update(self, pc):
         self._lag_update(pc)
+        self._omega_update(pc)
         self.pc.setUp()
 
     def apply(self, pc, X, Y):
+        self._omega_count_apply()
         self.pc.apply(X, Y)
 
     def applyTranspose(self, pc, X, Y):

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -383,45 +383,37 @@ class _AutoRichardsonMixin:
         self._omega_applies_seen = self._omega_applies
         self._omega_since_estimate += 1
 
-        # Under a lag the smoother reads a snapshot that changes only on a
-        # refresh step. Between refreshes the operator is identical, so a
-        # measurement would return what it returned last time. Check only on
-        # the steps where the snapshot moves.
-        lagged = getattr(self, "_Alag", None) is not None
-        refreshed = (not lagged) or self._nupdate % self.lag == 0
-
         reason = None
-        if refreshed:
-            diagonal = self._omega_diagonal_norm(
-                self._omega_smoother().getOperators()[0]
-            )
-            if self._omega_diagonal:
-                ratio = diagonal / self._omega_diagonal
-                if (ratio > self.omega_diagonal_ratio
-                        or ratio < 1.0 / self.omega_diagonal_ratio):
-                    reason = f"the diagonal moved by {ratio:.2f}"
+        diagonal = self._omega_diagonal_norm(
+            self._omega_smoother().getOperators()[0]
+        )
+        if self._omega_diagonal:
+            ratio = diagonal / self._omega_diagonal
+            if (ratio > self.omega_diagonal_ratio
+                    or ratio < 1.0 / self.omega_diagonal_ratio):
+                reason = f"the diagonal moved by {ratio:.2f}"
 
-            if reason is None and iterations > 0:
-                if len(self._omega_iter_samples) < self.omega_iter_window:
-                    # Establish the reference over several Newton steps. The
-                    # first step of a timestep is systematically cheaper than
-                    # the rest, so one sample makes the threshold trip on
-                    # ordinary variation.
-                    self._omega_iter_samples.append(iterations)
-                    ordered = sorted(self._omega_iter_samples)
-                    self._omega_iter_reference = ordered[len(ordered) // 2]
-                elif iterations > self.omega_iter_growth * self._omega_iter_reference:
-                    reason = (
-                        f"linear iterations rose from a reference of "
-                        f"{self._omega_iter_reference} to {iterations}"
-                    )
-
-            if (reason is None and self.omega_interval > 0
-                    and self._omega_since_estimate >= self.omega_interval):
+        if reason is None and iterations > 0:
+            if len(self._omega_iter_samples) < self.omega_iter_window:
+                # Establish the reference over several Newton steps. The
+                # first step of a timestep is systematically cheaper than
+                # the rest, so one sample makes the threshold trip on
+                # ordinary variation.
+                self._omega_iter_samples.append(iterations)
+                ordered = sorted(self._omega_iter_samples)
+                self._omega_iter_reference = ordered[len(ordered) // 2]
+            elif iterations > self.omega_iter_growth * self._omega_iter_reference:
                 reason = (
-                    f"{self._omega_since_estimate} Newton steps since the "
-                    f"last measurement"
+                    f"linear iterations rose from a reference of "
+                    f"{self._omega_iter_reference} to {iterations}"
                 )
+
+        if (reason is None and self.omega_interval > 0
+                and self._omega_since_estimate >= self.omega_interval):
+            reason = (
+                f"{self._omega_since_estimate} Newton steps since the "
+                f"last measurement"
+            )
 
         if reason is not None:
             self._omega_estimate(pc, reason)
@@ -430,97 +422,7 @@ class _AutoRichardsonMixin:
         self._omega_applies += 1
 
 
-class _LaggedOperatorMixin:
-    """Hold a private snapshot of the operator for the inner multigrid.
-
-    Firedrake reassembles the Jacobian in place on every Newton step, so the
-    PETSc object state of the operator changes every time. The inner PCMG
-    reacts to that change with a full setup: the Galerkin product P^T A P, the
-    coarse factorisation, and the eigenvalue estimate of a Chebyshev smoother.
-    For an extruded 3-D problem that setup cost dominates the solve.
-
-    This mixin gives the inner PCMG a private copy of the operator and
-    refreshes the copy every ``lag`` Newton steps. Between two refreshes the
-    object state does not change, so PETSc skips the complete setup. The outer
-    Krylov method keeps the true Jacobian for its residual, therefore the
-    accuracy of the Newton step does not change. Only the preconditioner is
-    stale.
-
-    The snapshot is necessary. A lag that leaves the live Jacobian visible to
-    the smoother makes the smoother evaluate B_old^-1 A_live. A polynomial or
-    stationary smoother contracts only on a bounded region, and modes that
-    leave that region during a sharp wetting front make the multigrid cycle
-    expansive. With the snapshot the smoother evaluates B_old^-1 A_old, which
-    is inside the region by construction, and the drift reaches the outer
-    Krylov method as a benign near-identity perturbation.
-
-    Set the lag with the integer option ``<prefix>vlumping_lag``. The default
-    is 1, which refreshes on every Newton step and reproduces the unlagged
-    behaviour exactly. The snapshot costs one extra copy of the Jacobian.
-
-    The boolean option ``<prefix>vlumping_lag_smoother`` decides whether the
-    fine smoother reads the snapshot as well. The default is on, which is the
-    coherent setting described above. Turn it off and the smoother keeps the
-    live Jacobian, so the multigrid cycle approximates the inverse of the
-    current operator with a stale smoother. On the cases measured so far that
-    is faster, about 17% against 9%, and it costs no extra iterations. It is
-    not the default because it evaluates ``B_old^-1 A_live``, which has no
-    guarantee of contraction once a front moves the spectrum.
-    """
-
-    def _lag_initialize(self, pc, P):
-        """Read the lag option and bind the inner PC to the snapshot."""
-        prefix = pc.getOptionsPrefix() or ""
-        self.lag = PETSc.Options().getInt(prefix + "vlumping_lag", 1)
-        self.lag_smoother = PETSc.Options().getBool(
-            prefix + "vlumping_lag_smoother", True
-        )
-        self._nupdate = 0
-        if self.lag <= 1:
-            self._Alag = None
-            return
-
-        # Copy the values now, because the first solve uses this matrix.
-        self._Alag = P.duplicate(copy=True)
-        # Both arguments must be the snapshot. KSPSetUp_Chebyshev compares the
-        # state of Amat and of Pmat, so a live Amat re-triggers the estimate
-        # and defeats the lag.
-        self.pc.setOperators(self._Alag, self._Alag)
-
-        # The fine smoother needs the snapshot as well, and it needs it
-        # explicitly. PCSetUp_MG binds the operators of the finest smoother
-        # only while they still match the operators of the PC
-        # (src/ksp/pc/impls/mg/mg.c:888-892). The first setup bound them to
-        # the live Jacobian, so the guard is now false and the smoother would
-        # keep the live operator for the whole run. It would then evaluate
-        # B_old^-1 A_live, which is the combination that loses the guarantee
-        # of contraction during a sharp front.
-        #
-        # The multigrid residual callback cannot be corrected the same way.
-        # PCMGSetResidual takes a permanent reference on the first setup
-        # (mgfunc.c:151-156) and petsc4py has no binding for it, so the
-        # mid-cycle residual keeps the live operator.
-        if self.lag_smoother:
-            self.pc.getMGSmoother(1).setOperators(self._Alag, self._Alag)
-
-    def _lag_update(self, pc):
-        """Refresh the snapshot when the lag interval is complete."""
-        if self._Alag is None:
-            return
-        self._nupdate += 1
-        if self._nupdate % self.lag == 0:
-            _, P = pc.getOperators()
-            # MatCopy increases the object state, so the inner PCMG runs a
-            # complete setup on this step and skips it on the others.
-            P.copy(self._Alag, structure=PETSc.Mat.Structure.SAME_NONZERO_PATTERN)
-
-    def _lag_destroy(self):
-        if getattr(self, "_Alag", None) is not None:
-            self._Alag.destroy()
-            self._Alag = None
-
-
-class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
+class VerticallyLumpedPC(_AutoRichardsonMixin, PCBase):
     """Two-level MG that collapses the vertical dimension on the coarse level.
 
     This preconditioner targets extruded meshes of high aspect ratio. It
@@ -538,10 +440,6 @@ class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
 
     Solver options for the coarse level use the prefix ``lumped_mg_coarse_``.
     The fine-level smoother uses ``lumped_mg_levels_``.
-
-    The integer option ``vlumping_lag`` rebuilds the preconditioner every N
-    Newton steps against a private snapshot of the Jacobian. The default is 1,
-    which rebuilds on every step. See ``_LaggedOperatorMixin``.
 
     The fine space must be a scalar tensor-product space on an extruded mesh.
     """
@@ -604,10 +502,6 @@ class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         self.pc.setMGInterpolation(1, Prol)
         self.pc.setFromOptions()
         self.pc.setUp()
-        # Bind the inner PCMG to a lagged snapshot when the user asks for one.
-        # This runs after the first setUp, so the multigrid residual callback
-        # keeps the live operator. See _LaggedOperatorMixin.
-        self._lag_initialize(pc, P)
         # Derive the Richardson damping factor when the user asks for it. The
         # first measurement needs a preconditioner that is already set up.
         self._omega_initialize(pc)
@@ -618,7 +512,6 @@ class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         # The inner PCMG holds a reference to the same Mat. It still needs
         # setUp() to recompute the Galerkin coarse operator A_c = P^T A P from
         # the updated state.
-        self._lag_update(pc)
         self._omega_update(pc)
         self.pc.setUp()
 
@@ -630,7 +523,6 @@ class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         self.pc.applyTranspose(X, Y)
 
     def destroy(self, pc):
-        self._lag_destroy()
         if hasattr(self, "pc"):
             self.pc.destroy()
 
@@ -648,7 +540,7 @@ class VerticallyLumpedPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         self.pc.view(viewer)
 
 
-class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
+class VerticallyLumpedHMGPC(_AutoRichardsonMixin, PCBase):
     """Two-level MG with the coarse level on the fine mesh's 2D base.
 
     This preconditioner uses the same two levels as ``VerticallyLumpedPC``.
@@ -663,9 +555,6 @@ class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
 
     Fine space : V          = hele x vele      (full 3D tensor-product)
     Coarse     : V_base_2d  = hele on base_2d  (same horizontal element)
-
-    The integer option ``vlumping_lag`` applies here as well. See
-    ``_LaggedOperatorMixin``.
 
     The prolongation from ``V_base_2d`` into ``V`` is the same-mesh
     interpolation from the vertically constant 3D space ``V_R = hele x R``
@@ -799,7 +688,6 @@ class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
 
         self.pc.setFromOptions()
         self.pc.setUp()
-        self._lag_initialize(pc, P)
         self._omega_initialize(pc)
         self.update(pc)
 
@@ -817,7 +705,6 @@ class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         return mats
 
     def update(self, pc):
-        self._lag_update(pc)
         self._omega_update(pc)
         self.pc.setUp()
 
@@ -829,7 +716,6 @@ class VerticallyLumpedHMGPC(_AutoRichardsonMixin, _LaggedOperatorMixin, PCBase):
         self.pc.applyTranspose(X, Y)
 
     def destroy(self, pc):
-        self._lag_destroy()
         if hasattr(self, "pc"):
             self.pc.destroy()
 

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -148,17 +148,24 @@ class _AutoRichardsonMixin:
     fires before the iteration count degrades, which the second cannot.
 
     The second is a rise in the linear iteration count. The reference is the
-    median over the first few Newton steps after a measurement, not a single
-    step, because the first Newton step of a timestep is systematically
-    cheaper than the rest and a single sample makes the threshold trip on
-    ordinary variation. Under a lag this condition is checked only on the
-    steps where the snapshot refreshes: between refreshes a rise in the
-    iteration count comes from the staleness of the snapshot, and
-    re-measuring an operator that has not changed cannot help.
+    upper median over the first few checked steps after a measurement, not a
+    single step, because the first Newton step of a timestep is
+    systematically cheaper than the rest and one sample makes the threshold
+    trip on ordinary variation. The reference is only as good as the steps
+    that establish it: a window that fills during a genuine degradation
+    raises the threshold and blinds the condition until the next measurement.
 
     The third is a plain interval. It exists because the first two conditions
     detect a change in one quantity each, and neither is guaranteed to notice
     a slow drift in something else. It is a backstop, so its default is long.
+
+    When a lag is in use, all three are checked only on the steps where the
+    snapshot refreshes. Between refreshes the operator the smoother reads is
+    identical, so a measurement returns what it returned last time. One
+    consequence is that both the reference and the value tested against it
+    are then the iteration counts of the steps with the stalest snapshot.
+    That is self-consistent, but it means the condition responds to staleness
+    and to spectral drift together rather than to drift alone.
 
     Options, all with the outer preconditioner's prefix:
 
@@ -297,6 +304,19 @@ class _AutoRichardsonMixin:
             for e in eigenvalues
             if e.real > 0.0 and abs(e) > 0.0
         ]
+        # An eigenvalue with a non-positive real part cannot be contracted by
+        # any positive damping factor, because |1 - omega*lambda| > 1 for
+        # every omega > 0. Dropping it from the bound is all this rule can
+        # do, so say so: the smoother amplifies that mode and the only
+        # symptom is a rise in the outer iteration count.
+        dropped = int((real <= 0.0).sum())
+        if dropped:
+            PETSc.Sys.Print(
+                f"VLumping omega: {dropped} of {eigenvalues.size} measured "
+                "eigenvalues have a non-positive real part. No damping factor "
+                "contracts those modes, and the outer Krylov method must "
+                "resolve them."
+            )
         limit = self.omega_margin * min(bounds) if bounds else optimum
         omega = self.omega_safety * min(optimum, limit)
         binding = "stability" if limit < optimum else "optimum"
@@ -396,9 +416,12 @@ class _AutoRichardsonMixin:
                         f"{self._omega_iter_reference} to {iterations}"
                     )
 
-        if (reason is None and self.omega_interval > 0
-                and self._omega_since_estimate >= self.omega_interval):
-            reason = f"{self._omega_since_estimate} Newton steps since the last measurement"
+            if (reason is None and self.omega_interval > 0
+                    and self._omega_since_estimate >= self.omega_interval):
+                reason = (
+                    f"{self._omega_since_estimate} Newton steps since the "
+                    f"last measurement"
+                )
 
         if reason is not None:
             self._omega_estimate(pc, reason)

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -11,7 +11,6 @@ from firedrake import (
     FiniteElement,
     Function,
     FunctionSpace,
-    MixedFunctionSpace,
     PCBase,
     TensorProductElement,
     TrialFunction,
@@ -91,20 +90,23 @@ class SPDAssembledPC(fd.AssembledPC):
 class VerticallyLumpedPC(PCBase):
     """Two-level MG that collapses the vertical dimension on the coarse level.
 
-    A preconditioner specifically designed for high-aspect-ratio extruded
-    meshes, inspired by Kramer et al. (2010, doi:10.1016/j.ocemod.2010.08.001)
-    and the ocean modelling community. The idea:
+    This preconditioner targets extruded meshes of high aspect ratio. It
+    follows Kramer et al. (2010, doi:10.1016/j.ocemod.2010.08.001) and the
+    ocean modelling community. It uses two levels:
 
         Fine level   : V = V_horiz x V_vert  (full 3D tensor-product space)
-        Coarse level : V_c = V_horiz x R     (vertically constant)
+        Coarse level : V_lumped = V_horiz x R  (vertically constant)
 
-    The prolongation P is the natural injection from V_c into V (a coarse
-    DOF is replicated along its column). The coarse operator is formed by
-    Galerkin projection, A_c = P^T A P, collapsing the entire vertical
-    dimension onto a 2D-like problem solvable cheaply with MUMPS or GAMG.
+    The prolongation P is the natural injection from V_lumped into V, which
+    replicates a coarse DOF along its column. Galerkin projection then forms
+    the coarse operator A_c = P^T A P. That projection collapses the whole
+    vertical dimension onto a 2D-like problem, which MUMPS or GAMG solves
+    cheaply.
 
-    Solver options for the coarse level use the prefix ``lumped_mg_coarse_``
-    and the fine-level smoother uses ``lumped_mg_levels_``.
+    Solver options for the coarse level use the prefix ``lumped_mg_coarse_``.
+    The fine-level smoother uses ``lumped_mg_levels_``.
+
+    The fine space must be a scalar tensor-product space on an extruded mesh.
     """
 
     def initialize(self, pc):
@@ -112,34 +114,50 @@ class VerticallyLumpedPC(PCBase):
         A, P = pc.getOperators()
         V = get_function_space(pc.getDM())
 
-        # Handle both scalar and mixed spaces
-        if len(V) == 1:
-            V = FunctionSpace(V.mesh(), V.ufl_element())
-        else:
-            V = MixedFunctionSpace([V_ for V_ in V])
+        # A mixed space has no factor_elements, so the lumped space below cannot
+        # be built for one. Reject it here with a clear message.
+        if len(V) != 1:
+            raise RuntimeError(
+                "VerticallyLumpedPC needs a scalar function space. It received "
+                f"a mixed space with {len(V)} components. Apply the "
+                "preconditioner to a single field, through a fieldsplit."
+            )
 
-        # Build vertically constant function space (V_horiz x R)
         mesh = V.mesh()
-        _, vcell = mesh.ufl_cell().sub_cells
-        hele, _ = V.ufl_element().factor_elements
+
+        # An extruded mesh has a tensor-product cell, so its ufl_cell has
+        # sub_cells and its element has factor_elements. A non-extruded mesh has
+        # neither, and both lookups raise AttributeError.
+        try:
+            _, vcell = mesh.ufl_cell().sub_cells
+            hele, _ = V.ufl_element().factor_elements
+        except AttributeError as exc:
+            raise RuntimeError(
+                "VerticallyLumpedPC needs an extruded mesh and a "
+                "tensor-product element. It received a space on "
+                f"{mesh.ufl_cell()}. Build the mesh with ExtrudedMesh, or use "
+                "a different preconditioner."
+            ) from exc
+
+        # Vertically constant space V_lumped = V_horiz x R.
         vele = FiniteElement("R", vcell, 0)
         ele = TensorProductElement(hele, vele)
-        V_coarse = FunctionSpace(mesh, ele)
+        V_lumped = FunctionSpace(mesh, ele)
 
-        # Build prolongation: interpolation from V_coarse to V
-        trial = TrialFunction(V_coarse)
+        # Prolongation: interpolation from V_lumped to V.
+        trial = TrialFunction(V_lumped)
         Prol = assemble(interpolate(trial, V)).petscmat
 
-        # Set up 2-level multigrid
+        # Configure the 2-level multigrid.
         self.pc = PETSc.PC().create(comm=pc.comm)
         self.pc.setOptionsPrefix(options_prefix + "lumped_")
         self.pc.incrementTabLevel(1, parent=pc)
-        # Propagate the outer DM so level smoothers (e.g. ASMLinesmoothPC)
-        # can resolve the fine function space.
+        # Propagate the outer DM so that level smoothers, for example
+        # ASMLinesmoothPC, can resolve the fine function space.
         self.pc.setDM(pc.getDM())
 
-        # Enable Galerkin coarse operator: A_c = P^T A P.
-        # petsc4py has no setMGGalerkin() binding, so we go via the options DB.
+        # Enable the Galerkin coarse operator A_c = P^T A P. petsc4py has no
+        # setMGGalerkin() binding, so we use the options database instead.
         options = PETSc.Options()
         options[options_prefix + "lumped_pc_mg_galerkin"] = "both"
 
@@ -152,10 +170,10 @@ class VerticallyLumpedPC(PCBase):
         self.update(pc)
 
     def update(self, pc):
-        # Firedrake reassembles the Jacobian in-place every Newton iteration;
-        # the inner PCMG holds a reference to the same Mat but needs setUp()
-        # to recompute the Galerkin coarse operator A_c = P^T A P from the
-        # updated state.
+        # Firedrake reassembles the Jacobian in place on every Newton iteration.
+        # The inner PCMG holds a reference to the same Mat. It still needs
+        # setUp() to recompute the Galerkin coarse operator A_c = P^T A P from
+        # the updated state.
         self.pc.setUp()
 
     def apply(self, pc, X, Y):
@@ -176,8 +194,8 @@ class VerticallyLumpedPC(PCBase):
             return
         viewer.pushASCIITab()
         viewer.printfASCII(
-            "Vertically lumped MG: collapses vertical dimension on "
-            "coarse level (cf. Kramer et al. 2010)\n"
+            "Vertically lumped MG: collapses the vertical dimension on the "
+            "coarse level (see Kramer et al. 2010)\n"
         )
         self.pc.view(viewer)
 
@@ -185,24 +203,28 @@ class VerticallyLumpedPC(PCBase):
 class VerticallyLumpedHMGPC(PCBase):
     """Two-level MG with the coarse level on the fine mesh's 2D base.
 
-    Same idea as ``VerticallyLumpedPC``, but the coarse level is built on
-    the fine mesh's 2D base (via ``mesh._base_mesh``) rather than on the
-    extruded mesh with an R-element vertically. The coarse KSP descends
-    a full geometric multigrid on the 2D base ``MeshHierarchy``, giving
-    optimal complexity for very large horizontal problems.
+    This preconditioner uses the same two levels as ``VerticallyLumpedPC``.
+    It builds the coarse level on the 2D base of the fine mesh, through
+    ``mesh._base_mesh``, instead of on the extruded mesh with a vertical
+    R-element. The coarse KSP then descends a geometric multigrid on the 2D
+    base ``MeshHierarchy``, which gives optimal complexity for large
+    horizontal problems.
 
-    Fine space : V         = hele x vele     (full 3D tensor-product)
-    Coarse     : V_coarse  = hele on base_2d (same horizontal element)
+    Note that "coarse" here means coarse relative to the 3D fine space. The
+    base mesh ``V_base_2d`` sits at the *finest* level of the base hierarchy.
 
-    The prolongation V_coarse -> V is the same-mesh interpolation from the
-    vertically-constant 3D space ``V_R = hele x R`` into ``V``. No explicit
-    V_coarse -> V_R relabelling is needed: a ``hele x Real`` space and the
-    horizontal ``hele`` space on the base share an identical PETSc DOF layout,
-    so that interpolation matrix already has the right column space (see the
-    detailed note in ``initialize``).
+    Fine space : V          = hele x vele      (full 3D tensor-product)
+    Coarse     : V_base_2d  = hele on base_2d  (same horizontal element)
 
-    Requires the fine mesh's base mesh to live in a ``MeshHierarchy``; if
-    not, ``initialize`` raises ``RuntimeError``.
+    The prolongation from ``V_base_2d`` into ``V`` is the same-mesh
+    interpolation from the vertically constant 3D space ``V_R = hele x R``
+    into ``V``. That matrix needs no relabelling. A ``hele x Real`` space and
+    the horizontal ``hele`` space on the base share one PETSc DOF layout, so
+    the matrix already has the right column space. The note in ``initialize``
+    gives the reason.
+
+    The base mesh of the fine mesh must live in a ``MeshHierarchy``. If it
+    does not, ``initialize`` raises ``RuntimeError``.
     """
 
     def initialize(self, pc):
@@ -210,75 +232,82 @@ class VerticallyLumpedHMGPC(PCBase):
         A, P = pc.getOperators()
         V = get_function_space(pc.getDM())
 
-        # Handle both scalar and mixed spaces.
-        if len(V) == 1:
-            V = FunctionSpace(V.mesh(), V.ufl_element())
-        else:
-            V = MixedFunctionSpace([V_ for V_ in V])
+        # A mixed space has no factor_elements, so the spaces below cannot be
+        # built for one. Reject it here with a clear message.
+        if len(V) != 1:
+            raise RuntimeError(
+                "VerticallyLumpedHMGPC needs a scalar function space. It "
+                f"received a mixed space with {len(V)} components. Apply the "
+                "preconditioner to a single field, through a fieldsplit."
+            )
 
         mesh = V.mesh()
 
         base_mesh = getattr(mesh, "_base_mesh", None)
         if base_mesh is None:
             raise RuntimeError(
-                "VerticallyLumpedHMGPC requires an extruded fine mesh "
-                "(mesh._base_mesh not found). Use VerticallyLumpedPC for "
-                "non-extruded meshes."
+                "VerticallyLumpedHMGPC needs an extruded fine mesh. This mesh "
+                "has no _base_mesh. Use VerticallyLumpedPC for a non-extruded "
+                "mesh."
             )
 
         hierarchy, level = get_level(base_mesh)
         if hierarchy is None or level is None:
             raise RuntimeError(
-                "VerticallyLumpedHMGPC requires the fine mesh's base mesh "
-                "to be part of a MeshHierarchy so the coarse PCMG can "
-                "descend a geometric hierarchy. Build the mesh with "
-                "ExtrudedMeshHierarchy(MeshHierarchy(base, L), ...) with "
-                "L >= 1, or fall back to VerticallyLumpedPC."
+                "VerticallyLumpedHMGPC needs the 2D base mesh of the fine mesh "
+                "to be part of a MeshHierarchy. The coarse PCMG descends that "
+                "hierarchy. Build the mesh with "
+                "ExtrudedMeshHierarchy(MeshHierarchy(base, L), ...) and L >= 1, "
+                "or use VerticallyLumpedPC instead."
             )
 
         hele, _ = V.ufl_element().factor_elements
-        V_coarse = FunctionSpace(base_mesh, hele)
-        self.V_coarse = V_coarse
+        # V_base_2d is coarse relative to the 3D fine space V. Within the base
+        # hierarchy it is the finest level, at index `level`.
+        V_base_2d = FunctionSpace(base_mesh, hele)
+        self.V_base_2d = V_base_2d
 
-        # Prolongation V_coarse (hele on the 2D base) -> V (full 3D).
+        # Prolongation from V_base_2d (hele on the 2D base) into V (full 3D).
         #
-        # We build it as the same-mesh interpolation V_R -> V, where
-        # V_R = hele x Real is the vertically-constant 3D space. That matrix
-        # *is already* the prolongation we want: V_R and V_coarse share an
-        # identical PETSc layout (owned size, ownership range, and lgmap
-        # including ghost order), so no V_coarse -> V_R relabelling is needed.
+        # We build it as the same-mesh interpolation from V_R into V, where
+        # V_R = hele x Real is the vertically constant 3D space. That matrix is
+        # already the prolongation we want. V_R and V_base_2d share one PETSc
+        # layout: the same owned size, the same ownership range, and the same
+        # lgmap including ghost order. No relabelling is therefore needed.
         #
-        # This is structural, not coincidental. An ExtrudedMeshTopology reuses
-        # the base mesh's topology_dm, _dm_renumbering and _entity_classes, and
-        # for a hele x Real element the section and node-class computations
-        # collapse the vertical extent away (create_section on_base=True;
-        # node_classes real_tensorproduct=True; zero dof offset), so V_R's
-        # global numbering is the same computation over the same DM as
-        # V_coarse's. Note a base<->extruded relabelling cannot be expressed as
-        # cross-mesh interpolation anyway: that requires matching geometric
-        # dimension (2D base vs 3D extruded).
+        # This equality is structural, not coincidental. An ExtrudedMeshTopology
+        # reuses the base mesh's topology_dm, _dm_renumbering and
+        # _entity_classes. For a hele x Real element, the section and node-class
+        # computations then collapse the vertical extent away. create_section
+        # uses on_base=True, node_classes uses real_tensorproduct=True, and the
+        # dof offset is zero. As a result, V_R and V_base_2d take their global
+        # numbering from the same computation over the same DM.
+        #
+        # A base-to-extruded relabelling is not an alternative. Cross-mesh
+        # interpolation needs a matching geometric dimension, and the base is 2D
+        # while the extruded mesh is 3D.
         vcell = mesh.ufl_cell().sub_cells[1]
         vele_R = FiniteElement("R", vcell, 0)
         V_R = FunctionSpace(mesh, TensorProductElement(hele, vele_R))
         Prol = assemble(interpolate(TrialFunction(V_R), V)).petscmat
         self.Prol = Prol
 
-        # Guard the layout assumption. If V_R and V_coarse ever stop sharing a
-        # layout, a pure size mismatch would surface later as a cryptic PETSc
-        # MatMatMult error in the galerkin setup; a same-size reordering would
-        # be worse still (a silently wrong coarse operator). Fail fast here.
-        with Function(V_coarse).dat.vec_ro as cvec:
-            coarse_owned = cvec.getLocalSize()
+        # Guard the layout assumption, because a later failure is worse. A pure
+        # size mismatch surfaces as a cryptic PETSc MatMatMult error in the
+        # Galerkin setup. A same-size reordering is worse still, because it
+        # gives a silently wrong coarse operator. Raise here instead.
+        with Function(V_base_2d).dat.vec_ro as cvec:
+            base_owned = cvec.getLocalSize()
         prol_cols_owned = Prol.getLocalSize()[1]
-        if coarse_owned != prol_cols_owned:
+        if base_owned != prol_cols_owned:
             raise RuntimeError(
-                "VerticallyLumpedHMGPC: prolongation column layout "
-                f"({prol_cols_owned} owned) does not match the coarse space "
-                f"V_coarse ({coarse_owned} owned). The hele x Real "
-                "layout-collapse assumption has been violated."
+                "VerticallyLumpedHMGPC: the prolongation column layout "
+                f"({prol_cols_owned} owned) does not match V_base_2d "
+                f"({base_owned} owned). The hele x Real space no longer "
+                "collapses onto the base layout."
             )
 
-        # Set up the 2-level MG.
+        # Configure the 2-level MG.
         self.pc = PETSc.PC().create(comm=pc.comm)
         self.pc.setOptionsPrefix(options_prefix + "lumped_")
         self.pc.incrementTabLevel(1, parent=pc)
@@ -294,15 +323,15 @@ class VerticallyLumpedHMGPC(PCBase):
         self.pc.setMGInterpolation(1, Prol)
 
         # Build the chain of horizontal interpolations along the base
-        # MeshHierarchy (coarsest level is 0, V_coarse is at `level`).
+        # MeshHierarchy. Level 0 is the coarsest and V_base_2d is at `level`.
         base_interp_mats = self._build_base_hierarchy_interpolations(
             hierarchy, level, hele
         )
         self._base_interp_mats = base_interp_mats
 
-        # Explicit base-mesh interpolations + galerkin coarsening side-step
-        # the DM-based coarsen hook, which would require a coarsened UFL
-        # appctx we don't have.
+        # Explicit base-mesh interpolations plus Galerkin coarsening avoid the
+        # DM-based coarsen hook. That hook needs a coarsened UFL appctx, which
+        # is not available here.
         if base_interp_mats:
             coarse_ksp = self.pc.getMGCoarseSolve()
             coarse_pc = coarse_ksp.getPC()
@@ -325,14 +354,13 @@ class VerticallyLumpedHMGPC(PCBase):
     def _build_base_hierarchy_interpolations(hierarchy, fine_level, hele):
         """Assemble horizontal interpolation matrices for the base MG."""
         mats = []
+        V_c = FunctionSpace(hierarchy[0], hele)
         for k in range(1, fine_level + 1):
-            mesh_c = hierarchy[k - 1]
-            mesh_f = hierarchy[k]
-            V_c = FunctionSpace(mesh_c, hele)
-            V_f = FunctionSpace(mesh_f, hele)
+            V_f = FunctionSpace(hierarchy[k], hele)
             trial = TrialFunction(V_c)
             P_k = assemble(interpolate(trial, V_f)).petscmat
             mats.append(P_k)
+            V_c = V_f  # the fine space becomes the coarse space next round
         return mats
 
     def update(self, pc):

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -108,32 +108,57 @@ class _AutoRichardsonMixin:
     becomes Richardson, whatever the preset asked for, and ``omega`` follows
     the measured spectrum.
 
-    The rule is the classical optimum of a stationary iteration over the
-    measured interval, ``omega = 2/(lmin + lmax)``. It matters that this
-    tracks both ends. The spectrum of ``B^-1 A`` is a tight cluster when the
-    mass term dominates and spreads by more than a factor of ten when the
-    stiffness term does, and the best damping factor moves by about a factor
-    of two between those regimes. ``vlumping_omega_safety`` scales the result
-    for a coarser or a more aggressive setting. The value is clamped so that
-    the iteration contracts on every measured eigenvalue, including the
-    complex ones that the gravity-advection term produces.
+    The damping factor
+    -----------------
 
-    Two conditions re-measure the spectrum. Both must be cheap to test,
-    because the test itself runs on every Newton step.
+    Two quantities bound it. The first is the classical optimum of a
+    stationary iteration over the measured interval, ``2/(lmin + lmax)``. The
+    second is the stability bound: Richardson contracts while
+    ``|1 - omega*lambda| < 1``, which for one eigenvalue means
+    ``omega < 2 Re(lambda)/|lambda|^2``. The damping factor is the smaller of
+    the two, times ``vlumping_omega_margin`` for headroom, times
+    ``vlumping_omega_safety``.
 
-    The first condition is a change in the balance of the operator. The
-    Jacobian is about ``(C(h)/dt) M + K(h)``, so the spectrum of ``B^-1 A``
-    depends on how much of the operator lies off the diagonal. The mixin
-    tracks ``||A||_F / ||diag A||_2``, which is invariant under a rescaling
-    of the whole operator and moves when the mass term and the stiffness term
-    change their relative weight. An adaptive time step is the usual cause: a
-    ramp from 60 s to 43200 s moves lmax from 1.04 to 1.42 on the Cockett
-    box. A sharp wetting front is the other cause.
+    Which of the two binds depends on the shape of the spectrum, and the
+    difference is not academic. On a clustered spectrum, which is what a
+    serial run on a near-isotropic mesh produces, the classical optimum
+    binds. On a spread spectrum, which is what a real decomposition produces
+    once block-Jacobi ILU drops the coupling at the rank boundaries, the
+    stability bound binds and the rule reduces to ``margin * 2/lmax``. Every
+    measurement in the 832-rank basin runs took the second branch.
 
-    The second condition is a rise in the linear iteration count. The mixin
-    counts its own applications, which equal the outer Krylov iterations, and
-    compares the last Newton step against the count that followed the last
-    measurement. This catches a drift that the operator balance does not see.
+    The margin matters because the bound is not conservative. At the default
+    of 0.9 the damping factor is ``1.8/lmax`` and the spectrum can grow by
+    11% before the smoother amplifies its top mode. PETSc's Chebyshev carries
+    a comparable margin in its transform, ``emax = 1.1 lmax``, and re-measures
+    on every Newton step, so it recovers from drift that this scheme has to
+    detect first.
+
+    When to measure again
+    ---------------------
+
+    Three conditions, checked once per Newton step. All three are cheap,
+    because the check itself runs far more often than the measurement.
+
+    The first is a change in the diagonal of the operator. The Jacobian is
+    about ``(C(h)/dt) M + K(h)``, so the mass term contributes to the
+    diagonal in inverse proportion to the timestep. An adaptive timestep that
+    ramps by a factor of 720 therefore moves the diagonal, and with it the
+    balance between the two terms that sets the spectrum. This condition
+    fires before the iteration count degrades, which the second cannot.
+
+    The second is a rise in the linear iteration count. The reference is the
+    median over the first few Newton steps after a measurement, not a single
+    step, because the first Newton step of a timestep is systematically
+    cheaper than the rest and a single sample makes the threshold trip on
+    ordinary variation. Under a lag this condition is checked only on the
+    steps where the snapshot refreshes: between refreshes a rise in the
+    iteration count comes from the staleness of the snapshot, and
+    re-measuring an operator that has not changed cannot help.
+
+    The third is a plain interval. It exists because the first two conditions
+    detect a change in one quantity each, and neither is guaranteed to notice
+    a slow drift in something else. It is a backstop, so its default is long.
 
     Options, all with the outer preconditioner's prefix:
 
@@ -141,15 +166,21 @@ class _AutoRichardsonMixin:
         Boolean. Off by default.
     ``vlumping_omega_safety``
         Scale factor on the derived damping factor. Default 1.0.
+    ``vlumping_omega_margin``
+        Fraction of the stability bound to keep. Default 0.9.
     ``vlumping_omega_esteig_steps``
         GMRES iterations for one measurement. Default 20.
-    ``vlumping_omega_balance_ratio``
-        Re-measure when the operator balance moves by this factor in either
-        direction. Default 1.1. This condition is the early one: it fires
-        when the operator changes, before the iteration count degrades.
+    ``vlumping_omega_diagonal_ratio``
+        Re-measure when the norm of the diagonal moves by this factor in
+        either direction. Default 2.0.
     ``vlumping_omega_iter_growth``
         Re-measure when the linear iteration count of one Newton step exceeds
         the reference count by this factor. Default 1.5.
+    ``vlumping_omega_iter_window``
+        Number of Newton steps that establish the reference. Default 4.
+    ``vlumping_omega_interval``
+        Re-measure unconditionally after this many Newton steps. Default 200.
+        Set 0 to disable the backstop.
     """
 
     def _omega_initialize(self, pc):
@@ -160,37 +191,49 @@ class _AutoRichardsonMixin:
         self.omega = None
         self._omega_applies = 0
         self._omega_applies_seen = 0
+        self._omega_iter_samples = []
         self._omega_iter_reference = None
-        self._omega_balance = None
+        self._omega_diagonal = None
         self._omega_estimates = 0
+        self._omega_since_estimate = 0
         if not self.omega_auto:
             return
         self.omega_safety = opts.getReal(prefix + "vlumping_omega_safety", 1.0)
+        self.omega_margin = opts.getReal(prefix + "vlumping_omega_margin", 0.9)
         self.omega_esteig_steps = opts.getInt(
             prefix + "vlumping_omega_esteig_steps", 20
         )
-        self.omega_balance_ratio = opts.getReal(
-            prefix + "vlumping_omega_balance_ratio", 1.1
+        self.omega_diagonal_ratio = opts.getReal(
+            prefix + "vlumping_omega_diagonal_ratio", 2.0
         )
         self.omega_iter_growth = opts.getReal(
             prefix + "vlumping_omega_iter_growth", 1.5
         )
+        self.omega_iter_window = opts.getInt(
+            prefix + "vlumping_omega_iter_window", 4
+        )
+        self.omega_interval = opts.getInt(prefix + "vlumping_omega_interval", 200)
         self._omega_estimate(pc, "startup")
+        if self.omega is None:
+            raise RuntimeError(
+                "vlumping_omega_auto is set, but the first measurement of the "
+                "spectrum gave no usable damping factor. The smoother would "
+                "silently keep the preset's own type. Check that the level "
+                "preconditioner is non-singular, or unset the option."
+            )
 
     def _omega_smoother(self):
         """The fine-level smoother of the two-level cycle."""
         return self.pc.getMGSmoother(1)
 
     @staticmethod
-    def _omega_operator_balance(A):
-        """Weight of the off-diagonal part, invariant under a rescaling."""
+    def _omega_diagonal_norm(A):
+        """Norm of the diagonal, which the mass term scales as 1/dt."""
         diag = A.createVecLeft()
         A.getDiagonal(diag)
-        diag_norm = diag.norm()
+        value = diag.norm()
         diag.destroy()
-        if diag_norm == 0.0:
-            return None
-        return A.norm(PETSc.NormType.FROBENIUS) / diag_norm
+        return value
 
     def _omega_estimate(self, pc, reason):
         """Measure the spectrum once and set the damping factor from it."""
@@ -216,13 +259,15 @@ class _AutoRichardsonMixin:
         x.destroy()
 
         self._omega_estimates += 1
-        self._omega_balance = self._omega_operator_balance(A)
+        self._omega_since_estimate = 0
+        self._omega_diagonal = self._omega_diagonal_norm(A)
+        self._omega_iter_samples = []
         self._omega_iter_reference = None
 
         if eigenvalues.size == 0:
             PETSc.Sys.Print(
                 "VLumping omega: the estimator returned no eigenvalues, "
-                "keeping the previous damping factor"
+                f"keeping omega = {self.omega}"
             )
             return
 
@@ -231,39 +276,38 @@ class _AutoRichardsonMixin:
         if lmax <= 0.0:
             PETSc.Sys.Print(
                 "VLumping omega: the measured spectrum has no positive real "
-                "part, keeping the previous damping factor"
+                f"part, keeping omega = {self.omega}"
             )
             return
 
-        # Classical optimum of a stationary iteration over the measured
-        # interval. A short Arnoldi run resolves the top of the spectrum well
-        # and the bottom badly, so fall back to PETSc's own assumption,
-        # lmin = 0.1 lmax, when the measured lower end is not positive.
+        # Classical optimum over the measured interval. A short Arnoldi run
+        # resolves the top of the spectrum well and the bottom badly, so fall
+        # back to PETSc's own assumption, lmin = 0.1 lmax, when the measured
+        # lower end is not positive.
         lmin = float(real.min())
         if lmin <= 0.0:
             lmin = 0.1 * lmax
-        omega = self.omega_safety * 2.0 / (lmin + lmax)
+        optimum = 2.0 / (lmin + lmax)
 
-        # Richardson contracts while |1 - omega * lambda| < 1, which is a disk
-        # rather than an interval. For one eigenvalue that bounds omega by
-        # 2 Re(lambda) / |lambda|^2. Take the tightest bound over the measured
-        # spectrum and keep a margin, which matters only when the
-        # gravity-advection term makes the spectrum complex.
+        # Stability bound. Richardson contracts inside a disk, not an
+        # interval, which matters because the gravity-advection term makes
+        # the Jacobian non-symmetric and the spectrum complex.
         bounds = [
             2.0 * e.real / abs(e) ** 2
             for e in eigenvalues
             if e.real > 0.0 and abs(e) > 0.0
         ]
-        if bounds:
-            omega = min(omega, 0.95 * min(bounds))
+        limit = self.omega_margin * min(bounds) if bounds else optimum
+        omega = self.omega_safety * min(optimum, limit)
+        binding = "stability" if limit < optimum else "optimum"
 
         self.omega = omega
         self._omega_apply(smoother, omega)
 
         PETSc.Sys.Print(
             f"VLumping omega: measurement {self._omega_estimates} ({reason}), "
-            f"spectrum = [{lmin:.4f}, {lmax:.4f}], omega = {omega:.4f}, "
-            f"balance = {self._omega_balance:.4f}"
+            f"spectrum = [{lmin:.4f}, {lmax:.4f}], omega = {omega:.4f} "
+            f"({binding} bound), diagonal = {self._omega_diagonal:.6e}"
         )
 
     @staticmethod
@@ -311,28 +355,50 @@ class _AutoRichardsonMixin:
                 options[key] = value
 
     def _omega_update(self, pc):
-        """Re-measure when the operator balance or the iteration count moves."""
+        """Re-measure when any of the three conditions is met."""
         if not self.omega_auto:
             return
 
         iterations = self._omega_applies - self._omega_applies_seen
         self._omega_applies_seen = self._omega_applies
+        self._omega_since_estimate += 1
+
+        # Under a lag the smoother reads a snapshot that changes only on a
+        # refresh step. Between refreshes the operator is identical, so a
+        # measurement would return what it returned last time. Check only on
+        # the steps where the snapshot moves.
+        lagged = getattr(self, "_Alag", None) is not None
+        refreshed = (not lagged) or self._nupdate % self.lag == 0
 
         reason = None
-        balance = self._omega_operator_balance(self._omega_smoother().getOperators()[0])
-        if balance is not None and self._omega_balance:
-            ratio = balance / self._omega_balance
-            if ratio > self.omega_balance_ratio or ratio < 1.0 / self.omega_balance_ratio:
-                reason = f"operator balance moved by {ratio:.2f}"
+        if refreshed:
+            diagonal = self._omega_diagonal_norm(
+                self._omega_smoother().getOperators()[0]
+            )
+            if self._omega_diagonal:
+                ratio = diagonal / self._omega_diagonal
+                if (ratio > self.omega_diagonal_ratio
+                        or ratio < 1.0 / self.omega_diagonal_ratio):
+                    reason = f"the diagonal moved by {ratio:.2f}"
 
-        if reason is None and iterations > 0:
-            if self._omega_iter_reference is None:
-                self._omega_iter_reference = iterations
-            elif iterations > self.omega_iter_growth * self._omega_iter_reference:
-                reason = (
-                    f"linear iterations rose from {self._omega_iter_reference} "
-                    f"to {iterations}"
-                )
+            if reason is None and iterations > 0:
+                if len(self._omega_iter_samples) < self.omega_iter_window:
+                    # Establish the reference over several Newton steps. The
+                    # first step of a timestep is systematically cheaper than
+                    # the rest, so one sample makes the threshold trip on
+                    # ordinary variation.
+                    self._omega_iter_samples.append(iterations)
+                    ordered = sorted(self._omega_iter_samples)
+                    self._omega_iter_reference = ordered[len(ordered) // 2]
+                elif iterations > self.omega_iter_growth * self._omega_iter_reference:
+                    reason = (
+                        f"linear iterations rose from a reference of "
+                        f"{self._omega_iter_reference} to {iterations}"
+                    )
+
+        if (reason is None and self.omega_interval > 0
+                and self._omega_since_estimate >= self.omega_interval):
+            reason = f"{self._omega_since_estimate} Newton steps since the last measurement"
 
         if reason is not None:
             self._omega_estimate(pc, reason)

--- a/gadopt/preconditioners.py
+++ b/gadopt/preconditioners.py
@@ -87,7 +87,69 @@ class SPDAssembledPC(fd.AssembledPC):
 # =========================================================================
 
 
-class VerticallyLumpedPC(PCBase):
+class _LaggedOperatorMixin:
+    """Hold a private snapshot of the operator for the inner multigrid.
+
+    Firedrake reassembles the Jacobian in place on every Newton step, so the
+    PETSc object state of the operator changes every time. The inner PCMG
+    reacts to that change with a full setup: the Galerkin product P^T A P, the
+    coarse factorisation, and the eigenvalue estimate of a Chebyshev smoother.
+    For an extruded 3-D problem that setup cost dominates the solve.
+
+    This mixin gives the inner PCMG a private copy of the operator and
+    refreshes the copy every ``lag`` Newton steps. Between two refreshes the
+    object state does not change, so PETSc skips the complete setup. The outer
+    Krylov method keeps the true Jacobian for its residual, therefore the
+    accuracy of the Newton step does not change. Only the preconditioner is
+    stale.
+
+    The snapshot is necessary. A lag that leaves the live Jacobian visible to
+    the smoother makes the smoother evaluate B_old^-1 A_live. A polynomial or
+    stationary smoother contracts only on a bounded region, and modes that
+    leave that region during a sharp wetting front make the multigrid cycle
+    expansive. With the snapshot the smoother evaluates B_old^-1 A_old, which
+    is inside the region by construction, and the drift reaches the outer
+    Krylov method as a benign near-identity perturbation.
+
+    Set the lag with the integer option ``<prefix>vlumping_lag``. The default
+    is 1, which refreshes on every Newton step and reproduces the unlagged
+    behaviour exactly. The snapshot costs one extra copy of the Jacobian.
+    """
+
+    def _lag_initialize(self, pc, P):
+        """Read the lag option and bind the inner PC to the snapshot."""
+        prefix = pc.getOptionsPrefix() or ""
+        self.lag = PETSc.Options().getInt(prefix + "vlumping_lag", 1)
+        self._nupdate = 0
+        if self.lag <= 1:
+            self._Alag = None
+            return
+
+        # Copy the values now, because the first solve uses this matrix.
+        self._Alag = P.duplicate(copy=True)
+        # Both arguments must be the snapshot. KSPSetUp_Chebyshev compares the
+        # state of Amat and of Pmat, so a live Amat re-triggers the estimate
+        # and defeats the lag.
+        self.pc.setOperators(self._Alag, self._Alag)
+
+    def _lag_update(self, pc):
+        """Refresh the snapshot when the lag interval is complete."""
+        if self._Alag is None:
+            return
+        self._nupdate += 1
+        if self._nupdate % self.lag == 0:
+            _, P = pc.getOperators()
+            # MatCopy increases the object state, so the inner PCMG runs a
+            # complete setup on this step and skips it on the others.
+            P.copy(self._Alag, structure=PETSc.Mat.Structure.SAME_NONZERO_PATTERN)
+
+    def _lag_destroy(self):
+        if getattr(self, "_Alag", None) is not None:
+            self._Alag.destroy()
+            self._Alag = None
+
+
+class VerticallyLumpedPC(_LaggedOperatorMixin, PCBase):
     """Two-level MG that collapses the vertical dimension on the coarse level.
 
     This preconditioner targets extruded meshes of high aspect ratio. It
@@ -105,6 +167,10 @@ class VerticallyLumpedPC(PCBase):
 
     Solver options for the coarse level use the prefix ``lumped_mg_coarse_``.
     The fine-level smoother uses ``lumped_mg_levels_``.
+
+    The integer option ``vlumping_lag`` rebuilds the preconditioner every N
+    Newton steps against a private snapshot of the Jacobian. The default is 1,
+    which rebuilds on every step. See ``_LaggedOperatorMixin``.
 
     The fine space must be a scalar tensor-product space on an extruded mesh.
     """
@@ -167,6 +233,10 @@ class VerticallyLumpedPC(PCBase):
         self.pc.setMGInterpolation(1, Prol)
         self.pc.setFromOptions()
         self.pc.setUp()
+        # Bind the inner PCMG to a lagged snapshot when the user asks for one.
+        # This runs after the first setUp, so the multigrid residual callback
+        # keeps the live operator. See _LaggedOperatorMixin.
+        self._lag_initialize(pc, P)
         self.update(pc)
 
     def update(self, pc):
@@ -174,6 +244,7 @@ class VerticallyLumpedPC(PCBase):
         # The inner PCMG holds a reference to the same Mat. It still needs
         # setUp() to recompute the Galerkin coarse operator A_c = P^T A P from
         # the updated state.
+        self._lag_update(pc)
         self.pc.setUp()
 
     def apply(self, pc, X, Y):
@@ -183,6 +254,7 @@ class VerticallyLumpedPC(PCBase):
         self.pc.applyTranspose(X, Y)
 
     def destroy(self, pc):
+        self._lag_destroy()
         if hasattr(self, "pc"):
             self.pc.destroy()
 
@@ -200,7 +272,7 @@ class VerticallyLumpedPC(PCBase):
         self.pc.view(viewer)
 
 
-class VerticallyLumpedHMGPC(PCBase):
+class VerticallyLumpedHMGPC(_LaggedOperatorMixin, PCBase):
     """Two-level MG with the coarse level on the fine mesh's 2D base.
 
     This preconditioner uses the same two levels as ``VerticallyLumpedPC``.
@@ -215,6 +287,9 @@ class VerticallyLumpedHMGPC(PCBase):
 
     Fine space : V          = hele x vele      (full 3D tensor-product)
     Coarse     : V_base_2d  = hele on base_2d  (same horizontal element)
+
+    The integer option ``vlumping_lag`` applies here as well. See
+    ``_LaggedOperatorMixin``.
 
     The prolongation from ``V_base_2d`` into ``V`` is the same-mesh
     interpolation from the vertically constant 3D space ``V_R = hele x R``
@@ -348,6 +423,7 @@ class VerticallyLumpedHMGPC(PCBase):
 
         self.pc.setFromOptions()
         self.pc.setUp()
+        self._lag_initialize(pc, P)
         self.update(pc)
 
     @staticmethod
@@ -364,6 +440,7 @@ class VerticallyLumpedHMGPC(PCBase):
         return mats
 
     def update(self, pc):
+        self._lag_update(pc)
         self.pc.setUp()
 
     def apply(self, pc, X, Y):
@@ -373,6 +450,7 @@ class VerticallyLumpedHMGPC(PCBase):
         self.pc.applyTranspose(X, Y)
 
     def destroy(self, pc):
+        self._lag_destroy()
         if hasattr(self, "pc"):
             self.pc.destroy()
 

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -43,6 +43,7 @@ __all__ = [
     "direct_richards_solver_parameters",
     "iterative_richards_solver_parameters",
     "vlumping_richards_solver_parameters",
+    "vlumping_linesmooth_richards_solver_parameters",
     "vlumping_hmg_richards_solver_parameters",
 ]
 
@@ -119,9 +120,16 @@ vlumping_richards_solver_parameters: dict[str, Any] = {
     "pc_type": "python",
     "pc_python_type": "gadopt.VerticallyLumpedPC",
 
-    # Fine-level smoother: Chebyshev wrapping block-Jacobi ILU handles
-    # the stiff vertical modes at modest cost. Iteration counts are
-    # insensitive to vertical resolution.
+    # Fine-level smoother: block-Jacobi ILU handles the stiff vertical
+    # modes at modest cost, and iteration counts are insensitive to
+    # vertical resolution. The Krylov wrapper is Richardson with a damping
+    # factor measured at startup (see vlumping_omega_auto below), not
+    # Chebyshev: PETSc re-estimates the Chebyshev spectral bounds whenever
+    # the operator state changes, and Firedrake reassembles the Jacobian in
+    # place, so the estimate runs once per Newton step for the whole
+    # simulation. Removing it is worth 10-20% of wall time on the basin
+    # benchmarks at an unchanged iteration count.
+    "vlumping_omega_auto": True,
     "lumped_mg_levels_ksp_type": "chebyshev",
     "lumped_mg_levels_ksp_max_it": 2,
     "lumped_mg_levels_ksp_convergence_test": "skip",
@@ -150,6 +158,49 @@ MeshHierarchy.
 """
 
 
+vlumping_linesmooth_richards_solver_parameters: dict[str, Any] = dict(
+    vlumping_richards_solver_parameters,
+    **{
+        # Fine-level smoother: one ASM patch per vertical column, each
+        # factorised by LU, in place of the rank-local block-Jacobi ILU(0).
+        # An exact column solve removes the anisotropic vertical coupling in
+        # a single sweep, so max_it drops from two to one.
+        "lumped_mg_levels_ksp_max_it": 1,
+        "lumped_mg_levels_pc_type": "python",
+        "lumped_mg_levels_pc_python_type": "firedrake.ASMLinesmoothPC",
+        # codims="0": one patch per base cell, the column above that cell.
+        "lumped_mg_levels_pc_linesmooth_codims": "0",
+        # The outer ASM PC's prefix ends in "_sub_", so the patch-local
+        # sub-PC lives under "_sub_sub_". A single sub_ hits the ASM PC's
+        # own type and downgrades it to LU on the whole rank-local matrix,
+        # which exhausts memory immediately.
+        "lumped_mg_levels_pc_linesmooth_sub_sub_pc_type": "lu",
+        "lumped_mg_levels_pc_linesmooth_sub_sub_pc_factor_mat_ordering_type":
+            "natural",
+    },
+)
+# The block-Jacobi keys of the base preset are written against the same
+# "lumped_mg_levels_sub_" prefix the ASM patch solver reads, so they must be
+# removed rather than left unused.
+for _key in ("lumped_mg_levels_sub_pc_type",
+             "lumped_mg_levels_sub_pc_factor_levels"):
+    vlumping_linesmooth_richards_solver_parameters.pop(_key, None)
+del _key
+"""Iterative solver preset: vertical lumping with a column-exact smoother.
+
+Identical to ``vlumping_richards_solver_parameters`` except that the
+fine-level preconditioner solves each vertical column exactly by LU
+(``firedrake.ASMLinesmoothPC``) instead of applying a rank-local
+incomplete factorisation. The coarse solve stays the direct MUMPS
+factorisation of the vertically collapsed operator.
+
+Costs more per smoother application than ``vlumping`` and buys a lower
+iteration count. Which of the two is faster depends on the problem; both
+are recommended defaults for basin-scale extruded meshes, and neither
+requires a ``MeshHierarchy``.
+"""
+
+
 vlumping_hmg_richards_solver_parameters: dict[str, Any] = {
     "mat_type": "aij",
     "ksp_type": "fgmres",
@@ -163,7 +214,9 @@ vlumping_hmg_richards_solver_parameters: dict[str, Any] = {
 
     # Fine-level smoother: ASM line smoother (one patch per vertical
     # column, factorised by LU). Exact column solves damp vertical modes
-    # in one sweep.
+    # in one sweep. Richardson wrapper with a measured damping factor, as
+    # in vlumping_richards_solver_parameters.
+    "vlumping_omega_auto": True,
     "lumped_mg_levels_ksp_type": "chebyshev",
     "lumped_mg_levels_ksp_max_it": 1,
     "lumped_mg_levels_ksp_convergence_test": "skip",
@@ -472,6 +525,7 @@ class RichardsSolver(SolverConfigurationMixin):
         "direct": direct_richards_solver_parameters,
         "iterative": iterative_richards_solver_parameters,
         "vlumping": vlumping_richards_solver_parameters,
+        "vlumping_linesmooth": vlumping_linesmooth_richards_solver_parameters,
         "vlumping_hmg": vlumping_hmg_richards_solver_parameters,
     }
 
@@ -538,7 +592,7 @@ class RichardsSolver(SolverConfigurationMixin):
                     "extruded Cartesian meshes, or 'direct')."
                 )
 
-        if name in ("vlumping", "vlumping_hmg"):
+        if name in ("vlumping", "vlumping_linesmooth", "vlumping_hmg"):
             if not getattr(self.mesh, "extruded", False):
                 raise RuntimeError(
                     f"solver_parameters='{name}' requires an extruded mesh. "

--- a/gadopt/richards_solver.py
+++ b/gadopt/richards_solver.py
@@ -42,6 +42,8 @@ __all__ = [
     "RichardsSolver",
     "direct_richards_solver_parameters",
     "iterative_richards_solver_parameters",
+    "vlumping_richards_solver_parameters",
+    "vlumping_hmg_richards_solver_parameters",
 ]
 
 
@@ -94,8 +96,106 @@ iterative_richards_solver_parameters: dict[str, Any] = {
 }
 """Iterative solver preset: Newton + GMRES + BoomerAMG (Hypre).
 
-G-ADOPT uses this preset by default in 3-D. Requires PETSc to be built with
-Hypre support; otherwise an informative error is raised at solve time.
+G-ADOPT uses this preset by default in 3-D for non-extruded meshes. Requires
+PETSc to be built with Hypre support; otherwise an informative error is
+raised at solve time.
+"""
+
+
+vlumping_richards_solver_parameters: dict[str, Any] = {
+    "mat_type": "aij",
+    # Flexible GMRES because the vertically-lumped 2-level MG is a
+    # variable preconditioner (the Galerkin coarse solve is itself
+    # iterative in practice).
+    "ksp_type": "fgmres",
+    "snes_linesearch_type": "bt",
+    # Inexact Newton: the 1e-4 linear tolerance consistently wins against
+    # the 1e-5 baseline across the scaling studies (Cockett and
+    # Murrumbidgee). Tighter linear solves don't reduce Newton counts.
+    "ksp_rtol": 1e-4,
+    "ksp_max_it": 200,
+    "ksp_gmres_restart": 30,
+
+    "pc_type": "python",
+    "pc_python_type": "gadopt.VerticallyLumpedPC",
+
+    # Fine-level smoother: Chebyshev wrapping block-Jacobi ILU handles
+    # the stiff vertical modes at modest cost. Iteration counts are
+    # insensitive to vertical resolution.
+    "lumped_mg_levels_ksp_type": "chebyshev",
+    "lumped_mg_levels_ksp_max_it": 2,
+    "lumped_mg_levels_ksp_convergence_test": "skip",
+    "lumped_mg_levels_pc_type": "bjacobi",
+    "lumped_mg_levels_sub_pc_type": "ilu",
+    "lumped_mg_levels_sub_pc_factor_levels": 0,
+
+    # Coarse solve: the vertically lumped coarse operator is 2D-like
+    # (~n_horiz DOFs) so MUMPS LU is cheap and robust.
+    "lumped_mg_coarse_ksp_type": "preonly",
+    "lumped_mg_coarse_pc_type": "lu",
+    "lumped_mg_coarse_pc_factor_mat_solver_type": "mumps",
+
+    **_newton_common,
+}
+"""Iterative solver preset: vertically lumped 2-level MG.
+
+Two-level multigrid tailored for high-aspect-ratio extruded meshes
+(Kramer et al. 2010). Collapses the vertical dimension onto a 2D-like
+coarse problem via Galerkin projection; the coarse solve is MUMPS LU.
+Inexact Newton (ksp_rtol=1e-4) is baked into the preset.
+
+G-ADOPT selects this preset by default in 3-D on extruded Cartesian
+meshes. It requires an extruded fine mesh but does not require a
+MeshHierarchy.
+"""
+
+
+vlumping_hmg_richards_solver_parameters: dict[str, Any] = {
+    "mat_type": "aij",
+    "ksp_type": "fgmres",
+    "snes_linesearch_type": "bt",
+    "ksp_rtol": 1e-4,
+    "ksp_max_it": 200,
+    "ksp_gmres_restart": 30,
+
+    "pc_type": "python",
+    "pc_python_type": "gadopt.VerticallyLumpedHMGPC",
+
+    # Fine-level smoother: ASM line smoother (one patch per vertical
+    # column, factorised by LU). Exact column solves damp vertical modes
+    # in one sweep.
+    "lumped_mg_levels_ksp_type": "chebyshev",
+    "lumped_mg_levels_ksp_max_it": 1,
+    "lumped_mg_levels_ksp_convergence_test": "skip",
+    "lumped_mg_levels_pc_type": "python",
+    "lumped_mg_levels_pc_python_type": "firedrake.ASMLinesmoothPC",
+    "lumped_mg_levels_pc_linesmooth_codims": "0",
+    # The outer ASM PC's prefix ends in "_sub_", so the patch-local
+    # sub-PC lives under "_sub_sub_". A single sub_ downgrades ASM
+    # itself to LU on the rank-local matrix -- an instant OOM.
+    "lumped_mg_levels_pc_linesmooth_sub_sub_pc_type": "lu",
+
+    # Coarse solve: geometric MG descending the 2D base MeshHierarchy.
+    "lumped_mg_coarse_pc_type": "mg",
+    "lumped_mg_coarse_mg_levels_ksp_type": "chebyshev",
+    "lumped_mg_coarse_mg_levels_ksp_max_it": 2,
+    "lumped_mg_coarse_mg_levels_pc_type": "bjacobi",
+    "lumped_mg_coarse_mg_levels_sub_pc_type": "ilu",
+    "lumped_mg_coarse_mg_coarse_pc_type": "lu",
+    "lumped_mg_coarse_mg_coarse_pc_factor_mat_solver_type": "mumps",
+
+    **_newton_common,
+}
+"""Iterative solver preset: vlumping + geometric MG on the 2D base.
+
+Same two-level structure as ``vlumping_richards_solver_parameters``, but
+the coarse solve descends a geometric multigrid on a 2D base
+``MeshHierarchy`` instead of MUMPS. Fine-level smoother is
+``ASMLinesmoothPC`` (exact per-column solves).
+
+Requires the extruded fine mesh's base mesh to live in a
+``MeshHierarchy`` with at least one refinement level. If that hierarchy
+is absent, the solver raises ``RuntimeError`` at setup time.
 """
 
 
@@ -371,6 +471,8 @@ class RichardsSolver(SolverConfigurationMixin):
     _PRESETS: dict[str, dict[str, Any]] = {
         "direct": direct_richards_solver_parameters,
         "iterative": iterative_richards_solver_parameters,
+        "vlumping": vlumping_richards_solver_parameters,
+        "vlumping_hmg": vlumping_hmg_richards_solver_parameters,
     }
 
     def set_solver_options(
@@ -410,10 +512,16 @@ class RichardsSolver(SolverConfigurationMixin):
         """Pick a default preset based on mesh type.
 
         * 2-D: ``"direct"`` (MUMPS LU).
-        * 3-D: ``"iterative"`` (BoomerAMG).
+        * 3-D extruded Cartesian: ``"vlumping"``, which exploits the
+          vertical anisotropy typical of water-table problems.
+        * 3-D otherwise: ``"iterative"`` (BoomerAMG).
         """
         if self.mesh.topological_dimension == 2:
             return "direct"
+        extruded = getattr(self.mesh, "extruded", False)
+        cartesian = getattr(self.mesh, "cartesian", False)
+        if extruded and cartesian:
+            return "vlumping"
         return "iterative"
 
     def _validate_preset(self, name: str) -> None:
@@ -426,7 +534,32 @@ class RichardsSolver(SolverConfigurationMixin):
                     "solver_parameters='iterative' requires PETSc to be "
                     "built with Hypre (BoomerAMG). This PETSc build does "
                     "not include Hypre. Rebuild PETSc with --download-hypre "
-                    "or choose a different preset (e.g. 'direct')."
+                    "or choose a different preset (e.g. 'vlumping' on "
+                    "extruded Cartesian meshes, or 'direct')."
+                )
+
+        if name in ("vlumping", "vlumping_hmg"):
+            if not getattr(self.mesh, "extruded", False):
+                raise RuntimeError(
+                    f"solver_parameters='{name}' requires an extruded mesh. "
+                    f"Use 'iterative' (BoomerAMG) or 'direct' for "
+                    f"non-extruded meshes."
+                )
+
+        if name == "vlumping_hmg":
+            from firedrake.mg.utils import get_level
+            base = getattr(self.mesh, "_base_mesh", None)
+            hierarchy, level = (None, None) if base is None else get_level(base)
+            if hierarchy is None or level is None:
+                raise RuntimeError(
+                    "solver_parameters='vlumping_hmg' requires the extruded "
+                    "mesh's base mesh to live in a MeshHierarchy so the "
+                    "coarse PCMG can descend a geometric hierarchy. Build "
+                    "the mesh with\n"
+                    "    base_h = MeshHierarchy(base, L)\n"
+                    "    mesh = ExtrudedMeshHierarchy(base_h, layers, "
+                    "layer_height=h)[-1]\n"
+                    "with L >= 1, or fall back to 'vlumping'."
                 )
 
     def setup_solver(self) -> None:

--- a/tests/richards/test_vlumping_variants.py
+++ b/tests/richards/test_vlumping_variants.py
@@ -1,0 +1,334 @@
+"""Correctness tests for the vertically-lumped preset family.
+
+Exercises the two iterative presets that are specific to extruded meshes:
+
+    "vlumping"     -- 2-level MG, vertical collapse on coarse level,
+                      MUMPS LU at the bottom. Inexact Newton baked in.
+    "vlumping_hmg" -- as above but the coarse solve descends a geometric
+                      MG on the 2D base MeshHierarchy; fine-level smoother
+                      is `ASMLinesmoothPC` (exact per-column solves).
+
+All cases are intentionally tiny (8x8 base, 4 layers, 2 steps) so the
+file is serial-laptop friendly.
+"""
+import numpy as np
+import pytest
+from firedrake import (
+    Constant,
+    ExtrudedMesh,
+    ExtrudedMeshHierarchy,
+    Function,
+    FunctionSpace,
+    MeshHierarchy,
+    RectangleMesh,
+    TestFunction,
+    TrialFunction,
+    assemble,
+    dx,
+    grad,
+    inner,
+)
+
+from gadopt import (
+    BackwardEuler,
+    ExponentialCurve,
+    RichardsSolver,
+    VerticallyLumpedHMGPC,
+    get_boundary_ids,
+)
+
+
+# ---------------------------------------------------------------------------
+# Problem setup helpers
+# ---------------------------------------------------------------------------
+
+# Mild exponential soil (Tracy-ish regime on a small domain).
+ALPHA = 0.25
+THETA_R = 0.15
+THETA_S = 0.45
+KS = 1.0e-05
+SS = 0.0
+
+NX = 8
+NLAYERS = 4
+LX = 4.0
+LZ = 2.0
+DEGREE = 1
+
+DT = 5.0e4
+NSTEPS = 2
+
+
+def _make_soil_curve():
+    return ExponentialCurve(
+        theta_r=THETA_R, theta_s=THETA_S, Ks=KS, Ss=SS, alpha=ALPHA,
+    )
+
+
+def _make_flat_extruded_mesh():
+    """Plain ExtrudedMesh with no hierarchy underneath."""
+    base = RectangleMesh(NX, NX, LX, LX, quadrilateral=True)
+    mesh = ExtrudedMesh(base, NLAYERS, layer_height=LZ / NLAYERS)
+    mesh.cartesian = True
+    return mesh
+
+
+def _make_hierarchy_extruded_mesh(base_levels=1):
+    """Finest level of an ExtrudedMeshHierarchy built over a 2D
+    MeshHierarchy -- the shape `vlumping_hmg` requires."""
+    nx_coarse = NX // (2 ** base_levels)
+    base_coarse = RectangleMesh(nx_coarse, nx_coarse, LX, LX, quadrilateral=True)
+    mh2d = MeshHierarchy(base_coarse, base_levels)
+    mh3d = ExtrudedMeshHierarchy(
+        mh2d, LZ, base_layer=NLAYERS,
+        refinement_ratio=1,
+        extrusion_type="uniform",
+    )
+    mesh = mh3d[-1]
+    mesh.cartesian = True
+    return mesh
+
+
+def _run_short(mesh, preset):
+    """Run a few Backward-Euler steps and return (head, solver)."""
+    soil_curve = _make_soil_curve()
+    V = FunctionSpace(mesh, "DQ", DEGREE)
+    hr = -LZ
+
+    h = Function(V, name="PressureHead")
+    h.interpolate(Constant(hr))
+
+    boundary_ids = get_boundary_ids(mesh)
+    richards_bcs = {
+        "top": {"h": Constant(-0.1)},
+        "bottom": {"h": Constant(hr)},
+        boundary_ids.left: {"flux": 0.0},
+        boundary_ids.right: {"flux": 0.0},
+        boundary_ids.front: {"flux": 0.0},
+        boundary_ids.back: {"flux": 0.0},
+    }
+
+    solver = RichardsSolver(
+        h, soil_curve, delta_t=Constant(DT),
+        timestepper=BackwardEuler,
+        bcs=richards_bcs,
+        solver_parameters=preset,
+        quad_degree=3, interior_penalty=0.5,
+    )
+    for _ in range(NSTEPS):
+        solver.solve()
+    return h, solver
+
+
+# Meshes are immutable and safe to share read-only; building the
+# ExtrudedMeshHierarchy is the one non-trivial cost in this file, so hoist
+# both meshes to module scope. Function spaces and solvers are still built
+# per test, so no mutable solver state leaks between tests.
+@pytest.fixture(scope="module")
+def flat_mesh():
+    return _make_flat_extruded_mesh()
+
+
+@pytest.fixture(scope="module")
+def hierarchy_mesh():
+    return _make_hierarchy_extruded_mesh(base_levels=1)
+
+
+# ---------------------------------------------------------------------------
+# "vlumping" and "vlumping_hmg": a short solve converges and the solutions
+# agree with one another up to a few multiples of the linear tolerance.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("preset", ["vlumping", "vlumping_hmg"])
+def test_preset_loads_and_runs(preset, flat_mesh, hierarchy_mesh):
+    """Preset resolves, solver converges, output is finite and nonzero."""
+    mesh = hierarchy_mesh if preset == "vlumping_hmg" else flat_mesh
+    h, _ = _run_short(mesh, preset)
+    arr = h.dat.data_ro
+    assert np.all(np.isfinite(arr))
+    assert np.linalg.norm(arr) > 0.0
+
+
+def test_vlumping_hmg_matches_vlumping(hierarchy_mesh):
+    """Both presets solve the same linear system to a 1e-4 relative
+    tolerance. The solutions should agree up to a small multiple of that."""
+    mesh = hierarchy_mesh
+    h_ref, _ = _run_short(mesh, "vlumping")
+    h_new, _ = _run_short(mesh, "vlumping_hmg")
+
+    diff = assemble((h_ref - h_new) ** 2 * dx) ** 0.5
+    ref_norm = assemble(h_ref ** 2 * dx) ** 0.5
+    rel = diff / ref_norm
+    assert rel < 1e-2, (
+        f"vlumping_hmg vs vlumping relative L2 difference {rel:.3e} too large"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants of the VerticallyLumpedHMGPC class
+# ---------------------------------------------------------------------------
+
+
+def test_prol_preserves_constants(hierarchy_mesh):
+    """Prolongation maps coarse-space ones to fine-space ones.
+
+    A columnwise injection is the whole point of the construction; this
+    is the strongest sanity check you can make on the Prol Mat.
+    """
+    from firedrake.assemble import assemble as fd_assemble
+    from petsc4py import PETSc
+
+    mesh = hierarchy_mesh
+    V = FunctionSpace(mesh, "DQ", DEGREE)
+    u, v = TrialFunction(V), TestFunction(V)
+    A = fd_assemble(inner(u, v) * dx + inner(grad(u), grad(v)) * dx).petscmat
+
+    pc = PETSc.PC().create(comm=mesh.comm)
+    pc.setOperators(A, A)
+    pc.setType("python")
+    pc.setPythonContext(VerticallyLumpedHMGPC())
+    pc.setDM(V.dm)
+    pc.setUp()
+
+    py_ctx = pc.getPythonContext()
+    ones_c = Function(py_ctx.V_coarse).assign(1.0)
+    with ones_c.dat.vec_ro as xc:
+        yf = py_ctx.Prol.createVecLeft()
+        py_ctx.Prol.mult(xc, yf)
+        arr = yf.getArray()
+
+    assert np.allclose(arr, 1.0, atol=1e-10), (
+        f"Prol @ ones(V_coarse) deviates from ones(V): "
+        f"min={arr.min():.3e}, max={arr.max():.3e}"
+    )
+
+
+def test_missing_hierarchy_raises_clearly(flat_mesh):
+    """The vlumping_hmg PC must reject a flat (no-hierarchy) extruded mesh
+    with a message that names the missing MeshHierarchy, rather than failing
+    cryptically.
+
+    We invoke the context's ``initialize`` directly instead of going through
+    ``pc.setUp()``. ``initialize`` is exactly the code ``setUp`` runs, and the
+    guard raises a plain Python ``RuntimeError`` -- so we assert on its message
+    without routing it through ``PCSetUp_Python``. That C path prints PETSc's
+    "Unhandled Python Exception" banner to the raw stderr fd as the exception
+    unwinds, which segfaults under pytest's fd-capture on a debug PETSc build,
+    and also buries the real message behind petsc4py's bare "error code 101".
+    """
+    from firedrake.assemble import assemble as fd_assemble
+    from petsc4py import PETSc
+
+    V = FunctionSpace(flat_mesh, "DQ", DEGREE)
+    u, v = TrialFunction(V), TestFunction(V)
+    A = fd_assemble(inner(u, v) * dx + inner(grad(u), grad(v)) * dx).petscmat
+
+    pc = PETSc.PC().create(comm=flat_mesh.comm)
+    pc.setOperators(A, A)
+    pc.setType("python")
+    pc.setPythonContext(VerticallyLumpedHMGPC())
+    pc.setDM(V.dm)
+
+    ctx = pc.getPythonContext()
+    with pytest.raises(RuntimeError, match="(?i)hierarchy"):
+        ctx.initialize(pc)
+
+
+def test_mg_descent_on_coarse_side(hierarchy_mesh):
+    """After setup, the coarse KSP's PC is a PCMG with > 1 level.
+    Guards against a silent-failure mode where the hierarchy doesn't
+    propagate through setDM."""
+    mesh = hierarchy_mesh
+    _, solver = _run_short(mesh, "vlumping_hmg")
+
+    outer_pc = solver.solver.snes.getKSP().getPC()
+    py_ctx = outer_pc.getPythonContext()
+    inner_mg = py_ctx.pc
+    coarse_pc = inner_mg.getMGCoarseSolve().getPC()
+
+    try:
+        nlevels = coarse_pc.getMGLevels()
+    except Exception as e:
+        pytest.fail(f"coarse PC is not MG: {e!r}")
+    assert nlevels > 1, (
+        f"coarse MG has only {nlevels} level(s); setDM did not "
+        f"propagate the MeshHierarchy"
+    )
+
+
+def test_fine_smoother_is_asm_not_lu(hierarchy_mesh):
+    """Regression guard for the `sub_sub_` prefix bug.
+
+    The vlumping_hmg preset uses `ASMLinesmoothPC` at the fine level.
+    Its inner ASM sub-PC lives at prefix `..._sub_sub_`; a single
+    `_sub_` would hit ASM's own `pc_type` field and silently
+    downgrade the line smoother to a full-rank LU (instant OOM on
+    large meshes).
+    """
+    mesh = hierarchy_mesh
+    _, solver = _run_short(mesh, "vlumping_hmg")
+
+    outer_pc = solver.solver.snes.getKSP().getPC()
+    inner_mg = outer_pc.getPythonContext().pc
+
+    # Fine level is the last level of a 2-level PCMG.
+    fine_ksp = inner_mg.getMGSmoother(inner_mg.getMGLevels() - 1)
+    fine_pc = fine_ksp.getPC()
+    # Firedrake's ASMLinesmoothPC wraps a PETSc PCASM; drill through.
+    linesmooth_ctx = fine_pc.getPythonContext()
+    asm_pc = linesmooth_ctx.asmpc
+    assert asm_pc.getType() == "asm", (
+        f"fine-level smoother resolved to PC type '{asm_pc.getType()}'; "
+        f"expected 'asm' -- a downgrade to LU indicates the "
+        f"sub_sub_ prefix got truncated to sub_"
+    )
+
+
+def test_update_is_not_noop_for_hmg(hierarchy_mesh):
+    """Across two successive solves the inner operator state advances.
+    Confirms `update()` reassembles the Galerkin coarse operator."""
+    mesh = hierarchy_mesh
+    soil_curve = _make_soil_curve()
+
+    V = FunctionSpace(mesh, "DQ", DEGREE)
+    h = Function(V, name="PressureHead").interpolate(Constant(-LZ))
+    boundary_ids = get_boundary_ids(mesh)
+    richards_bcs = {
+        "top": {"h": Constant(-0.1)},
+        "bottom": {"h": Constant(-LZ)},
+        boundary_ids.left: {"flux": 0.0},
+        boundary_ids.right: {"flux": 0.0},
+        boundary_ids.front: {"flux": 0.0},
+        boundary_ids.back: {"flux": 0.0},
+    }
+    solver = RichardsSolver(
+        h, soil_curve, delta_t=Constant(DT),
+        timestepper=BackwardEuler,
+        bcs=richards_bcs,
+        solver_parameters="vlumping_hmg",
+        quad_degree=3, interior_penalty=0.5,
+    )
+
+    solver.solve()
+    inner_mg = solver.solver.snes.getKSP().getPC().getPythonContext().pc
+    A0, _ = inner_mg.getOperators()
+    state_before = A0.getInfo().get("assemblies", None)
+    norm_before = A0.norm()
+
+    # Second solve: h has moved so the Jacobian genuinely changes.
+    solver.solve()
+    A1, _ = inner_mg.getOperators()
+    state_after = A1.getInfo().get("assemblies", None)
+    norm_after = A1.norm()
+
+    advanced = (
+        (state_before is not None and state_after is not None
+         and state_after > state_before)
+        or not np.isclose(norm_before, norm_after, rtol=1e-14, atol=0.0)
+    )
+    assert advanced, (
+        f"inner PCMG operator did not change between solves "
+        f"(norm_before={norm_before}, norm_after={norm_after}); "
+        f"update() appears to be a no-op"
+    )

--- a/tests/richards/test_vlumping_variants.py
+++ b/tests/richards/test_vlumping_variants.py
@@ -29,6 +29,8 @@ from firedrake import (
     inner,
 )
 
+from gadopt.richards_solver import vlumping_richards_solver_parameters
+
 from gadopt import (
     BackwardEuler,
     ExponentialCurve,
@@ -331,4 +333,83 @@ def test_update_is_not_noop_for_hmg(hierarchy_mesh):
         f"inner PCMG operator did not change between solves "
         f"(norm_before={norm_before}, norm_after={norm_after}); "
         f"update() appears to be a no-op"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lagged setup: the inner PCMG runs against a private snapshot of the
+# Jacobian that only refreshes every `vlumping_lag` Newton steps.
+# ---------------------------------------------------------------------------
+
+
+def _lagged_preset(lag):
+    params = dict(vlumping_richards_solver_parameters)
+    params["vlumping_lag"] = lag
+    return params
+
+
+def test_lag_defaults_to_no_snapshot(flat_mesh):
+    """Without the option the PC holds no snapshot and nothing changes."""
+    _, solver = _run_short(flat_mesh, "vlumping")
+    ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
+    assert ctx.lag == 1
+    assert ctx._Alag is None
+
+
+def test_lag_binds_inner_mg_to_the_snapshot(flat_mesh):
+    """With a lag the inner PCMG sees the snapshot, not the live Jacobian."""
+    _, solver = _run_short(flat_mesh, _lagged_preset(3))
+    outer_pc = solver.solver.snes.getKSP().getPC()
+    ctx = outer_pc.getPythonContext()
+    assert ctx._Alag is not None
+
+    inner_amat, inner_pmat = ctx.pc.getOperators()
+    # Both operators must be the snapshot. KSPSetUp_Chebyshev compares the
+    # state of Amat and of Pmat, so a live Amat defeats the lag.
+    assert inner_amat.handle == ctx._Alag.handle
+    assert inner_pmat.handle == ctx._Alag.handle
+
+    live_amat, _ = outer_pc.getOperators()
+    assert live_amat.handle != ctx._Alag.handle
+
+
+def test_lag_refreshes_the_snapshot_on_the_lag_th_update(flat_mesh):
+    """The snapshot follows the live Jacobian on every third update only."""
+    lag = 3
+    _, solver = _run_short(flat_mesh, _lagged_preset(lag))
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    _, live = pc.getOperators()
+
+    # Move the live Jacobian before each update, so a refresh is visible as a
+    # change in the norm of the snapshot. This corrupts the operator, so the
+    # solver is not used again after this loop.
+    start = ctx._nupdate
+    refreshed = []
+    for _ in range(2 * lag):
+        live.scale(1.5)
+        before = ctx._Alag.norm()
+        ctx.update(pc)
+        refreshed.append(
+            not np.isclose(before, ctx._Alag.norm(), rtol=1e-12, atol=0.0)
+        )
+
+    expected = [(start + i + 1) % lag == 0 for i in range(2 * lag)]
+    assert refreshed == expected, (
+        f"snapshot refresh cadence {refreshed} does not match the expected "
+        f"{expected} for vlumping_lag={lag}"
+    )
+
+
+def test_lag_does_not_change_the_solution(flat_mesh):
+    """Lagging the preconditioner leaves the Newton solution unchanged."""
+    h_ref, _ = _run_short(flat_mesh, "vlumping")
+    h_lag, _ = _run_short(flat_mesh, _lagged_preset(3))
+
+    diff = assemble((h_ref - h_lag) ** 2 * dx) ** 0.5
+    ref_norm = assemble(h_ref ** 2 * dx) ** 0.5
+    rel = diff / ref_norm
+    assert rel < 1e-3, (
+        f"lagged and unlagged solutions differ by {rel:.3e}; the outer "
+        f"Krylov method should keep the true Jacobian for its residual"
     )

--- a/tests/richards/test_vlumping_variants.py
+++ b/tests/richards/test_vlumping_variants.py
@@ -29,7 +29,12 @@ from firedrake import (
     inner,
 )
 
-from gadopt.richards_solver import vlumping_richards_solver_parameters
+from firedrake.petsc import PETSc
+
+from gadopt.richards_solver import (
+    vlumping_hmg_richards_solver_parameters,
+    vlumping_richards_solver_parameters,
+)
 
 from gadopt import (
     BackwardEuler,
@@ -413,3 +418,119 @@ def test_lag_does_not_change_the_solution(flat_mesh):
         f"lagged and unlagged solutions differ by {rel:.3e}; the outer "
         f"Krylov method should keep the true Jacobian for its residual"
     )
+
+
+# ---------------------------------------------------------------------------
+# Automatic Richardson damping: the damping factor follows the measured
+# spectrum, and two conditions decide when to measure it again.
+# ---------------------------------------------------------------------------
+
+
+def _auto_preset(base=None, **extra):
+    params = dict(base or vlumping_richards_solver_parameters)
+    params["vlumping_omega_auto"] = True
+    params.update(extra)
+    return params
+
+
+def test_omega_auto_defaults_off(flat_mesh):
+    """Without the option the preconditioner derives nothing."""
+    _, solver = _run_short(flat_mesh, "vlumping")
+    ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
+    assert ctx.omega_auto is False
+    assert ctx.omega is None
+
+
+def test_omega_auto_sets_a_richardson_smoother(flat_mesh):
+    """The fine smoother becomes Richardson with the derived damping."""
+    _, solver = _run_short(flat_mesh, _auto_preset())
+    ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
+
+    assert ctx.omega is not None
+    assert ctx.omega > 0.0
+    assert ctx._omega_estimates >= 1
+
+    smoother = ctx.pc.getMGSmoother(1)
+    assert smoother.getType() == "richardson"
+    # The preset asked for Chebyshev. The derived value must override it.
+    assert vlumping_richards_solver_parameters[
+        "lumped_mg_levels_ksp_type"] == "chebyshev"
+
+
+def test_omega_auto_does_not_change_the_solution(flat_mesh):
+    """A different smoother must not move the Newton solution."""
+    h_ref, _ = _run_short(flat_mesh, "vlumping")
+    h_auto, _ = _run_short(flat_mesh, _auto_preset())
+
+    diff = assemble((h_ref - h_auto) ** 2 * dx) ** 0.5
+    ref_norm = assemble(h_ref ** 2 * dx) ** 0.5
+    assert diff / ref_norm < 1e-3
+
+
+def test_omega_auto_remeasures_when_the_operator_balance_moves(flat_mesh):
+    """A shift changes the diagonal alone, so the balance metric moves."""
+    _, solver = _run_short(flat_mesh, _auto_preset())
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    before = ctx._omega_estimates
+
+    # A uniform rescaling leaves the metric alone by construction, so shift
+    # the diagonal instead. This corrupts the operator; the solver is not
+    # used again after this call.
+    A, _ = ctx.pc.getMGSmoother(1).getOperators()
+    A.shift(10.0 * A.norm(PETSc.NormType.FROBENIUS))
+    ctx.update(pc)
+
+    assert ctx._omega_estimates == before + 1
+
+
+def test_omega_auto_remeasures_when_iterations_rise(flat_mesh):
+    """A Newton step that costs far more iterations triggers a measurement."""
+    _, solver = _run_short(flat_mesh, _auto_preset())
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+
+    # Establish a reference of one iteration, then present a step that took
+    # far more. The balance is untouched, so only the second condition can
+    # fire.
+    ctx._omega_iter_reference = 1
+    ctx._omega_applies = ctx._omega_applies_seen + 20
+    before = ctx._omega_estimates
+    ctx.update(pc)
+
+    assert ctx._omega_estimates == before + 1
+
+
+def test_omega_auto_holds_still_when_nothing_moves(flat_mesh):
+    """Neither condition fires on a repeated update with a fixed operator."""
+    _, solver = _run_short(flat_mesh, _auto_preset())
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    before = ctx._omega_estimates
+
+    for _ in range(4):
+        ctx.update(pc)
+
+    assert ctx._omega_estimates == before
+
+
+def test_omega_auto_works_with_the_lag(flat_mesh):
+    """The derived damping and the operator snapshot compose."""
+    _, solver = _run_short(flat_mesh, _auto_preset(vlumping_lag=3))
+    ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
+    assert ctx.omega is not None
+    assert ctx._Alag is not None
+    # Under a lag the smoother reads the snapshot, so the measurement and the
+    # balance metric must both come from the snapshot.
+    assert ctx.pc.getMGSmoother(1).getOperators()[0].handle == ctx._Alag.handle
+
+
+def test_omega_auto_works_for_hmg(hierarchy_mesh):
+    """The HMG variant derives a damping factor for its fine level too."""
+    _, solver = _run_short(
+        hierarchy_mesh,
+        _auto_preset(vlumping_hmg_richards_solver_parameters),
+    )
+    ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
+    assert ctx.omega is not None
+    assert ctx.pc.getMGSmoother(1).getType() == "richardson"

--- a/tests/richards/test_vlumping_variants.py
+++ b/tests/richards/test_vlumping_variants.py
@@ -192,14 +192,14 @@ def test_prol_preserves_constants(hierarchy_mesh):
     pc.setUp()
 
     py_ctx = pc.getPythonContext()
-    ones_c = Function(py_ctx.V_coarse).assign(1.0)
+    ones_c = Function(py_ctx.V_base_2d).assign(1.0)
     with ones_c.dat.vec_ro as xc:
         yf = py_ctx.Prol.createVecLeft()
         py_ctx.Prol.mult(xc, yf)
         arr = yf.getArray()
 
     assert np.allclose(arr, 1.0, atol=1e-10), (
-        f"Prol @ ones(V_coarse) deviates from ones(V): "
+        f"Prol @ ones(V_base_2d) deviates from ones(V): "
         f"min={arr.min():.3e}, max={arr.max():.3e}"
     )
 

--- a/tests/richards/test_vlumping_variants.py
+++ b/tests/richards/test_vlumping_variants.py
@@ -467,16 +467,14 @@ def test_omega_auto_does_not_change_the_solution(flat_mesh):
     assert diff / ref_norm < 1e-3
 
 
-def test_omega_auto_remeasures_when_the_operator_balance_moves(flat_mesh):
-    """A shift changes the diagonal alone, so the balance metric moves."""
+def test_omega_auto_remeasures_when_the_diagonal_moves(flat_mesh):
+    """A shift changes the diagonal, which is what an adaptive dt does."""
     _, solver = _run_short(flat_mesh, _auto_preset())
     pc = solver.solver.snes.getKSP().getPC()
     ctx = pc.getPythonContext()
     before = ctx._omega_estimates
 
-    # A uniform rescaling leaves the metric alone by construction, so shift
-    # the diagonal instead. This corrupts the operator; the solver is not
-    # used again after this call.
+    # This corrupts the operator; the solver is not used again after it.
     A, _ = ctx.pc.getMGSmoother(1).getOperators()
     A.shift(10.0 * A.norm(PETSc.NormType.FROBENIUS))
     ctx.update(pc)
@@ -490,9 +488,9 @@ def test_omega_auto_remeasures_when_iterations_rise(flat_mesh):
     pc = solver.solver.snes.getKSP().getPC()
     ctx = pc.getPythonContext()
 
-    # Establish a reference of one iteration, then present a step that took
-    # far more. The balance is untouched, so only the second condition can
-    # fire.
+    # Fill the reference window with a cheap count, then present a step that
+    # took far more. The diagonal is untouched, so only this condition fires.
+    ctx._omega_iter_samples = [1] * ctx.omega_iter_window
     ctx._omega_iter_reference = 1
     ctx._omega_applies = ctx._omega_applies_seen + 20
     before = ctx._omega_estimates
@@ -534,3 +532,63 @@ def test_omega_auto_works_for_hmg(hierarchy_mesh):
     ctx = solver.solver.snes.getKSP().getPC().getPythonContext()
     assert ctx.omega is not None
     assert ctx.pc.getMGSmoother(1).getType() == "richardson"
+
+
+def test_omega_auto_reference_needs_several_samples(flat_mesh):
+    """The reference is a middle sample of the window, not a single step."""
+    _, solver = _run_short(flat_mesh, _auto_preset())
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    ctx._omega_iter_samples = []
+    before = ctx._omega_estimates
+
+    # A cheap first step of a timestep, two ordinary ones, and one outlier.
+    # Nothing may trigger while the window is still filling.
+    for count in (2, 3, 4, 40):
+        ctx._omega_applies = ctx._omega_applies_seen + count
+        ctx.update(pc)
+
+    assert ctx._omega_estimates == before
+    assert len(ctx._omega_iter_samples) == ctx.omega_iter_window
+    # Neither the cheap first step nor the outlier sets the threshold.
+    assert 2 < ctx._omega_iter_reference < 40
+
+
+def test_omega_auto_interval_is_a_backstop(flat_mesh):
+    """The interval re-measures even when nothing else moves."""
+    _, solver = _run_short(flat_mesh, _auto_preset(vlumping_omega_interval=3))
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    before = ctx._omega_estimates
+
+    for _ in range(3):
+        ctx.update(pc)
+
+    assert ctx._omega_estimates == before + 1
+
+
+def test_omega_auto_checks_only_on_refresh_steps_under_lag(flat_mesh):
+    """Between refreshes the snapshot is identical, so nothing is checked."""
+    _, solver = _run_short(
+        flat_mesh, _auto_preset(vlumping_lag=3, vlumping_omega_interval=0)
+    )
+    pc = solver.solver.snes.getKSP().getPC()
+    ctx = pc.getPythonContext()
+    ctx._omega_iter_samples = [1] * ctx.omega_iter_window
+    ctx._omega_iter_reference = 1
+
+    # _lag_update increments the counter before _omega_update reads it, so
+    # this lands the expensive step on an update that does not refresh.
+    ctx._nupdate = 0
+    ctx._omega_applies = ctx._omega_applies_seen + 40
+    before = ctx._omega_estimates
+    ctx.update(pc)
+    assert ctx._omega_estimates == before
+
+    # The same step on a refresh does trigger.
+    ctx._omega_iter_samples = [1] * ctx.omega_iter_window
+    ctx._omega_iter_reference = 1
+    ctx._nupdate = ctx.lag - 1
+    ctx._omega_applies = ctx._omega_applies_seen + 40
+    ctx.update(pc)
+    assert ctx._omega_estimates == before + 1


### PR DESCRIPTION
Fourth of five PRs decomposing the Richards-equation foundation work. Stacked on #523.

Two new Python preconditioners target high-aspect-ratio extruded meshes typical of water-table problems:

- **`VerticallyLumpedPC`**: two-level multigrid (Kramer et al. 2010). The fine operator is collapsed onto a 2D-like coarse problem via Galerkin projection; the coarse solve is MUMPS LU. Fine-level smoother is Chebyshev wrapping block-Jacobi ILU, which damps the stiff vertical modes cheaply and is insensitive to vertical resolution.
- **`VerticallyLumpedHMGPC`**: same two-level structure but the coarse solve descends a geometric multigrid on a 2D base `MeshHierarchy`. Fine-level smoother is `ASMLinesmoothPC` (exact per-column solves) for one-sweep damping of vertical modes. Requires the base mesh to live in a `MeshHierarchy` with at least one refinement level.

`RichardsSolver` gains two presets that wire these in (`vlumping`, `vlumping_hmg`) and `_auto_select_preset` now picks `vlumping` on 3-D extruded Cartesian meshes (where vertical anisotropy is most pronounced), falling back to `iterative` (BoomerAMG) on other 3-D meshes. `_validate_preset` fails fast when structural prerequisites aren't met: `vlumping` requires an extruded mesh; `vlumping_hmg` additionally requires the base mesh hierarchy.

Both presets bake in inexact Newton (`ksp_rtol=1e-4`), which consistently wins over `1e-5` in the Cockett and Murrumbidgee scaling studies; tighter linear solves don't reduce Newton counts.

The standalone PCs and the wired-in presets land together because vlumping is only used by Richards in practice, and the natural reproducer (`test_vlumping_variants.py`, carried from `richardson`) exercises the presets through `RichardsSolver` on tiny extruded problems (8x8 base, 4 layers, 2 steps) so the file stays serial-laptop friendly.
