### PR TITLE
Use explicit Riesz maps for adjoint Controls

### DIFF
--- a/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_boundary.py
@@ -138,7 +138,8 @@ T0.project(T_wrong)
 # Note that L2 is the default Riesz map if none is explicitly specified.
 
 # +
-m = Control(T0, riesz_map="L2")
+riesz_map = RieszMap(Q, "L2", constant_jacobian=True)
+m = Control(T0, riesz_map=riesz_map)
 
 J = AdjFloat(0.0)  # Initialise functional
 factor = AdjFloat(0.5)  # First & final boundary integral weighted by 0.5 to implement mid-point rule time-integration.

--- a/demos/PDE_constrained_optimisation/PDE_constrained_field.py
+++ b/demos/PDE_constrained_optimisation/PDE_constrained_field.py
@@ -141,7 +141,8 @@ T0.project(T_target)
 # ensuring that gradients are computed in the $L^2$ Hilbert space with
 # respect to the inner product.
 
-m = Control(T0, riesz_map="L2")
+riesz_map = RieszMap(Q, "L2", constant_jacobian=True)
+m = Control(T0, riesz_map=riesz_map)
 
 # Based on our guess for the initial temperature, we run the model for a specified number of timesteps:
 

--- a/demos/glacial_isostatic_adjustment/adjoint_ice/adjoint_ice.py
+++ b/demos/glacial_isostatic_adjustment/adjoint_ice/adjoint_ice.py
@@ -216,7 +216,8 @@ surface_mesh = CircleManifoldMesh(ncells, radius=rmax, degree=1, name='surface_m
 # Define control on surface mesh
 P1_surf = FunctionSpace(surface_mesh, "CG", 1)  # Function space on surface mesh for control
 ice_thickness_control = Function(P1_surf, name="Ice thickness (control)")  # What we optimise
-control = Control(ice_thickness_control, riesz_map="L2")
+riesz_map = RieszMap(P1_surf, "L2", constant_jacobian=True)
+control = Control(ice_thickness_control, riesz_map=riesz_map)
 # -
 
 # In the cell above, when we initialised the control field, we also specified the option

--- a/demos/glacial_isostatic_adjustment/adjoint_viscosity/adjoint_viscosity.py
+++ b/demos/glacial_isostatic_adjustment/adjoint_viscosity/adjoint_viscosity.py
@@ -207,7 +207,8 @@ initialise_background_field(
 # +
 viscosity_control = Function(P1, name="Viscosity (control)")
 
-control = Control(viscosity_control, riesz_map="L2")
+riesz_map = RieszMap(P1, "L2", constant_jacobian=True)
+control = Control(viscosity_control, riesz_map=riesz_map)
 
 viscosity = background_viscosity * 10**viscosity_control
 # -

--- a/demos/mantle_convection/adjoint/adjoint.py
+++ b/demos/mantle_convection/adjoint/adjoint.py
@@ -194,7 +194,8 @@ T0_bcs = [DirichletBC(Q1, 0., boundary.top), DirichletBC(Q1, 1., boundary.bottom
 T0 = Function(Q1, name="Initial_Guess_Temperature").project(Tic, bcs=T0_bcs)
 
 # We next make pyadjoint aware of our control problem:
-control = Control(Tic)
+riesz_map = RieszMap(Q1, "L2", constant_jacobian=True)
+control = Control(Tic, riesz_map=riesz_map)
 
 # Take our initial guess and project to T, simultaneously applying boundary conditions in the Q2 space:
 T.project(Tic, bcs=energy_solver.strong_bcs)


### PR DESCRIPTION
Because our adjoint examples are on non-moving meshes, we can construct the Riesz map ahead of time and cache the mass matrix. Otherwise, a RieszMap object is constructed on every derivative evaluation and incurs an LU factorisation and solve.

Something to consider for larger applications is to use an iterative rather than direct solver for this process.

If this is indeed a useful thing to do:
- [ ] add a statement to the accompanying documentation cells in the demos