### PR TITLE
Add GPU solver options.

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -65,6 +65,7 @@ iterative_fieldsplit_0_gpu_parameters: ConfigType = {
             "pc_type": "python",
             "pc_python_type": "firedrake.OffloadPC",
             "offload": {
+                "ksp_type": "preonly",
                 "pc_type": "ksp",
                 "ksp": {
                     "ksp_type": "cg",
@@ -83,12 +84,10 @@ iterative_fieldsplit_0_gpu_parameters: ConfigType = {
     }
 }
 
-iterative_cuda_workarounds_inner: dict[str, dict[str, bool]] = {
-    "ksp": {
-        "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
-        "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
-        "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
-    }
+iterative_cuda_ksp_workarounds_inner: dict[str, bool] = {
+    "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
+    "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
+    "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
 }
 
 # Missing parameter: "fieldsplit_0"
@@ -197,11 +196,13 @@ gia_iterative_cpu_assembled_parameters: dict[str, str | float | int | bool] = {
 }
 
 gia_iterative_gpu_assembled_parameters: ConfigType = {
+    "ksp_type": "preonly",
     "assembled": {
         "ksp_type": "preonly",
         "pc_type": "python",
         "pc_python_type": "firedrake.OffloadPC",
         "offload": {
+            "ksp_type": "preonly",
             "pc_type": "ksp",
             "ksp": {
                 "pc_type": "gamg",
@@ -532,16 +533,14 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                 odb = fd.PETSc.Options()
                 odb["matmatmult_backend_cpu"] = None
                 odb["matptap_backend_cpu"] = None
+                odb["inner_C_loc_mat_product_algorithm_backend_cpu"] = None
+                odb["inner_C_oth_mat_product_algorithm_backend_cpu"] = None
                 if gpu_telescope_factor == 1:
-                    for k, v in iterative_cuda_workarounds_inner:
-                        offload_conf["assembled"]["offload"][k] = v
-                    odb["inner_C_loc_mat_product_algorithm_backend_cpu"] = None
-                    odb["inner_C_oth_mat_product_algorithm_backend_cpu"] = None
+                    for k, v in iterative_cuda_ksp_workarounds_inner.items():
+                        offload_conf["assembled"]["offload"]["ksp"][k] = v
                 else:
-                    for k, v in iterative_cuda_workarounds_inner:
-                        offload_conf["fieldsplit_0"]["assembled"]["offload"][
-                            "telescope"
-                        ][k] = v
+                    for k, v in iterative_cuda_ksp_workarounds_inner.items():
+                        offload_conf["assembled"]["offload"]["telescope"]["ksp"][k] = v
             return offload_conf
 
     def _set_monitoring_config(

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -477,37 +477,16 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             telescope_factor: If PCTELESCOPE is in use, the telescope reduction
             factor (see https://petsc.org/main/manualpages/PC/PCTELESCOPE/)
         """
+        if device_type is not None:
+            if telescope_factor == 1:
+                d = {"assembled": {"offload": {"ksp": d}}}
+            else:
+                d = {"assembled": {"offload": {"telescope": {"ksp": d}}}}
         top_pc = self.solver_parameters.get("pc_type")
         if top_pc == "fieldsplit":
-            if device_type is None:
-                self.add_to_solver_config({"fieldsplit_0": d})
-            else:
-                if telescope_factor == 1:
-                    self.add_to_solver_config(
-                        {"fieldsplit_0": {"assembled": {"offload": {"ksp": d}}}}
-                    )
-                else:
-                    self.add_to_solver_config(
-                        {
-                            "fieldsplit_0": {
-                                "assembled": {
-                                    "offload": {"telescope": {"ksp": d}}
-                                }
-                            }
-                        }
-                    )
+            self.add_to_solver_config({"fieldsplit_0": d})
         else:
-            if device_type is None:
-                self.add_to_solver_config(d)
-            else:
-                if telescope_factor == 1:
-                    self.add_to_solver_config(
-                        {"assembled": {"offload": {"ksp": d}}}
-                    )
-                else:
-                    self.add_to_solver_config(
-                        {"assembled": {"offload": {"telescope": {"ksp": d}}}}
-                    )
+            self.add_to_solver_config(d)
 
     def _handle_gpu_settings(
         self,
@@ -543,27 +522,26 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         )
         if device_type is None:
             return in_config
-        else:
-            # in_config can be one of the predefined config dicts, make sure it is not
-            # modified
-            offload_conf = deepcopy(in_config)
-            if gpu_telescope_factor > 1:
-                ksp_params = offload_conf["assembled"]["offload"]
-                offload_conf["assembled"]["offload"] = {
-                    "ksp_type": "preonly",
-                    "pc_type": "telescope",
-                    "pc_telescope_reduction_factor": gpu_telescope_factor,
-                    "telescope": ksp_params,
-                }
-            if device_type == "CUDA":
-                # Add cuda workarounds
-                odb = fd.PETSc.Options()
-                odb.setValue("matmatmult_backend_cpu", True)
-                odb.setValue("matptap_backend_cpu", True)
-                odb.setValue("inner_C_loc_mat_product_algorithm_backend_cpu", True)
-                odb.setValue("inner_C_oth_mat_product_algorithm_backend_cpu", True)
-                self._add_to_offloaded_solver(iterative_cuda_ksp_workarounds_inner, device_type, gpu_telescope_factor)
-            return offload_conf
+        # in_config can be one of the predefined config dicts, make sure it is not
+        # modified
+        offload_conf = deepcopy(in_config)
+        if gpu_telescope_factor > 1:
+            ksp_params = offload_conf["assembled"]["offload"]
+            offload_conf["assembled"]["offload"] = {
+                "ksp_type": "preonly",
+                "pc_type": "telescope",
+                "pc_telescope_reduction_factor": gpu_telescope_factor,
+                "telescope": ksp_params,
+            }
+        if device_type == "CUDA":
+            # Add cuda workarounds
+            odb = fd.PETSc.Options()
+            odb.setValue("matmatmult_backend_cpu", True)
+            odb.setValue("matptap_backend_cpu", True)
+            odb.setValue("inner_C_loc_mat_product_algorithm_backend_cpu", True)
+            odb.setValue("inner_C_oth_mat_product_algorithm_backend_cpu", True)
+            self._add_to_offloaded_solver(iterative_cuda_ksp_workarounds_inner, device_type, gpu_telescope_factor)
+        return offload_conf
 
     def _set_monitoring_config(
         self,
@@ -593,7 +571,6 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         gpu_telescope_factor = (
             1 if gpu_extras is None else int(gpu_extras.get("telescope_factor", 1))
         )
-        print(log_level)
         if DEBUG >= log_level:
             self._add_to_offloaded_solver({"ksp_converged_reason": None}, device_type, gpu_telescope_factor)
             if self.solver_parameters.get("pc_type") == "fieldsplit":
@@ -607,6 +584,54 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                 )
             else:
                 self._add_to_offloaded_solver({"ksp_converged_reason": None}, device_type, gpu_telescope_factor)
+
+    def _configure_iterative_solver(
+        self, device_type: str | None, gpu_extras: ConfigType
+    ):
+        """Configure iterative solver settings
+
+        Add the appropriate parameter sets at the right nesting levels for iterative
+        solver settings with and without GPUs.
+
+        Args:
+            device_type: Target GPU device type (e.g., `CUDA`).
+            gpu_extras: GPU-specific settings. Used to determine whether to add
+            telescope configuration.
+        """
+        top_pc = self.solver_parameters.get("pc_type")
+        # Early return if this set of solver parameters already has a fieldsplit_0 entry
+        if top_pc == "fieldsplit" and "fieldsplit_0" in self.solver_parameters:
+            return
+        if device_type is None:
+            additional_params = {
+                "assembled": cpu_gamg_parameters | gamg_common_parameters
+            } | spd_ksp_parameters
+            if top_pc == "fieldsplit":
+                additional_params = {
+                    "fieldsplit_0": additional_params | spd_pc_parameters
+                }
+            self.add_to_solver_config(additional_params)
+        else:
+            additional_params = {
+                "assembled": dict(offload_parameters),
+                "ksp_type": "preonly",
+            }
+            additional_params["assembled"]["offload"] = dict(
+                offload_parameters["offload"]
+            )
+            additional_params["assembled"]["offload"]["ksp"] = (
+                gamg_common_parameters | gpu_gamg_parameters | spd_ksp_parameters
+            )
+            if top_pc == "fieldsplit":
+                additional_params = self._handle_gpu_settings(
+                    gpu_extras, device_type, additional_params | spd_pc_parameters
+                )
+                additional_params = {"fieldsplit_0": additional_params}
+            else:
+                additional_params = self._handle_gpu_settings(
+                    gpu_extras, device_type, additional_params | {"ksp_type": "preonly"}
+                )
+            self.add_to_solver_config(additional_params)
 
     def set_solver_options(
         self,
@@ -642,66 +667,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
 
         device_type = get_device_type(gpu_extras)
         if iterative_solve:
-            # First construct SPD solver settings
-            if self.solver_parameters.get("pc_type") == "fieldsplit":
-                if "fieldsplit_0" not in self.solver_parameters:
-                    # If fieldsplit_0 is missing, decide which set of parameters
-                    # to use based whether we detect a GPU, and the settings the
-                    # user has specified.
-                    self.add_to_solver_config({"fieldsplit_0": spd_pc_parameters})
-                    if device_type is None:
-                        self.add_to_solver_config({"fieldsplit_0": spd_ksp_parameters})
-                        self.add_to_solver_config(
-                            {"fieldsplit_0": {"assembled": cpu_gamg_parameters}}
-                        )
-                        self.add_to_solver_config(
-                            {"fieldsplit_0": {"assembled": gamg_common_parameters}}
-                        )
-                    else:
-                        # dict() cast copies MappingProxyTypes to mutable dicts
-                        additional_params = dict(spd_pc_parameters)
-                        additional_params["ksp_type"] = "preonly"
-                        additional_params["assembled"] = dict(offload_parameters)
-                        additional_params["assembled"]["offload"] = dict(
-                            offload_parameters["offload"]
-                        )
-                        additional_params["assembled"]["offload"]["ksp"] = {
-                            **gamg_common_parameters,
-                            **gpu_gamg_parameters,
-                            **spd_ksp_parameters
-                        }
-                        self.add_to_solver_config(
-                            {
-                                "fieldsplit_0": self._handle_gpu_settings(
-                                    gpu_extras,
-                                    device_type,
-                                    additional_params,
-                                )
-                            }
-                        )
-            else:
-                # Iterative solve with no fieldsplit assumes GIA
-                if device_type is None:
-                    self.add_to_solver_config(spd_ksp_parameters)
-                    self.add_to_solver_config({"assembled": cpu_gamg_parameters})
-                    self.add_to_solver_config({"assembled": gamg_common_parameters})
-                else:
-                    additional_params = {"ksp_type": "preonly"}
-                    additional_params["assembled"] = dict(offload_parameters)
-                    additional_params["assembled"]["offload"] = dict(
-                        offload_parameters["offload"]
-                    )
-                    additional_params["assembled"]["offload"]["ksp"] = {
-                        **gamg_common_parameters,
-                        **gpu_gamg_parameters,
-                        **spd_ksp_parameters,
-                    }
-                    gpu_params = self._handle_gpu_settings(
-                        gpu_extras,
-                        device_type,
-                        additional_params,
-                    )
-                    self.add_to_solver_config(gpu_params)
+            self._configure_iterative_solver(device_type, gpu_extras)
 
         self._set_monitoring_config(device_type, gpu_extras, iterative_solve)
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -463,16 +463,19 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         device_type: str | None,
         telescope_factor: int,
     ):
-        """Add a key-value pair to a solver that may be using OffloadPC
+        """Add any ConfigType object to a solver that may be using OffloadPC
 
         Handles the varied levels of nesting in the default solver configurations
-        that are subject to offloading when a GPU is used.
+        that are subject to offloading when a GPU is used. Determines the nesting
+        level of the 'inner' KSP solver in the case of a fieldsplit preconditioner
+        or the main KSP solve using heuristics based on the default solver settings.
+        Not intended to work with custom solver settings.
 
         Args:
-            key: _description_
-            val: _description_
-            device_type:
-            telescope_factor:
+            d: The object to insert.
+            device_type: Target GPU device type (e.g., `CUDA`).
+            telescope_factor: If PCTELESCOPE is in use, the telescope reduction
+            factor (see https://petsc.org/main/manualpages/PC/PCTELESCOPE/)
         """
         top_pc = self.solver_parameters.get("pc_type")
         if top_pc == "fieldsplit":

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
 from warnings import warn
+from types import MappingProxyType
 
 import firedrake as fd
 from ufl.core.expr import Expr
@@ -39,76 +40,84 @@ from .utility import (
     get_device_type
 )
 
-iterative_fieldsplit_0_cpu_params: dict[str, dict[str, str | int | float]] = {
-    "fieldsplit_0": {
+gamg_common_parameters: Mapping[str, str | float | int | bool] = MappingProxyType(
+    {
+        "pc_type": "gamg",
+        "pc_gamg_threshold": 0.01,
+        "pc_gamg_square_graph": 100,
+        "pc_gamg_coarse_eq_limit": 1000,
+        "pc_gamg_mis_k_minimum_degree_ordering": True,
+    }
+)
+
+spd_ksp_parameters: Mapping[str, str | float | int] = MappingProxyType(
+    {
         "ksp_type": "cg",
         "ksp_rtol": 1e-5,
         "ksp_max_it": 1000,
+    }
+)
+
+spd_pc_parameters: Mapping[str, str] = MappingProxyType(
+    {
         "pc_type": "python",
         "pc_python_type": "gadopt.SPDAssembledPC",
-        "assembled_pc_type": "gamg",
-        "assembled_mg_levels_pc_type": "sor",
-        "assembled_pc_gamg_threshold": 0.01,
-        "assembled_pc_gamg_square_graph": 100,
-        "assembled_pc_gamg_coarse_eq_limit": 1000,
-        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
     }
-}
+)
 
-iterative_fieldsplit_0_gpu_parameters: ConfigType = {
-    "fieldsplit_0": {
+cpu_gamg_parameters: Mapping[str, str] = MappingProxyType(
+    {
+        "mg_levels_pc_type": "sor",
+    }
+)
+
+gpu_gamg_parameters: Mapping[str, str | int] = MappingProxyType(
+    {
+        "mg_levels_pc_type": "jacobi",
+        "mg_levels_ksp_max_it": 2,
+    }
+)
+
+offload_parameters: Mapping[str, str | Mapping[str, str]] = MappingProxyType(
+    {
         "ksp_type": "preonly",
         "pc_type": "python",
-        "pc_python_type": "gadopt.SPDAssembledPC",
-        "assembled": {
-            "ksp_type": "preonly",
-            "pc_type": "python",
-            "pc_python_type": "firedrake.OffloadPC",
-            "offload": {
-                "ksp_type": "preonly",
-                "pc_type": "ksp",
-                "ksp": {
-                    "ksp_type": "cg",
-                    "ksp_rtol": 1e-5,
-                    "ksp_max_it": 1000,
-                    "pc_type": "gamg",
-                    "mg_levels_pc_type": "jacobi",
-                    "mg_levels_ksp_max_it": 2,
-                    "pc_gamg_threshold": 0.01,
-                    "pc_gamg_square_graph": 100,
-                    "pc_gamg_coarse_eq_limit": 1000,
-                    "pc_gamg_mis_k_minimum_degree_ordering": True,
-                },
-            },
-        },
+        "pc_python_type": "firedrake.OffloadPC",
+        "offload": MappingProxyType({"ksp_type": "preonly", "pc_type": "ksp"}),
     }
-}
+)
 
-iterative_cuda_ksp_workarounds_inner: dict[str, bool] = {
+iterative_cuda_ksp_workarounds_inner: Mapping[str, bool] = MappingProxyType({
     "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
     "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
     "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
-}
+})
 
 # Missing parameter: "fieldsplit_0"
-iterative_outer_stokes_solver_parameters: dict[str, str | dict[str, str | int | float]] = {
-    "mat_type": "matfree",
-    "ksp_type": "preonly",
-    "pc_type": "fieldsplit",
-    "pc_fieldsplit_type": "schur",
-    "pc_fieldsplit_schur_type": "full",
-    "fieldsplit_1": {
-        "ksp_type": "fgmres",
-        "ksp_rtol": 1e-4,
-        "ksp_max_it": 200,
-        "pc_type": "python",
-        "pc_python_type": "firedrake.MassInvPC",
-        "Mp_pc_type": "ksp",
-        "Mp_ksp_ksp_rtol": 1e-5,
-        "Mp_ksp_ksp_type": "cg",
-        "Mp_ksp_pc_type": "sor",
-    },
-}
+iterative_outer_stokes_solver_parameters: Mapping[
+    str, str | Mapping[str, str | int | float]
+] = MappingProxyType(
+    {
+        "mat_type": "matfree",
+        "ksp_type": "preonly",
+        "pc_type": "fieldsplit",
+        "pc_fieldsplit_type": "schur",
+        "pc_fieldsplit_schur_type": "full",
+        "fieldsplit_1": MappingProxyType(
+            {
+                "ksp_type": "fgmres",
+                "ksp_rtol": 1e-4,
+                "ksp_max_it": 200,
+                "pc_type": "python",
+                "pc_python_type": "firedrake.MassInvPC",
+                "Mp_pc_type": "ksp",
+                "Mp_ksp_ksp_rtol": 1e-5,
+                "Mp_ksp_ksp_type": "cg",
+                "Mp_ksp_pc_type": "sor",
+            }
+        ),
+    }
+)
 """Default iterative solver parameters for solution of Stokes system.
 
 We configure the Schur complement approach as described in Section of 4.3 of Davies et
@@ -137,12 +146,14 @@ Note:
   .
 """
 
-direct_stokes_solver_parameters: dict[str, str] = {
-    "mat_type": "aij",
-    "ksp_type": "preonly",
-    "pc_type": "lu",
-    "pc_factor_mat_solver_type": "mumps",
-}
+direct_stokes_solver_parameters: Mapping[str, str] = MappingProxyType(
+    {
+        "mat_type": "aij",
+        "ksp_type": "preonly",
+        "pc_type": "lu",
+        "pc_factor_mat_solver_type": "mumps",
+    }
+)
 """Default direct solver parameters for solution of Stokes system.
 
 We configure the direct solver to use the LU (`lu`) factorisation provided by the MUMPS
@@ -157,13 +168,15 @@ Note:
   and values to extend the default ones.
 """
 
-newton_stokes_solver_parameters: dict[str, str | int | float] = {
-    "snes_type": "newtonls",
-    "snes_linesearch_type": "l2",
-    "snes_max_it": 100,
-    "snes_atol": 1e-10,
-    "snes_rtol": 1e-5,
-}
+newton_stokes_solver_parameters: Mapping[str, str | int | float] = MappingProxyType(
+    {
+        "snes_type": "newtonls",
+        "snes_linesearch_type": "l2",
+        "snes_max_it": 100,
+        "snes_atol": 1e-10,
+        "snes_rtol": 1e-5,
+    }
+)
 """Default non-linear solver parameters for solution of Stokes system.
 
 We use a setup based on Newton's method (newtonls) with a secant line
@@ -177,74 +190,34 @@ Note:
   dictionary via the `solver_parameters_extra` argument. This dictionary can also hold
   new pairs of keys and values to extend the default ones.
 """
-gia_outer_solver_parameters: dict[str, str | float] = {
-    "mat_type": "matfree",
-    "snes_type": "ksponly",
-    "pc_type": "python",
-    "pc_python_type": "gadopt.SPDAssembledPC",
-}
+gia_outer_solver_parameters: Mapping[str, str | float] = MappingProxyType(
+    {
+        "mat_type": "matfree",
+        "snes_type": "ksponly",
+        **spd_pc_parameters
+    }
+)
 
-gia_iterative_cpu_assembled_parameters: dict[str, str | float | int | bool] = {
-    "ksp_type": "cg",
-    "ksp_rtol": 1e-5,
-    "assembled_pc_type": "gamg",
-    "assembled_mg_levels_pc_type": "sor",
-    "assembled_pc_gamg_threshold": 0.01,
-    "assembled_pc_gamg_square_graph": 100,
-    "assembled_pc_gamg_coarse_eq_limit": 1000,
-    "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-}
-
-gia_iterative_gpu_assembled_parameters: ConfigType = {
-    "ksp_type": "preonly",
-    "assembled": {
-        "ksp_type": "preonly",
-        "pc_type": "python",
-        "pc_python_type": "firedrake.OffloadPC",
-        "offload": {
-            "ksp_type": "preonly",
-            "pc_type": "ksp",
-            "ksp": {
-                "ksp_type": "cg",
-                "ksp_rtol": 1e-5,
-                "pc_type": "gamg",
-                "mg_levels_pc_type": "jacobi",
-                "mg_levels_ksp_max_it": 2,
-                "pc_gamg_threshold": 0.01,
-                "pc_gamg_square_graph": 100,
-                "pc_gamg_coarse_eq_limit": 1000,
-                "pc_gamg_mis_k_minimum_degree_ordering": True,
-            }
-        },
-    },
-}
-
-coupled_gia_solver_parameters: ConfigType = {
-    "mat_type": "matfree",
-    "ksp_type": "gmres",
-    "ksp_rtol": 1e-3,
-    "pc_type": "fieldsplit",
-    "pc_fieldsplit_type": "symmetric_multiplicative",
-    "fieldsplit_0": {
-        "ksp_type": "cg",
-        "pc_type": "python",
-        "pc_python_type": "gadopt.SPDAssembledPC",
-        "assembled_pc_type": "gamg",
-        "assembled_mg_levels_pc_type": "sor",
-        "ksp_rtol": 1e-5,
-        "assembled_pc_gamg_threshold": 0.01,
-        "assembled_pc_gamg_square_graph": 100,
-        "assembled_pc_gamg_coarse_eq_limit": 1000,
-        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-    },
-    "fieldsplit_1": {
-        "ksp_type": "cg",
-        "pc_type": "python",
-        "pc_python_type": "firedrake.AssembledPC",
-        "assembled_pc_type": "sor",
-        "ksp_rtol": 1e-5,
-    },
-}
+coupled_gia_solver_parameters: Mapping[str, str | float | Mapping[str, str | float]] = (
+    MappingProxyType(
+        {
+            "mat_type": "matfree",
+            "ksp_type": "gmres",
+            "ksp_rtol": 1e-3,
+            "pc_type": "fieldsplit",
+            "pc_fieldsplit_type": "symmetric_multiplicative",
+            "fieldsplit_1": MappingProxyType(
+                {
+                    "ksp_type": "cg",
+                    "pc_type": "python",
+                    "pc_python_type": "firedrake.AssembledPC",
+                    "assembled_pc_type": "sor",
+                    "ksp_rtol": 1e-5,
+                }
+            ),
+        }
+    )
+)
 """Default iterative solver parameters for CoupledInternalVariableSolver (GIA problems).
 
 Uses a Newton SNES outer loop with a GMRES/fieldsplit preconditioned inner solve. SNES
@@ -521,7 +494,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         else:
             # in_config can be one of the predefined config dicts, make sure it is not
             # modified
-            offload_conf: ConfigType = deepcopy(in_config)
+            offload_conf = deepcopy(in_config)
             if gpu_telescope_factor > 1:
                 ksp_params = offload_conf["assembled"]["offload"]
                 offload_conf["assembled"]["offload"] = {
@@ -583,20 +556,20 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                         }
                     )
                 else:
-                    extra_param_dict = {
+                    extra_params = {
                         "fieldsplit_0": {"assembled": {"offload": {}}},
                         "fieldsplit_1": {"ksp_monitor": None},
                     }
                     if gpu_telescope_factor > 1:
-                        extra_param_dict["fieldsplit_0"]["assembled"]["offload"] = {
+                        extra_params["fieldsplit_0"]["assembled"]["offload"] = {
                             "telescope": {"ksp": {"ksp_converged_reason": None}}
                         }
 
                     else:
-                        extra_param_dict["fieldsplit_0"]["assembled"]["offload"] = {
+                        extra_params["fieldsplit_0"]["assembled"]["offload"] = {
                             "ksp": {"ksp_converged_reason": None}
                         }
-                    self.add_to_solver_config(extra_param_dict)
+                    self.add_to_solver_config(extra_params)
 
             elif INFO >= log_level:
                 self.add_to_solver_config(
@@ -609,27 +582,27 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                 if DEBUG >= log_level:
                     self.add_to_solver_config({"ksp_monitor": None})
             else:
-                extra_param_dict = {"assembled": {"offload": {}}}
+                extra_params = {"assembled": {"offload": {}}}
                 if gpu_telescope_factor > 1:
                     if INFO >= log_level:
-                        extra_param_dict["assembled"]["offload"]["telescope"] = {
+                        extra_params["assembled"]["offload"]["telescope"] = {
                             "ksp": {"ksp_converged_reason": None}
                         }
                     if DEBUG >= log_level:
-                        extra_param_dict["assembled"]["offload"]["telescope"]["ksp"][
+                        extra_params["assembled"]["offload"]["telescope"]["ksp"][
                             "ksp_monitor"
                         ] = None
                 else:
                     if INFO >= log_level:
-                        extra_param_dict["assembled"]["offload"]["ksp"] = {
+                        extra_params["assembled"]["offload"]["ksp"] = {
                             "ksp_converged_reason": None
                         }
                     if DEBUG >= log_level:
-                        extra_param_dict["assembled"]["offload"]["ksp"][
+                        extra_params["assembled"]["offload"]["ksp"][
                             "ksp_monitor"
                         ] = None
 
-                self.add_to_solver_config(extra_param_dict)
+                self.add_to_solver_config(extra_params)
 
     def set_solver_options(
         self,
@@ -665,30 +638,64 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
 
         device_type = get_device_type(gpu_extras)
         if iterative_solve:
+            # First construct SPD solver settings
             if self.solver_parameters.get("pc_type") == "fieldsplit":
                 if "fieldsplit_0" not in self.solver_parameters:
                     # If fieldsplit_0 is missing, decide which set of parameters
                     # to use based whether we detect a GPU, and the settings the
-                    # user has specified
+                    # user has specified.
+                    self.add_to_solver_config({"fieldsplit_0": spd_pc_parameters})
                     if device_type is None:
-                        self.add_to_solver_config(iterative_fieldsplit_0_cpu_params)
-                    else:
-                        gpu_params: ConfigType = {"fieldsplit_0": None}
-                        gpu_params["fieldsplit_0"] = self._handle_gpu_settings(
-                            gpu_extras,
-                            device_type,
-                            iterative_fieldsplit_0_gpu_parameters["fieldsplit_0"],
+                        self.add_to_solver_config({"fieldsplit_0": spd_ksp_parameters})
+                        self.add_to_solver_config(
+                            {"fieldsplit_0": {"assembled": cpu_gamg_parameters}}
                         )
-                        self.add_to_solver_config(gpu_params)
+                        self.add_to_solver_config(
+                            {"fieldsplit_0": {"assembled": gamg_common_parameters}}
+                        )
+                    else:
+                        # dict() cast copies MappingProxyTypes to mutable dicts
+                        additional_params = dict(spd_pc_parameters)
+                        additional_params["ksp_type"] = "preonly"
+                        additional_params["assembled"] = dict(offload_parameters)
+                        additional_params["assembled"]["offload"] = dict(
+                            offload_parameters["offload"]
+                        )
+                        additional_params["assembled"]["offload"]["ksp"] = {
+                            **gamg_common_parameters,
+                            **gpu_gamg_parameters,
+                            **spd_ksp_parameters
+                        }
+                        self.add_to_solver_config(
+                            {
+                                "fieldsplit_0": self._handle_gpu_settings(
+                                    gpu_extras,
+                                    device_type,
+                                    additional_params,
+                                )
+                            }
+                        )
             else:
                 # Iterative solve with no fieldsplit assumes GIA
                 if device_type is None:
-                    self.add_to_solver_config(gia_iterative_cpu_assembled_parameters)
+                    self.add_to_solver_config(spd_ksp_parameters)
+                    self.add_to_solver_config({"assembled": cpu_gamg_parameters})
+                    self.add_to_solver_config({"assembled": gamg_common_parameters})
                 else:
+                    additional_params = {"ksp_type": "preonly"}
+                    additional_params["assembled"] = dict(offload_parameters)
+                    additional_params["assembled"]["offload"] = dict(
+                        offload_parameters["offload"]
+                    )
+                    additional_params["assembled"]["offload"]["ksp"] = {
+                        **gamg_common_parameters,
+                        **gpu_gamg_parameters,
+                        **spd_ksp_parameters,
+                    }
                     gpu_params = self._handle_gpu_settings(
                         gpu_extras,
                         device_type,
-                        gia_iterative_gpu_assembled_parameters,
+                        additional_params,
                     )
                     self.add_to_solver_config(gpu_params)
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -180,13 +180,13 @@ Note:
 gia_outer_solver_parameters: dict[str, str | float] = {
     "mat_type": "matfree",
     "snes_type": "ksponly",
-    "ksp_type": "cg",
-    "ksp_rtol": 1e-5,
     "pc_type": "python",
     "pc_python_type": "gadopt.SPDAssembledPC",
 }
 
 gia_iterative_cpu_assembled_parameters: dict[str, str | float | int | bool] = {
+    "ksp_type": "cg",
+    "ksp_rtol": 1e-5,
     "assembled_pc_type": "gamg",
     "assembled_mg_levels_pc_type": "sor",
     "assembled_pc_gamg_threshold": 0.01,
@@ -205,6 +205,8 @@ gia_iterative_gpu_assembled_parameters: ConfigType = {
             "ksp_type": "preonly",
             "pc_type": "ksp",
             "ksp": {
+                "ksp_type": "cg",
+                "ksp_rtol": 1e-5,
                 "pc_type": "gamg",
                 "mg_levels_pc_type": "jacobi",
                 "mg_levels_ksp_max_it": 2,
@@ -521,7 +523,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             # modified
             offload_conf: ConfigType = deepcopy(in_config)
             if gpu_telescope_factor > 1:
-                ksp_params = in_config["assembled"]["offload"]
+                ksp_params = offload_conf["assembled"]["offload"]
                 offload_conf["assembled"]["offload"] = {
                     "ksp_type": "preonly",
                     "pc_type": "telescope",
@@ -531,10 +533,10 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             if device_type == "CUDA":
                 # Add cuda workarounds
                 odb = fd.PETSc.Options()
-                odb["matmatmult_backend_cpu"] = None
-                odb["matptap_backend_cpu"] = None
-                odb["inner_C_loc_mat_product_algorithm_backend_cpu"] = None
-                odb["inner_C_oth_mat_product_algorithm_backend_cpu"] = None
+                odb.setValue("matmatmult_backend_cpu", True)
+                odb.setValue("matptap_backend_cpu", True)
+                odb.setValue("inner_C_loc_mat_product_algorithm_backend_cpu", True)
+                odb.setValue("inner_C_oth_mat_product_algorithm_backend_cpu", True)
                 if gpu_telescope_factor == 1:
                     for k, v in iterative_cuda_ksp_workarounds_inner.items():
                         offload_conf["assembled"]["offload"]["ksp"][k] = v

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -457,6 +457,55 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                     raise ValueError("Solver type must be 'direct' or 'iterative'.")
         return self.mesh.topological_dimension == 3
 
+    def _add_to_offloaded_solver(
+        self,
+        d: ConfigType,
+        device_type: str | None,
+        telescope_factor: int,
+    ):
+        """Add a key-value pair to a solver that may be using OffloadPC
+
+        Handles the varied levels of nesting in the default solver configurations
+        that are subject to offloading when a GPU is used.
+
+        Args:
+            key: _description_
+            val: _description_
+            device_type:
+            telescope_factor:
+        """
+        top_pc = self.solver_parameters.get("pc_type")
+        if top_pc == "fieldsplit":
+            if device_type is None:
+                self.add_to_solver_config({"fieldsplit_0": d})
+            else:
+                if telescope_factor == 1:
+                    self.add_to_solver_config(
+                        {"fieldsplit_0": {"assembled": {"offload": {"ksp": d}}}}
+                    )
+                else:
+                    self.add_to_solver_config(
+                        {
+                            "fieldsplit_0": {
+                                "assembled": {
+                                    "offload": {"telescope": {"ksp": d}}
+                                }
+                            }
+                        }
+                    )
+        else:
+            if device_type is None:
+                self.add_to_solver_config(d)
+            else:
+                if telescope_factor == 1:
+                    self.add_to_solver_config(
+                        {"assembled": {"offload": {"ksp": d}}}
+                    )
+                else:
+                    self.add_to_solver_config(
+                        {"assembled": {"offload": {"telescope": {"ksp": d}}}}
+                    )
+
     def _handle_gpu_settings(
         self,
         gpu_extras: ConfigType | None,
@@ -510,12 +559,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                 odb.setValue("matptap_backend_cpu", True)
                 odb.setValue("inner_C_loc_mat_product_algorithm_backend_cpu", True)
                 odb.setValue("inner_C_oth_mat_product_algorithm_backend_cpu", True)
-                if gpu_telescope_factor == 1:
-                    for k, v in iterative_cuda_ksp_workarounds_inner.items():
-                        offload_conf["assembled"]["offload"]["ksp"][k] = v
-                else:
-                    for k, v in iterative_cuda_ksp_workarounds_inner.items():
-                        offload_conf["assembled"]["offload"]["telescope"]["ksp"][k] = v
+                self._add_to_offloaded_solver(iterative_cuda_ksp_workarounds_inner, device_type, gpu_telescope_factor)
             return offload_conf
 
     def _set_monitoring_config(
@@ -546,63 +590,20 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         gpu_telescope_factor = (
             1 if gpu_extras is None else int(gpu_extras.get("telescope_factor", 1))
         )
-        if self.solver_parameters.get("pc_type") == "fieldsplit":
-            if DEBUG >= log_level:
-                if device_type is None:
-                    self.add_to_solver_config(
-                        {
-                            "fieldsplit_0": {"ksp_converged_reason": None},
-                            "fieldsplit_1": {"ksp_monitor": None},
-                        }
-                    )
-                else:
-                    extra_params = {
-                        "fieldsplit_0": {"assembled": {"offload": {}}},
-                        "fieldsplit_1": {"ksp_monitor": None},
-                    }
-                    if gpu_telescope_factor > 1:
-                        extra_params["fieldsplit_0"]["assembled"]["offload"] = {
-                            "telescope": {"ksp": {"ksp_converged_reason": None}}
-                        }
-
-                    else:
-                        extra_params["fieldsplit_0"]["assembled"]["offload"] = {
-                            "ksp": {"ksp_converged_reason": None}
-                        }
-                    self.add_to_solver_config(extra_params)
-
-            elif INFO >= log_level:
+        print(log_level)
+        if DEBUG >= log_level:
+            self._add_to_offloaded_solver({"ksp_converged_reason": None}, device_type, gpu_telescope_factor)
+            if self.solver_parameters.get("pc_type") == "fieldsplit":
+                self.add_to_solver_config({"fieldsplit_1": {"ksp_monitor": None}})
+            else:
+                self.add_to_solver_config({"ksp_monitor": None})
+        if INFO >= log_level:
+            if self.solver_parameters.get("pc_type") == "fieldsplit":
                 self.add_to_solver_config(
                     {"fieldsplit_1": {"ksp_converged_reason": None}}
                 )
-        else:
-            if device_type is None:
-                if INFO >= log_level:
-                    self.add_to_solver_config({"ksp_converged_reason": None})
-                if DEBUG >= log_level:
-                    self.add_to_solver_config({"ksp_monitor": None})
             else:
-                extra_params = {"assembled": {"offload": {}}}
-                if gpu_telescope_factor > 1:
-                    if INFO >= log_level:
-                        extra_params["assembled"]["offload"]["telescope"] = {
-                            "ksp": {"ksp_converged_reason": None}
-                        }
-                    if DEBUG >= log_level:
-                        extra_params["assembled"]["offload"]["telescope"]["ksp"][
-                            "ksp_monitor"
-                        ] = None
-                else:
-                    if INFO >= log_level:
-                        extra_params["assembled"]["offload"]["ksp"] = {
-                            "ksp_converged_reason": None
-                        }
-                    if DEBUG >= log_level:
-                        extra_params["assembled"]["offload"]["ksp"][
-                            "ksp_monitor"
-                        ] = None
-
-                self.add_to_solver_config(extra_params)
+                self._add_to_offloaded_solver({"ksp_converged_reason": None}, device_type, gpu_telescope_factor)
 
     def set_solver_options(
         self,

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -37,12 +37,7 @@ from .utility import (
     vertical_component,
 )
 
-iterative_stokes_solver_parameters = {
-    "mat_type": "matfree",
-    "ksp_type": "preonly",
-    "pc_type": "fieldsplit",
-    "pc_fieldsplit_type": "schur",
-    "pc_fieldsplit_schur_type": "full",
+iterative_fieldsplit_0_cpu_params: dict[str, dict[str, str | int | float]] = {
     "fieldsplit_0": {
         "ksp_type": "cg",
         "ksp_rtol": 1e-5,
@@ -55,7 +50,52 @@ iterative_stokes_solver_parameters = {
         "assembled_pc_gamg_square_graph": 100,
         "assembled_pc_gamg_coarse_eq_limit": 1000,
         "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-    },
+    }
+}
+
+iterative_fieldsplit_0_gpu_parameters: ConfigType = {
+    "fieldsplit_0": {
+        "ksp_type": "preonly",
+        "pc_type": "python",
+        "pc_python_type": "gadopt.SPDAssembledPC",
+        "assembled": {
+            "ksp_type": "preonly",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.OffloadPC",
+            "offload": {
+                "pc_type": "ksp",
+                "ksp": {
+                    "ksp_type": "cg",
+                    "ksp_rtol": 1e-5,
+                    "ksp_max_it": 1000,
+                    "pc_type": "gamg",
+                    "mg_levels_pc_type": "jacobi",
+                    "mg_levels_ksp_max_it": 2,
+                    "pc_gamg_threshold": 0.01,
+                    "pc_gamg_square_graph": 100,
+                    "pc_gamg_coarse_eq_limit": 1000,
+                    "pc_gamg_mis_k_minimum_degree_ordering": True,
+                },
+            },
+        },
+    }
+}
+
+iterative_cuda_workarounds_inner: dict[str, dict[str, bool]] = {
+    "ksp": {
+        "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
+        "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
+        "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
+    }
+}
+
+# Missing parameter: "fieldsplit_0"
+iterative_outer_stokes_solver_parameters: dict[str, str | dict[str, str | int | float]] = {
+    "mat_type": "matfree",
+    "ksp_type": "preonly",
+    "pc_type": "fieldsplit",
+    "pc_fieldsplit_type": "schur",
+    "pc_fieldsplit_schur_type": "full",
     "fieldsplit_1": {
         "ksp_type": "fgmres",
         "ksp_rtol": 1e-4,
@@ -96,7 +136,7 @@ Note:
   .
 """
 
-direct_stokes_solver_parameters = {
+direct_stokes_solver_parameters: dict[str, str] = {
     "mat_type": "aij",
     "ksp_type": "preonly",
     "pc_type": "lu",
@@ -116,7 +156,7 @@ Note:
   and values to extend the default ones.
 """
 
-newton_stokes_solver_parameters = {
+newton_stokes_solver_parameters: dict[str, str | int | float] = {
     "snes_type": "newtonls",
     "snes_linesearch_type": "l2",
     "snes_max_it": 100,
@@ -136,33 +176,69 @@ Note:
   dictionary via the `solver_parameters_extra` argument. This dictionary can also hold
   new pairs of keys and values to extend the default ones.
 """
-
-coupled_gia_solver_parameters = {
+gia_outer_solver_parameters: dict[str, str | float] = {
     "mat_type": "matfree",
-    "snes_type": "newtonls",
-    "snes_linesearch_type": "l2",
-    "snes_max_it": 100,
-    "snes_atol": 1e-15,
-    "snes_rtol": 1e-4,
+    "snes_type": "ksponly",
+    "ksp_type": "cg",
+    "ksp_rtol": 1e-5,
+    "pc_type": "python",
+    "pc_python_type": "gadopt.SPDAssembledPC",
+}
+
+gia_iterative_cpu_assembled_parameters: dict[str, str | float | int | bool] = {
+    "assembled_pc_type": "gamg",
+    "assembled_mg_levels_pc_type": "sor",
+    "assembled_pc_gamg_threshold": 0.01,
+    "assembled_pc_gamg_square_graph": 100,
+    "assembled_pc_gamg_coarse_eq_limit": 1000,
+    "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
+}
+
+gia_iterative_gpu_assembled_parameters: ConfigType = {
+    "assembled": {
+        "ksp_type": "preonly",
+        "pc_type": "python",
+        "pc_python_type": "firedrake.OffloadPC",
+        "offload": {
+            "pc_type": "ksp",
+            "ksp": {
+                "pc_type": "gamg",
+                "mg_levels_pc_type": "jacobi",
+                "mg_levels_ksp_max_it": 2,
+                "pc_gamg_threshold": 0.01,
+                "pc_gamg_square_graph": 100,
+                "pc_gamg_coarse_eq_limit": 1000,
+                "pc_gamg_mis_k_minimum_degree_ordering": True,
+            }
+        },
+    },
+}
+
+coupled_gia_solver_parameters: ConfigType = {
+    "mat_type": "matfree",
     "ksp_type": "gmres",
     "ksp_rtol": 1e-3,
     "pc_type": "fieldsplit",
     "pc_fieldsplit_type": "symmetric_multiplicative",
-    "fieldsplit_0_ksp_type": "cg",
-    "fieldsplit_0_pc_type": "python",
-    "fieldsplit_0_pc_python_type": "gadopt.SPDAssembledPC",
-    "fieldsplit_0_assembled_pc_type": "gamg",
-    "fieldsplit_0_assembled_mg_levels_pc_type": "sor",
-    "fieldsplit_0_ksp_rtol": 1e-5,
-    "fieldsplit_0_assembled_pc_gamg_threshold": 0.01,
-    "fieldsplit_0_assembled_pc_gamg_square_graph": 100,
-    "fieldsplit_0_assembled_pc_gamg_coarse_eq_limit": 1000,
-    "fieldsplit_0_assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-    "fieldsplit_1_ksp_type": "cg",
-    "fieldsplit_1_pc_type": "python",
-    "fieldsplit_1_pc_python_type": "firedrake.AssembledPC",
-    "fieldsplit_1_assembled_pc_type": "sor",
-    "fieldsplit_1_ksp_rtol": 1e-5,
+    "fieldsplit_0": {
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": "gadopt.SPDAssembledPC",
+        "assembled_pc_type": "gamg",
+        "assembled_mg_levels_pc_type": "sor",
+        "ksp_rtol": 1e-5,
+        "assembled_pc_gamg_threshold": 0.01,
+        "assembled_pc_gamg_square_graph": 100,
+        "assembled_pc_gamg_coarse_eq_limit": 1000,
+        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
+    },
+    "fieldsplit_1": {
+        "ksp_type": "cg",
+        "pc_type": "python",
+        "pc_python_type": "firedrake.AssembledPC",
+        "assembled_pc_type": "sor",
+        "ksp_rtol": 1e-5,
+    },
 }
 """Default iterative solver parameters for CoupledInternalVariableSolver (GIA problems).
 
@@ -197,6 +273,9 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         Dictionary of PETSc solver options or string matching one of the default sets
       solver_parameters_extra:
         Dictionary of PETSc solver options used to update the default G-ADOPT options
+      gpu_extra_parameters:
+        Dictionary of additional GPU-specific settings that StokesSolver will translate
+        into appropriate PETSc solver options
       J:
         Firedrake function representing the Jacobian of the mixed Stokes system
       constant_jacobian:
@@ -252,6 +331,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         quad_degree: int = 6,
         solver_parameters: ConfigType | str | None = None,
         solver_parameters_extra: ConfigType | None = None,
+        gpu_extra_parameters: ConfigType | None = None,
         J: fd.Function | None = None,
         constant_jacobian: bool = False,
         nullspace: fd.MixedVectorSpaceBasis | None = None,
@@ -300,7 +380,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         self.set_boundary_conditions()
         self.set_equations()
         self.set_form()
-        self.set_solver_options(solver_parameters, solver_parameters_extra)
+        self.set_solver_options(solver_parameters, solver_parameters_extra, gpu_extra_parameters)
         self.set_solver()
 
     def set_boundary_conditions(self) -> None:
@@ -373,10 +453,133 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             eq.residual(sol) for eq, sol in zip(self.equations, self.solution_split)
         )
 
+    def _use_iterative_solve(self, solver_preset: str | None) -> bool:
+        if solver_preset is not None:
+            match solver_preset:
+                case "direct":
+                    return False
+                case "iterative":
+                    return True
+                case _:
+                    raise ValueError("Solver type must be 'direct' or 'iterative'.")
+        return self.mesh.topological_dimension == 3
+
+    def _handle_gpu_settings(
+        self, gpu_extras: ConfigType | None, device_type: str | None, in_config: ConfigType
+    ) -> ConfigType:
+        # Are we running an iterative solver on a GPU-enabled system?
+        gpu_telescope_factor = (
+            1 if gpu_extras is None else int(gpu_extras.get("telescope_factor", 1))
+        )
+        if device_type is None:
+            return in_config
+        else:
+            offload_conf: ConfigType = in_config
+            if gpu_telescope_factor > 1:
+                ksp_params = in_config["assembled"]["offload"]
+                offload_conf["assembled"]["offload"] = {
+                    "ksp_type": "preonly",
+                    "pc_type": "telescope",
+                    "pc_telescope_reduction_factor": gpu_telescope_factor,
+                    "telescope": ksp_params,
+                }
+            if device_type == "CUDA":
+                # Add cuda workarounds
+                odb = fd.PETSc.Options()
+                odb["matmatmult_backend_cpu"] = None
+                odb["matptap_backend_cpu"] = None
+                if gpu_telescope_factor == 1:
+                    for k, v in iterative_cuda_workarounds_inner:
+                        offload_conf["assembled"]["offload"][k] = v
+                    odb["inner_C_loc_mat_product_algorithm_backend_cpu"] = None
+                    odb["inner_C_oth_mat_product_algorithm_backend_cpu"] = None
+                else:
+                    for k, v in iterative_cuda_workarounds_inner:
+                        offload_conf["fieldsplit_0"]["assembled"]["offload"][
+                            "telescope"
+                        ][k] = v
+            return offload_conf
+
+    def _set_monitoring_config(
+        self,
+        device_type: str | None,
+        gpu_extras: ConfigType | None,
+        iterative_solve: bool,
+    ):
+        if INFO >= log_level:
+            self.add_to_solver_config({"snes_monitor": None})
+
+        if not iterative_solve:
+            return
+        # Extra monitoring options for iterative solvers
+        gpu_telescope_factor = (
+            1 if gpu_extras is None else int(gpu_extras.get("telescope_factor", 1))
+        )
+        if self.solver_parameters.get("pc_type") == "fieldsplit":
+            if DEBUG >= log_level:
+                if device_type is None:
+                    self.add_to_solver_config(
+                        {
+                            "fieldsplit_0": {"ksp_converged_reason": None},
+                            "fieldsplit_1": {"ksp_monitor": None},
+                        }
+                    )
+                else:
+                    extra_param_dict = {
+                        "fieldsplit_0": {"assembled": {"offload": {}}},
+                        "fieldsplit_1": {"ksp_monitor": None},
+                    }
+                    if gpu_telescope_factor > 1:
+                        extra_param_dict["fieldsplit_0"]["assembled"]["offload"] = {
+                            "telescope": {"ksp": {"ksp_converged_reason": None}}
+                        }
+
+                    else:
+                        extra_param_dict["fieldsplit_0"]["assembled"]["offload"] = {
+                            "ksp": {"ksp_converged_reason": None}
+                        }
+                    self.add_to_solver_config(extra_param_dict)
+
+            elif INFO >= log_level:
+                self.add_to_solver_config(
+                    {"fieldsplit_1": {"ksp_converged_reason": None}}
+                )
+        else:
+            if device_type is None:
+                if INFO >= log_level:
+                    self.add_to_solver_config({"ksp_converged_reason": None})
+                if DEBUG >= log_level:
+                    self.add_to_solver_config({"ksp_monitor": None})
+            else:
+                extra_param_dict = {"assembled": {"offload": {}}}
+                if gpu_telescope_factor > 1:
+                    if INFO >= log_level:
+                        extra_param_dict["assembled"]["offload"]["telescope"] = {
+                            "ksp": {"ksp_converged_reason": None}
+                        }
+                    if DEBUG >= log_level:
+                        extra_param_dict["assembled"]["offload"]["telescope"]["ksp"][
+                            "ksp_monitor"
+                        ] = None
+                else:
+                    if INFO >= log_level:
+                        extra_param_dict["assembled"]["offload"]["ksp"] = {
+                            "ksp_converged_reason": None
+                        }
+                    if DEBUG >= log_level:
+                        extra_param_dict["assembled"]["offload"]["ksp"][
+                            "ksp_monitor"
+                        ] = None
+
+                self.add_to_solver_config(extra_param_dict)
+
     def set_solver_options(
         self,
         solver_preset: ConfigType | str | None,
         solver_extras: ConfigType | None,
+        gpu_extras: ConfigType | None,
+        iterative_preset: ConfigType = iterative_outer_stokes_solver_parameters,
+        direct_preset: ConfigType = direct_stokes_solver_parameters,
     ) -> None:
         """Sets PETSc solver options."""
         # Application context for the inverse mass matrix preconditioner
@@ -388,39 +591,52 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             self.register_update_callback(self.set_solver)
             return
 
-        if not depends_on(self.approximation.mu, self.solution):
-            self.add_to_solver_config({"snes_type": "ksponly"})
+        iterative_solve = self._use_iterative_solve(solver_preset)
+        if iterative_solve:
+            self.add_to_solver_config(iterative_preset)
         else:
-            self.add_to_solver_config(newton_stokes_solver_parameters)
+            self.add_to_solver_config(direct_preset)
 
-        if INFO >= log_level:
-            self.add_to_solver_config({"snes_monitor": None})
+        if "snes_type" not in self.solver_parameters:
+            if not depends_on(self.approximation.mu, self.solution):
+                # If a set of solver parameters already has a "snes_type", do not
+                # override it.
+                self.add_to_solver_config({"snes_type": "ksponly"})
+            else:
+                self.add_to_solver_config(newton_stokes_solver_parameters)
 
-        if solver_preset is not None:
-            match solver_preset:
-                case "direct":
-                    self.add_to_solver_config(direct_stokes_solver_parameters)
-                case "iterative":
-                    self.add_to_solver_config(iterative_stokes_solver_parameters)
-                case _:
-                    raise ValueError("Solver type must be 'direct' or 'iterative'.")
-        elif self.mesh.topological_dimension == 2:
-            self.add_to_solver_config(direct_stokes_solver_parameters)
-        else:
-            self.add_to_solver_config(iterative_stokes_solver_parameters)
+        # Set the PETSc error handler so that Firedrake can correctly
+        # intercept the exception from PETSc - add this to Firedrake
+        fd.PETSc.Sys.pushErrorHandler("python")
+        device_type = fd.utils.get_device_type()
+        fd.PETSc.Sys.popErrorHandler()
+        if iterative_solve:
+            if self.solver_parameters.get("pc_type") == "fieldsplit":
+                if "fieldsplit_0" not in self.solver_parameters:
+                    # If fieldsplit_0 is missing, decide which set of parameters
+                    # to use based whether we detect a GPU, and the settings the
+                    # user has specified
+                    if device_type is None:
+                        self.add_to_solver_config(iterative_fieldsplit_0_cpu_params)
+                    else:
+                        gpu_params: ConfigType = {"fieldsplit_0": None}
+                        gpu_params["fieldsplit_0"] = self._handle_gpu_settings(
+                            gpu_extras,
+                            device_type,
+                            iterative_fieldsplit_0_gpu_parameters["fieldsplit_0"],
+                        )
+                        self.add_to_solver_config(gpu_params)
+            else:
+                # Iterative solve with no fieldsplit assumes GIA
+                if device_type is None:
+                    self.add_to_solver_config(gia_iterative_cpu_assembled_parameters)
+                else:
+                    gpu_params = self._handle_gpu_settings(
+                        gpu_extras, gia_iterative_gpu_assembled_parameters
+                    )
+                    self.add_to_solver_config(gpu_params)
 
-        # Extra monitoring options for iterative solvers
-        if self.solver_parameters.get("pc_type") == "fieldsplit":
-            if DEBUG >= log_level:
-                self.add_to_solver_config(
-                    {
-                        "fieldsplit_0": {"ksp_converged_reason": None},
-                        "fieldsplit_1": {"ksp_monitor": None},
-                    }
-                )
-
-            elif INFO >= log_level:
-                self.add_to_solver_config({"fieldsplit_1": {"ksp_converged_reason": None}})
+        self._set_monitoring_config(device_type, gpu_extras, iterative_solve)
 
         self.add_to_solver_config(solver_extras)
         self.register_update_callback(self.set_solver)
@@ -496,6 +712,9 @@ class StokesSolver(StokesSolverBase):
         Dictionary of PETSc solver options or string matching one of the default sets
       solver_parameters_extra:
         Dictionary of PETSc solver options used to update the default G-ADOPT options
+      gpu_extra_parameters:
+        Dictionary of additional GPU-specific settings that StokesSolver will translate
+        into appropriate PETSc solver options
       J:
         Firedrake function representing the Jacobian of the mixed Stokes system
       constant_jacobian:
@@ -593,9 +812,16 @@ class StokesSolver(StokesSolverBase):
             )
 
     def set_solver_options(
-        self, solver_preset: ConfigType | None, solver_extras: ConfigType | None
+        self,
+        solver_preset: ConfigType | None,
+        solver_extras: ConfigType | None,
+        gpu_extras: ConfigType | None,
+        iterative_preset: ConfigType = iterative_outer_stokes_solver_parameters,
+        direct_preset: ConfigType = direct_stokes_solver_parameters,
     ) -> None:
-        super().set_solver_options(solver_preset, None)
+        super().set_solver_options(
+            solver_preset, None, gpu_extras, iterative_preset, direct_preset
+        )
         if self.free_surface_map and self.is_iterative_solver():
             # Update application context
             self.appctx["free_surface"] = self.free_surface_map
@@ -603,9 +829,13 @@ class StokesSolver(StokesSolverBase):
 
             # Gather pressure and free surface fields for Schur complement solve
             fields_ind = ",".join(map(str, range(1, len(self.solution_split))))
-            self.add_to_solver_config({"pc_fieldsplit_0_fields": "0", "pc_fieldsplit_1_fields": fields_ind})
+            self.add_to_solver_config(
+                {"pc_fieldsplit_0_fields": "0", "pc_fieldsplit_1_fields": fields_ind}
+            )
             # Update mass inverse preconditioner
-            self.add_to_solver_config({"fieldsplit_1": {"pc_python_type": "gadopt.FreeSurfaceMassInvPC"}})
+            self.add_to_solver_config(
+                {"fieldsplit_1": {"pc_python_type": "gadopt.FreeSurfaceMassInvPC"}}
+            )
         self.add_to_solver_config(solver_extras)
 
     def force_on_boundary(self, subdomain_id: int | str, **kwargs) -> fd.Function:
@@ -812,6 +1042,18 @@ class InternalVariableSolver(StokesSolverBase):
 
         super().__init__(solution, approximation, dt=dt, **kwargs)
 
+    def set_solver_options(
+        self,
+        solver_preset: ConfigType | str | None,
+        solver_extras: ConfigType | None,
+        gpu_extras: ConfigType | None,
+        iterative_preset: ConfigType = gia_outer_solver_parameters,
+        direct_preset: ConfigType = direct_stokes_solver_parameters,
+    ) -> None:
+        super().set_solver_options(
+            solver_preset, solver_extras, gpu_extras, iterative_preset, direct_preset
+        )
+
     def set_equations(self) -> None:
         self.strain = self.approximation.deviatoric_strain(self.solution)
 
@@ -1015,6 +1257,9 @@ class CoupledInternalVariableSolver(StokesSolverBase):
         self,
         solver_preset: ConfigType | str | None,
         solver_extras: ConfigType | None,
+        gpu_extras: ConfigType | None,
+        iterative_preset: ConfigType = coupled_gia_solver_parameters | newton_stokes_solver_parameters,
+        direct_preset: ConfigType = direct_stokes_solver_parameters | newton_stokes_solver_parameters
     ) -> None:
         """Sets PETSc solver options for the coupled GIA system.
 
@@ -1031,27 +1276,9 @@ class CoupledInternalVariableSolver(StokesSolverBase):
         is intentionally not used here: its Schur-complement structure is designed
         for the standard Stokes system, not the larger coupled GIA block.
         """
-        if isinstance(solver_preset, Mapping):
-            super().set_solver_options(solver_preset, solver_extras)
-            return
-
-        if solver_preset == "direct":
-            # Delegate to base class for direct_stokes_solver_parameters and
-            # monitoring, then override SNES from ksponly to Newton.
-            super().set_solver_options(solver_preset, solver_extras)
-            self.add_to_solver_config(newton_stokes_solver_parameters)
-            return
-
-        if solver_preset not in (None, "iterative"):
-            raise ValueError("Solver type must be 'direct' or 'iterative'.")
-
-        # "iterative" or no preset: use the GIA-specific coupled solver defaults.
-        # Newton SNES is already included in coupled_gia_solver_parameters.
-        self.appctx = {"mu": self.approximation.mu / self.rho_continuity}
-        self.add_to_solver_config(coupled_gia_solver_parameters)
-        if solver_extras:
-            self.add_to_solver_config(solver_extras)
-        self.register_update_callback(self.set_solver)
+        super().set_solver_options(
+            solver_preset, solver_extras, gpu_extras, iterative_preset, direct_preset
+        )
 
     def set_free_surface_boundary(
         self, params_fs: dict[str, int | bool], bc_id: int

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -13,6 +13,7 @@ a relevant set of arguments and then call the `solve` method to request a solver
 import abc
 from collections import defaultdict
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Any
 from warnings import warn
 
@@ -474,7 +475,9 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         if device_type is None:
             return in_config
         else:
-            offload_conf: ConfigType = in_config
+            # in_config can be one of the predefined config dicts, make sure it is not
+            # modified
+            offload_conf: ConfigType = deepcopy(in_config)
             if gpu_telescope_factor > 1:
                 ksp_params = in_config["assembled"]["offload"]
                 offload_conf["assembled"]["offload"] = {
@@ -605,11 +608,15 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             else:
                 self.add_to_solver_config(newton_stokes_solver_parameters)
 
-        # Set the PETSc error handler so that Firedrake can correctly
-        # intercept the exception from PETSc - add this to Firedrake
+        # Set the PETSc error handler so that Firedrake can correctly intercept the
+        # exception from PETSc if a GPU-enabled build calls this on a non-GPU enabled
+        # system - add this to Firedrake. This function returns None for a GPU-enabled
+        # build or HOST on a non-GPU enabled build when GPUs are not available.
         fd.PETSc.Sys.pushErrorHandler("python")
         device_type = fd.utils.get_device_type()
         fd.PETSc.Sys.popErrorHandler()
+        if device_type == "HOST":
+            device_type = None
         if iterative_solve:
             if self.solver_parameters.get("pc_type") == "fieldsplit":
                 if "fieldsplit_0" not in self.solver_parameters:
@@ -632,7 +639,9 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
                     self.add_to_solver_config(gia_iterative_cpu_assembled_parameters)
                 else:
                     gpu_params = self._handle_gpu_settings(
-                        gpu_extras, gia_iterative_gpu_assembled_parameters
+                        gpu_extras,
+                        device_type,
+                        gia_iterative_gpu_assembled_parameters,
                     )
                     self.add_to_solver_config(gpu_params)
 

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -36,6 +36,7 @@ from .utility import (
     log_level,
     upward_normal,
     vertical_component,
+    get_device_type
 )
 
 iterative_fieldsplit_0_cpu_params: dict[str, dict[str, str | int | float]] = {
@@ -455,6 +456,21 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         )
 
     def _use_iterative_solve(self, solver_preset: str | None) -> bool:
+        """Determine whether a short-hand solver preset is iterative or not
+
+        If a user has not provided a dict of custom solver options (handled by the
+        caller), this function determines whether G-ADOPT will use an iterative or
+        direct solver either by user input (if provided) or the mesh dimension.
+
+        Args:
+            solver_preset: The string `solver_preset` or `None` as passed to the caller
+
+        Raises:
+            ValueError: The solver_preset was not one of `None`, `iterative` or `direct`
+
+        Returns:
+            A boolean to indicate whether an iterative solver is being used
+        """
         if solver_preset is not None:
             match solver_preset:
                 case "direct":
@@ -466,8 +482,33 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         return self.mesh.topological_dimension == 3
 
     def _handle_gpu_settings(
-        self, gpu_extras: ConfigType | None, device_type: str | None, in_config: ConfigType
+        self,
+        gpu_extras: ConfigType | None,
+        device_type: str | None,
+        in_config: ConfigType,
     ) -> ConfigType:
+        """Insert GPU settings into G-ADOPT preconfigured solver settings
+
+        Apply GPU solver settings to preconfigured G-ADOPT iterative solver settings.
+        Applying these settings is complicated by the change in nesting levels required
+        for the `OffloadPC` (and potentially `PCTelescope`). Also apply any
+        device-specific workarounds to both the solver settings and directly to the
+        PETSc options database if necessary.
+
+        Args:
+            gpu_extras: GPU-specific settings. Indicates whether to apply `PCTelescope`
+            wrapping.
+            device_type: Target GPU device type (e.g., `CUDA`).
+            in_config: The iterative solver configuration containing the `OffloadPC`
+            settings. This can be a full solver dict as in the case of
+            `gia_iterative_gpu_assembled_parameters`, or can be a subset as in the case
+            of `iterative_fieldsplit_0_gpu_parameters`. Must contain an 'assembled' key
+            with a sub-dictionary containing the 'offload' key.
+
+        Returns:
+            Solver settings for the requested device configuration. Deepcopy is used to
+            avoid mutating the input.
+        """
         # Are we running an iterative solver on a GPU-enabled system?
         gpu_telescope_factor = (
             1 if gpu_extras is None else int(gpu_extras.get("telescope_factor", 1))
@@ -509,6 +550,19 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
         gpu_extras: ConfigType | None,
         iterative_solve: bool,
     ):
+        """Handle solver monitoring configuration
+
+        Applies GPU solver configurations to G-ADOPT iterative solver settings. Handles
+        the increased nesting depth required for `OffloadPC` and optional `PCTelescope`
+        wrapping. Also applies device-specific workarounds to both the solver
+        configuration dictionary and the PETSc options database when necessary.
+
+        Args:
+            device_type: Target GPU device type (e.g., `CUDA`).
+            gpu_extras: GPU-specific settings. Used to determine whether to add
+            telescope configuration.
+            iterative_solve: Whether an iterative solver is being used.
+        """
         if INFO >= log_level:
             self.add_to_solver_config({"snes_monitor": None})
 
@@ -608,15 +662,7 @@ class StokesSolverBase(SolverConfigurationMixin, abc.ABC):
             else:
                 self.add_to_solver_config(newton_stokes_solver_parameters)
 
-        # Set the PETSc error handler so that Firedrake can correctly intercept the
-        # exception from PETSc if a GPU-enabled build calls this on a non-GPU enabled
-        # system - add this to Firedrake. This function returns None for a GPU-enabled
-        # build or HOST on a non-GPU enabled build when GPUs are not available.
-        fd.PETSc.Sys.pushErrorHandler("python")
-        device_type = fd.utils.get_device_type()
-        fd.PETSc.Sys.popErrorHandler()
-        if device_type == "HOST":
-            device_type = None
+        device_type = get_device_type(gpu_extras)
         if iterative_solve:
             if self.solver_parameters.get("pc_type") == "fieldsplit":
                 if "fieldsplit_0" not in self.solver_parameters:

--- a/gadopt/utility.py
+++ b/gadopt/utility.py
@@ -13,6 +13,7 @@ import ufl
 import time
 from ufl.corealg.traversal import traverse_unique_terminals
 from firedrake.petsc import PETSc
+from firedrake.utils import get_device_type as fd_get_device_type
 from functools import cached_property
 from mpi4py import MPI
 import numpy as np
@@ -29,6 +30,8 @@ except ImportError:
 
 # TBD: do we want our own set_log_level and use logging module with handlers?
 log_level = logging.getLevelName(os.environ.get("GADOPT_LOGLEVEL", "INFO").upper())
+
+valid_devices = ("HOST", "CUDA", "HIP")
 
 
 def log(*args, level=None):
@@ -141,6 +144,48 @@ def ensure_constant(f):
         return Constant(f)
     else:
         return f
+
+
+def get_device_type(gpu_options: dict | None) -> str | None:
+    """Determine the available GPU device type.
+
+    Checks for a GPU device in the following order of priority:
+    1. The `GADOPT_DEVICE_OVERRIDE` environment variable.
+    2. The `device_type` key in the `gpu_options` dictionary.
+    3. Firedrake's `get_device_type()` function.
+
+    Returns:
+        The detected device type (e.g., `CUDA`, `HIP`). Returns `None` if the `HOST`
+        device is detected (i.e. no GPU) or if the device set in `gpu_options` or
+        returned by Firedrake's `get_device_type()` is `None`.
+
+    Raises:
+        ValueError: If `GADOPT_DEVICE_OVERRIDE` or `gpu_options["device_type"]`
+        specifies a device type not in `valid_devices`.
+    """
+    if "GADOPT_DEVICE_OVERRIDE" in os.environ:
+        device_type = os.environ["GADOPT_DEVICE_OVERRIDE"]
+        if device_type not in valid_devices:
+            raise ValueError(
+                f"Invalid device specified in GADOPT_DEVICE_OVERRIDE. Valid values are {','.join(valid_devices)}"
+            )
+    elif gpu_options is not None and "device_type" in gpu_options:
+        device_type = gpu_options["device_type"]
+        if device_type is not None and device_type not in valid_devices:
+            raise ValueError(
+                f"Invalid device specified in 'device_type' key. Valid values are {','.join(valid_devices)} or None"
+            )
+    else:
+        # Set the PETSc error handler so that Firedrake can correctly intercept the
+        # exception from PETSc if a GPU-enabled build calls this on a non-GPU enabled
+        # system - add this to Firedrake. This function returns None for a GPU-enabled
+        # build or HOST on a non-GPU enabled build when GPUs are not available.
+        PETSc.Sys.pushErrorHandler("python")
+        device_type = fd_get_device_type()
+        PETSc.Sys.popErrorHandler()
+    if device_type == "HOST":
+        return None
+    return device_type
 
 
 class CombinedSurfaceMeasure(ufl.Measure):

--- a/tests/3d_spada/3d_spada.py
+++ b/tests/3d_spada/3d_spada.py
@@ -250,23 +250,6 @@ approximation = approx(
 # needed for the solve along with the approximation, timestep and boundary conditions.
 #
 
-iterative_parameters = {"mat_type": "matfree",
-                        "snes_monitor": None,
-                        "snes_converged_reason": None,
-                        "snes_type": "ksponly",
-                        "ksp_type": "cg",
-                        "ksp_rtol": 1e-5,
-                        "ksp_converged_reason": None,
-                        "ksp_monitor": None,
-                        "pc_type": "python",
-                        "pc_python_type": "gadopt.SPDAssembledPC",
-                        "assembled_pc_type": "gamg",
-                        "assembled_mg_levels_pc_type": "sor",
-                        "assembled_pc_gamg_threshold": 0.01,
-                        "assembled_pc_gamg_square_graph": 100,
-                        "assembled_pc_gamg_coarse_eq_limit": 1000,
-                        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-                        }
 
 V_nullspace = rigid_body_modes(V, rotational=True)
 V_near_nullspace = rigid_body_modes(V, rotational=True, translations=[0, 1, 2])
@@ -277,7 +260,7 @@ coupled_solver = InternalVariableSolver(
     dt=dt,
     internal_variables=m_list,
     bcs=stokes_bcs,
-    solver_parameters=iterative_parameters,
+    solver_parameters_extra={"snes_converged_reason": None},
     nullspace=V_nullspace,
     transpose_nullspace=V_nullspace,
     near_nullspace=V_near_nullspace,

--- a/tests/3d_sphere_burgers/3d_sphere_burgers.py
+++ b/tests/3d_sphere_burgers/3d_sphere_burgers.py
@@ -312,24 +312,6 @@ approximation = approx(
     bulk_shear_ratio=args.bulk_shear_ratio)
 
 
-iterative_parameters = {"mat_type": "matfree",
-                        "snes_monitor": None,
-                        "snes_converged_reason": None,
-                        "snes_type": "ksponly",
-                        "ksp_type": "cg",
-                        "ksp_rtol": 1e-5,
-                        "ksp_converged_reason": None,
-                        "ksp_monitor": None,
-                        "pc_type": "python",
-                        "pc_python_type": "gadopt.SPDAssembledPC",
-                        "assembled_pc_type": "gamg",
-                        "assembled_mg_levels_pc_type": "sor",
-                        "assembled_pc_gamg_threshold": 0.01,
-                        "assembled_pc_gamg_square_graph": 100,
-                        "assembled_pc_gamg_coarse_eq_limit": 1000,
-                        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-                        }
-
 Z_nullspace = rigid_body_modes(V, rotational=True)
 Z_near_nullspace = rigid_body_modes(V, rotational=True, translations=[0, 1, 2])
 
@@ -339,7 +321,7 @@ coupled_solver = InternalVariableSolver(
     dt=dt,
     internal_variables=m_list,
     bcs=stokes_bcs,
-    solver_parameters=iterative_parameters,
+    solver_parameters_extra={"snes_converged_reason": None},
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,
     near_nullspace=Z_near_nullspace,

--- a/tests/3d_weerdesteijn/3d_weerdesteijn.py
+++ b/tests/3d_weerdesteijn/3d_weerdesteijn.py
@@ -346,25 +346,6 @@ approximation = approx(
     bulk_modulus=bulk_modulus, density=density, shear_modulus=shear_mod_list,
     viscosity=visc_list, B_mu=B_mu, bulk_shear_ratio=args.bulk_shear_ratio)
 
-iterative_parameters = {"mat_type": "matfree",
-                        "snes_monitor": None,
-                        "snes_converged_reason": None,
-                        "snes_type": "ksponly",
-                        "ksp_type": "cg",
-                        "ksp_rtol": 1e-5,
-                        "ksp_converged_reason": None,
-                        "ksp_monitor": None,
-                        "pc_type": "python",
-                        "pc_fieldsplit_type": "firedrake.AssembledPC",
-                        "pc_python_type": "gadopt.SPDAssembledPC",
-                        "assembled_pc_type": "gamg",
-                        "assembled_mg_levels_pc_type": "sor",
-                        "assembled_pc_gamg_threshold": args.gamg_threshold,
-                        "assembled_pc_gamg_square_graph": 100,
-                        "assembled_pc_gamg_coarse_eq_limit": 1000,
-                        "assembled_pc_gamg_mis_k_minimum_degree_ordering": True,
-                        }
-
 Z_nullspace = None  # Default: don't add nullspace for now
 Z_near_nullspace = rigid_body_modes(V, rotational=args.gamg_near_null_rot,
                                     translations=[0, 1, 2])
@@ -375,7 +356,7 @@ coupled_solver = InternalVariableSolver(
     dt=dt,
     internal_variables=m_list,
     bcs=stokes_bcs,
-    solver_parameters=iterative_parameters,
+    solver_parameters_extra={"snes_converged_reason": None},
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,
     near_nullspace=Z_near_nullspace,

--- a/tests/3d_weerdesteijn_coupled/3d_weerdesteijn_coupled.py
+++ b/tests/3d_weerdesteijn_coupled/3d_weerdesteijn_coupled.py
@@ -381,7 +381,8 @@ coupled_solver = CoupledInternalVariableSolver(
     nullspace=Z_nullspace,
     transpose_nullspace=Z_nullspace,
     near_nullspace=Z_near_nullspace,
-    scaling_factor=1e6
+    scaling_factor=1e6,
+    solver_parameters_extra={"snes_atol": 1e-15, "snes_rtol": 1e-4},
 )
 
 

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -450,6 +450,14 @@ for test_type, direct_params, iter_params, device_type, gpu_param in TEST_VARIAN
             )
         )
 
+debugging_tests = [
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CPU_DEBUG_PARAMS), "HOST", {}),
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS), "CUDA", {}),
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE), "CUDA", {"telescope_factor": 2}),
+    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CPU_PARAMS | {"ksp_monitor": None}), "HOST", {}),
+    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CUDA_PARAMS | {"ksp_monitor": None}), "CUDA", {})
+]
+
 
 def idfn(fixture_value):
     if isinstance(fixture_value, str):
@@ -572,15 +580,6 @@ def test_free_surface_params():
     )
 
     assert solver.solver_parameters == ITERATIVE_FREE_SURFACE_CPU_PARAMS
-
-
-debugging_tests = [
-    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CPU_DEBUG_PARAMS), "HOST", {}),
-    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS), "CUDA", {}),
-    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE), "CUDA", {"telescope_factor": 2}),
-    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CPU_PARAMS | {"ksp_monitor": None}), "HOST", {}),
-    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CUDA_PARAMS | {"ksp_monitor": None}), "CUDA", {})
-]
 
 
 @pytest.mark.parametrize("test_type, mesh_and_fields, test_params, device, gpu_extra_parameters", debugging_tests, ids=idfn, indirect=["mesh_and_fields"])

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -3,36 +3,226 @@ import pytest
 
 from copy import deepcopy
 
-from gadopt.approximations import BoussinesqApproximation, MaxwellApproximation
+from gadopt.approximations import (
+    BoussinesqApproximation,
+    MaxwellApproximation,
+    CompressibleInternalVariableApproximation,
+)
 from gadopt.stokes_integrators import (
     StokesSolver,
     InternalVariableSolver,
+    CoupledInternalVariableSolver,
     direct_stokes_solver_parameters,
     iterative_outer_stokes_solver_parameters,
-    iterative_fieldsplit_0_cpu_params,
     newton_stokes_solver_parameters,
     gia_outer_solver_parameters,
-    gia_iterative_cpu_assembled_parameters,
+    coupled_gia_solver_parameters,
 )
 from gadopt.solver_options_manager import DeleteParam
 
-test_cases = [
+# Section 1 - Test cases
+#
+# Different solver settings need different test cases, group those here
+ITERATIVE_TEST_CASES = ["iterative"]
+
+TEST_CASES = [
     "unspecified",
     "direct",
-    "iterative",
     "dictionary",
     "cartesian_false",
     "add_parameter",
     "delete_parameter",
-    "change_tolerance",
-]
+] + ITERATIVE_TEST_CASES
 
-test_cases_mantle = ["linear_false"]
+TEST_CASES_STOKES = ["linear_false", "change_tolerance_fs"]
+TEST_CASES_STOKES_GPU = ["linear_false", "change_tolerance_fs_gpu"]
+TEST_CASES_STOKES_GPU_TELESCOPE = ["change_tolerance_fs_gpu_telescope"]
+TEST_CASES_GIA = ["change_tolerance"]
+TEST_CASES_GIA_GPU = ["change_tolerance_gpu"]
+TEST_CASES_GIA_GPU_TELESCOPE = ["change_tolerance_gpu_telescope"]
+TEST_CASES_GIA_COUPLED = ["change_tolerance_fs"]
+TEST_CASES_GIA_COUPLED_GPU = ["change_tolerance_fs_gpu"]
+
+BASE_LINEAR_PARAMS_WITH_LOG = {"snes_type": "ksponly", "snes_monitor": None}
+
+# Section 2 - Pre-defined expected solver settings
+#
+# These are constructed manually here to avoid dependence on the solver options
+# construction process being tested. Any entries to this section can use existing
+# solver MappingProxyObjects from stokes_integrators.py but any modifications to
+# those must be performed in this section and not by any of the machinery in
+# StokesSolver.set_solver_options().
+ITERATIVE_FIELDSPLIT_0_CPU = {
+    "fieldsplit_0": {
+        "ksp_type": "cg",
+        "ksp_rtol": 1e-5,
+        "ksp_max_it": 1000,
+        "pc_type": "python",
+        "pc_python_type": "gadopt.SPDAssembledPC",
+        "assembled": {
+            "pc_type": "gamg",
+            "mg_levels_pc_type": "sor",
+            "pc_gamg_threshold": 0.01,
+            "pc_gamg_square_graph": 100,
+            "pc_gamg_coarse_eq_limit": 1000,
+            "pc_gamg_mis_k_minimum_degree_ordering": True,
+        },
+    }
+}
+
+ITERATIVE_STOKES_CPU_PARAMS = (
+    dict(iterative_outer_stokes_solver_parameters)
+    | {
+        "fieldsplit_1": iterative_outer_stokes_solver_parameters["fieldsplit_1"]
+        | {"ksp_converged_reason": None}
+    }
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_CPU)
+)
+
+ITERATIVE_FIELDSPLIT_0_GPU = {
+    "fieldsplit_0": {
+        "ksp_type": "preonly",
+        "pc_type": "python",
+        "pc_python_type": "gadopt.SPDAssembledPC",
+        "assembled": {
+            "ksp_type": "preonly",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.OffloadPC",
+            "offload": {
+                "ksp_type": "preonly",
+                "pc_type": "ksp",
+                "ksp": {
+                    "ksp_type": "cg",
+                    "ksp_rtol": 1e-5,
+                    "ksp_max_it": 1000,
+                    "pc_type": "gamg",
+                    "mg_levels_pc_type": "jacobi",
+                    "mg_levels_ksp_max_it": 2,
+                    "pc_gamg_threshold": 0.01,
+                    "pc_gamg_square_graph": 100,
+                    "pc_gamg_coarse_eq_limit": 1000,
+                    "pc_gamg_mis_k_minimum_degree_ordering": True,
+                    "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
+                    "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
+                    "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
+                },
+            },
+        },
+    }
+}
+
+ITERATIVE_STOKES_GPU_PARAMS = (
+    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
+    | iterative_outer_stokes_solver_parameters
+    | {
+        "fieldsplit_1": iterative_outer_stokes_solver_parameters["fieldsplit_1"]
+        | {"ksp_converged_reason": None}
+    }
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU)
+)
+
+ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE = {
+    "fieldsplit_0": {
+        "ksp_type": "preonly",
+        "pc_type": "python",
+        "pc_python_type": "gadopt.SPDAssembledPC",
+        "assembled": {
+            "ksp_type": "preonly",
+            "pc_type": "python",
+            "pc_python_type": "firedrake.OffloadPC",
+            "offload": {
+                "ksp_type": "preonly",
+                "pc_type": "telescope",
+                "pc_telescope_reduction_factor": 2,
+                "telescope": {
+                    "ksp_type": "preonly",
+                    "pc_type": "ksp",
+                    "ksp": {
+                        "ksp_type": "cg",
+                        "ksp_rtol": 1e-5,
+                        "ksp_max_it": 1000,
+                        "pc_type": "gamg",
+                        "mg_levels_pc_type": "jacobi",
+                        "mg_levels_ksp_max_it": 2,
+                        "pc_gamg_threshold": 0.01,
+                        "pc_gamg_square_graph": 100,
+                        "pc_gamg_coarse_eq_limit": 1000,
+                        "pc_gamg_mis_k_minimum_degree_ordering": True,
+                        "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
+                        "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
+                        "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
+                    },
+                },
+            },
+        },
+    }
+}
+
+ITERATIVE_STOKES_GPU_PARAMS_TELESCOPE = (
+    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
+    | iterative_outer_stokes_solver_parameters
+    | {
+        "fieldsplit_1": iterative_outer_stokes_solver_parameters["fieldsplit_1"]
+        | {"ksp_converged_reason": None}
+    }
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE)
+)
+
+ITERATIVE_GIA_CPU_PARAMS = (
+    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
+    | gia_outer_solver_parameters
+    | {"ksp_converged_reason": None}
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_CPU["fieldsplit_0"])
+)
+
+ITERATIVE_GIA_GPU_PARAMS = (
+    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
+    | gia_outer_solver_parameters
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU["fieldsplit_0"])
+)
+ITERATIVE_GIA_GPU_PARAMS["assembled"]["offload"]["ksp"]["ksp_converged_reason"] = None
+
+ITERATIVE_GIA_GPU_PARAMS_TELESCOPE = (
+    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
+    | gia_outer_solver_parameters
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE["fieldsplit_0"])
+)
+ITERATIVE_GIA_GPU_PARAMS_TELESCOPE["assembled"]["offload"]["telescope"]["ksp"]["ksp_converged_reason"] = None
+
+ITERATIVE_GIA_COUPLED_CPU_PARAMS = (
+    {"snes_monitor": None}
+    | coupled_gia_solver_parameters
+    | {
+        "fieldsplit_1": coupled_gia_solver_parameters["fieldsplit_1"]
+        | {"ksp_converged_reason": None}
+    }
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_CPU)
+    | newton_stokes_solver_parameters
+)
+
+ITERATIVE_GIA_COUPLED_GPU_PARAMS = (
+    {"snes_monitor": None}
+    | coupled_gia_solver_parameters
+    | {
+        "fieldsplit_1": coupled_gia_solver_parameters["fieldsplit_1"]
+        | {"ksp_converged_reason": None}
+    }
+    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU)
+    | newton_stokes_solver_parameters
+)
+
+DIRECT_GIA_COUPLED_CPU_PARAMS = (
+    newton_stokes_solver_parameters | direct_stokes_solver_parameters
+)
 
 
-@pytest.mark.parametrize("test_case", test_cases + test_cases_mantle)
-def test_solver_parameters_argument(test_case):
+# Section 3 - Mesh and Fields Fixtures
+#
+# Define fixtures for mesh and fields for Stokes 2D, Stokes 3D, GIA and Coupled GIA.
+@pytest.fixture
+def stokes_mesh_and_fields():
     mesh = fd.UnitSquareMesh(10, 10)
+    mesh.cartesian = True
 
     func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
     func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
@@ -42,69 +232,235 @@ def test_solver_parameters_argument(test_case):
     func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
     temperature = fd.Function(func_space_temp, name="Temperature")
 
-    base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
-    example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
+    return mesh, stokes_function, temperature
 
-    mu = 1
+
+@pytest.fixture
+def stokes_mesh_and_fields_3d():
+    mesh = fd.UnitCubeMesh(2, 2, 2)
     mesh.cartesian = True
 
-    # Create copies of the solver parameters
-    direct_params = deepcopy(direct_stokes_solver_parameters)
-    iterative_params = deepcopy(iterative_outer_stokes_solver_parameters)
-    iterative_params["fieldsplit_0"] = deepcopy(iterative_fieldsplit_0_cpu_params)["fieldsplit_0"]
-    newton_params = deepcopy(newton_stokes_solver_parameters)
+    func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
+    func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
+    func_space_stokes = fd.MixedFunctionSpace([func_space_vel, func_space_pres])
+    stokes_function = fd.Function(func_space_stokes)
 
-    match test_case:
-        case "unspecified":
-            solver_parameters = None
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | direct_params
-        case "direct":
-            solver_parameters = "direct"
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | direct_params
-        case "iterative":
-            solver_parameters = "iterative"
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | iterative_params
-            expected_value["fieldsplit_1"]["ksp_converged_reason"] = None
-        case "dictionary":
-            solver_parameters = example_solver_params
-            solver_parameters_extra = None
-            expected_value = example_solver_params
-        case "cartesian_false":
-            mesh.cartesian = False
-            solver_parameters = None
-            solver_parameters_extra = None
-            expected_value = (
-                base_linear_params_with_log | direct_stokes_solver_parameters
-            )
-        case "linear_false":
-            mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
-            solver_parameters = "direct"
-            solver_parameters_extra = None
-            expected_value = {"snes_monitor": None} | newton_params | direct_params
-        case "add_parameter":
-            solver_parameters = None
-            solver_parameters_extra = {"ksp_converged_reason": None}
-            expected_value = (
-                {"ksp_converged_reason": None} | base_linear_params_with_log | direct_params
-            )
-        case "delete_parameter":
-            solver_parameters = None
-            solver_parameters_extra = {"snes_monitor": DeleteParam}
-            expected_value = base_linear_params_with_log | direct_params
-            del expected_value["snes_monitor"]
-        case "change_tolerance":
-            solver_parameters = "iterative"
-            solver_parameters_extra = {
+    func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
+    temperature = fd.Function(func_space_temp, name="Temperature")
+
+    return mesh, stokes_function, temperature
+
+
+@pytest.fixture
+def gia_mesh_and_fields():
+    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
+    mesh.cartesian = True
+
+    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
+    S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
+    DQ0 = fd.FunctionSpace(mesh, "DQ", 0)  # Density/viscosity/shear modulus function space
+    u = fd.Function(V, name="displacement")  # field to hold our displacement solution
+    m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
+    density = fd.Function(DQ0).assign(1)
+
+    return mesh, u, m, density
+
+
+@pytest.fixture
+def coupled_gia_mesh_and_fields():
+    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
+    mesh.cartesian = True
+
+    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
+    S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
+    DQ0 = fd.FunctionSpace(mesh, "DQ", 0)      # Density/viscosity/shear modulus function space
+
+    Z = fd.MixedFunctionSpace([V, S])
+    z = fd.Function(Z)
+    density = fd.Function(DQ0).assign(1)
+
+    return mesh, z, density
+
+
+# Section 4 - Test definitions
+#
+# Constructs a dictionary with the test names as keys and a dict containing
+# 'solver_parameters', 'solver_parameters_extra', 'expected', 'mu' and
+# 'cartesian' keys. The argument to the fixture defines the configuration to be
+# tested, expected parameters and the dimensionality of the problem. The configs
+# dict is constructed in-place as much as possible.
+@pytest.fixture
+def test_case_config(request):
+
+    cfg, direct_base, iterative_base, dim = request.param
+
+    iterative_different_tolerance = deepcopy(iterative_base)
+    if iterative_base["pc_type"] == "fieldsplit":
+        # Indicates GPU solve
+        if iterative_base["fieldsplit_0"]["ksp_type"] == "preonly":
+            # Indicates 'telescope_factor' has been specified
+            if "telescope" in iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]:
+                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
+            else:
+                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
+        else:
+            iterative_different_tolerance["fieldsplit_0"]["ksp_rtol"] = 1e-4
+        iterative_different_tolerance["fieldsplit_1"]["ksp_rtol"] = 1e-3
+    else:
+        # Indicates GPU solve
+        if iterative_base["ksp_type"] == "preonly":
+            # Indicates 'telescope_factor' has been specified
+            if "telescope" in iterative_different_tolerance["assembled"]["offload"]:
+                iterative_different_tolerance["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
+            else:
+                iterative_different_tolerance["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
+        else:
+            iterative_different_tolerance["ksp_rtol"] = 1e-4
+    configs = {
+        "unspecified": {
+            "solver_parameters": None,
+            "solver_parameters_extra": None,
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | (direct_base if dim == 2 else iterative_base),
+            "mu": 1,
+            "cartesian": True,
+        },
+        "direct": {
+            "solver_parameters": "direct",
+            "solver_parameters_extra": None,
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | direct_base,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "iterative": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": None,
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_base,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "dictionary": {
+            "solver_parameters": {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"},
+            "solver_parameters_extra": None,
+            "expected": {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"},
+            "mu": 1,
+            "cartesian": True,
+        },
+        "cartesian_false": {
+            "solver_parameters": None,
+            "solver_parameters_extra": None,
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | (direct_base if dim == 2 else iterative_base),
+            "mu": 1,
+            "cartesian": False,
+        },
+        "add_parameter": {
+            "solver_parameters": None,
+            "solver_parameters_extra": {"ksp_converged_reason": None},
+            "expected": {"ksp_converged_reason": None}
+            | BASE_LINEAR_PARAMS_WITH_LOG | (direct_base if dim == 2 else iterative_base),
+            "mu": 1,
+            "cartesian": True,
+        },
+        "delete_parameter": {
+            "solver_parameters": None,
+            "solver_parameters_extra": {"snes_monitor": DeleteParam},
+            "expected": {"snes_type": "ksponly"} | (direct_base if dim == 2 else iterative_base),
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance_fs": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {
                 "fieldsplit_0": {"ksp_rtol": 1e-4},
                 "fieldsplit_1": {"ksp_rtol": 1e-3},
-            }
-            expected_value = base_linear_params_with_log | iterative_params
-            expected_value["fieldsplit_0"]["ksp_rtol"] = 1e-4
-            expected_value["fieldsplit_1"]["ksp_rtol"] = 1e-3
-            expected_value["fieldsplit_1"]["ksp_converged_reason"] = None
+            },
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance_fs_gpu": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {
+                "fieldsplit_0": {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}},
+                "fieldsplit_1": {"ksp_rtol": 1e-3},
+            },
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance_fs_gpu_telescope": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {
+                "fieldsplit_0": {
+                    "assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}
+                },
+                "fieldsplit_1": {"ksp_rtol": 1e-3},
+            },
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {"ksp_rtol": 1e-4},
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance_gpu": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {
+                "assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}
+            },
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "change_tolerance_gpu_telescope": {
+            "solver_parameters": "iterative",
+            "solver_parameters_extra": {
+                "assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}
+            },
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
+            "mu": 1,
+            "cartesian": True,
+        },
+        "linear_false": {
+            "solver_parameters": "direct",
+            "solver_parameters_extra": None,
+            "expected": BASE_LINEAR_PARAMS_WITH_LOG
+            | direct_base
+            | newton_stokes_solver_parameters,
+            "mu": "sym_grad",  # Marker for non-constant mu
+            "cartesian": True,
+        },
+    }
+
+    return configs[cfg]
+
+
+# Section 5 - Tests
+#
+# Selects the relevant tests and expected results for a given solver setup. Different
+# solver setups have different relevant tests.
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_STOKES
+    ],
+    ids=TEST_CASES + TEST_CASES_STOKES,
+    indirect=True,
+)
+def test_stokes_solver_parameters_cpu(test_case_config, stokes_mesh_and_fields):
+    mesh, stokes_function, temperature = stokes_mesh_and_fields
+
+    # Apply cartesian flag override per test case
+    mesh.cartesian = test_case_config["cartesian"]
+
+    # Handle non-standard viscosity definition
+    mu = test_case_config["mu"]
+    if mu == "sym_grad":
+        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
 
     approximation = BoussinesqApproximation(1, mu=mu)
 
@@ -112,100 +468,283 @@ def test_solver_parameters_argument(test_case):
         stokes_function,
         approximation,
         temperature,
-        solver_parameters=solver_parameters,
-        solver_parameters_extra=solver_parameters_extra,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "HOST"},
     )
 
-    assert stokes_solver.solver_parameters == expected_value
-
-    with pytest.raises(ValueError):
-        StokesSolver(stokes_function, approximation, temperature, solver_parameters="")
+    # Verify solver parameters match expected configuration
+    assert stokes_solver.solver_parameters == test_case_config["expected"]
 
 
-@pytest.mark.parametrize("test_case", test_cases)
-def test_gia_solver_parameters_argument(test_case):
-    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, 3)
+        for i in TEST_CASES + TEST_CASES_STOKES
+    ],
+    ids=TEST_CASES + TEST_CASES_STOKES,
+    indirect=True,
+)
+def test_stokes_solver_parameters_cpu_3d(test_case_config, stokes_mesh_and_fields_3d):
+    mesh, stokes_function, temperature = stokes_mesh_and_fields_3d
 
-    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
-    S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
-    DQ0 = fd.FunctionSpace(mesh, "DQ", 0)  # Density/viscosity/shear modulus function space
-    u = fd.Function(V, name="displacement")  # field to hold our displacement solution
-    m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
+    # Apply cartesian flag override per test case
+    mesh.cartesian = test_case_config["cartesian"]
 
-    base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
-    example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
+    # Handle non-standard viscosity definition
+    mu = test_case_config["mu"]
+    if mu == "sym_grad":
+        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
 
-    mesh.cartesian = True
+    approximation = BoussinesqApproximation(1, mu=mu)
 
-    # Create copies of the solver parameters
-    direct_params = deepcopy(direct_stokes_solver_parameters)
-    iterative_params = deepcopy(gia_outer_solver_parameters) | deepcopy(
-        gia_iterative_cpu_assembled_parameters
+    stokes_solver = StokesSolver(
+        stokes_function,
+        approximation,
+        temperature,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "HOST"},
     )
 
-    match test_case:
-        case "unspecified":
-            solver_parameters = None
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | direct_params
-        case "direct":
-            solver_parameters = "direct"
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | direct_params
-        case "iterative":
-            solver_parameters = "iterative"
-            solver_parameters_extra = None
-            expected_value = base_linear_params_with_log | iterative_params
-            expected_value["ksp_converged_reason"] = None
-        case "dictionary":
-            solver_parameters = example_solver_params
-            solver_parameters_extra = None
-            expected_value = example_solver_params
-        case "cartesian_false":
-            mesh.cartesian = False
-            solver_parameters = None
-            solver_parameters_extra = None
-            expected_value = (
-                base_linear_params_with_log | direct_stokes_solver_parameters
-            )
-        case "add_parameter":
-            solver_parameters = None
-            solver_parameters_extra = {"ksp_converged_reason": None}
-            expected_value = (
-                {"ksp_converged_reason": None} | base_linear_params_with_log | direct_params
-            )
-        case "delete_parameter":
-            solver_parameters = None
-            solver_parameters_extra = {"snes_monitor": DeleteParam}
-            expected_value = base_linear_params_with_log | direct_params
-            del expected_value["snes_monitor"]
-        case "change_tolerance":
-            solver_parameters = "iterative"
-            solver_parameters_extra = {"ksp_rtol": 1e-4}
-            expected_value = base_linear_params_with_log | iterative_params
-            expected_value["ksp_rtol"] = 1e-4
-            expected_value["ksp_converged_reason"] = None
+    # Verify solver parameters match expected configuration
+    assert stokes_solver.solver_parameters == test_case_config["expected"]
 
-    density = fd.Function(DQ0).assign(1)
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_GPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_STOKES_GPU
+    ],
+    ids=TEST_CASES + TEST_CASES_STOKES_GPU,
+    indirect=True,
+)
+def test_stokes_solver_parameters_gpu(test_case_config, stokes_mesh_and_fields):
+    mesh, stokes_function, temperature = stokes_mesh_and_fields
+
+    # Apply cartesian flag override per test case
+    mesh.cartesian = test_case_config["cartesian"]
+
+    # Handle non-standard viscosity definition
+    mu = test_case_config["mu"]
+    if mu == "sym_grad":
+        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
+
+    approximation = BoussinesqApproximation(1, mu=mu)
+
+    stokes_solver = StokesSolver(
+        stokes_function,
+        approximation,
+        temperature,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "CUDA"},
+    )
+
+    # Verify solver parameters match expected configuration
+    assert stokes_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_GPU_PARAMS_TELESCOPE, 2)
+        for i in ITERATIVE_TEST_CASES + TEST_CASES_STOKES_GPU_TELESCOPE
+    ],
+    ids=ITERATIVE_TEST_CASES + TEST_CASES_STOKES_GPU_TELESCOPE,
+    indirect=True,
+)
+def test_stokes_solver_parameters_gpu_telescope(
+    test_case_config, stokes_mesh_and_fields
+):
+    mesh, stokes_function, temperature = stokes_mesh_and_fields
+
+    # Apply cartesian flag override per test case
+    mesh.cartesian = test_case_config["cartesian"]
+
+    approximation = BoussinesqApproximation(1)
+
+    stokes_solver = StokesSolver(
+        stokes_function,
+        approximation,
+        temperature,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "CUDA", "telescope_factor": 2},
+    )
+
+    # Verify solver parameters match expected configuration
+    assert stokes_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_CPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_GIA
+    ],
+    ids=TEST_CASES + TEST_CASES_GIA,
+    indirect=True,
+)
+def test_gia_solver_parameters_cpu(test_case_config, gia_mesh_and_fields):
+    mesh, u, m, density = gia_mesh_and_fields
+
+    mesh.cartesian = test_case_config["cartesian"]
+
     approximation = MaxwellApproximation(
-        bulk_modulus=1,
-        viscosity=1,
-        shear_modulus=1,
-        B_mu=1.27,
-        density=density)
+        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+    )
 
-    stokes_solver = InternalVariableSolver(
+    gia_solver = InternalVariableSolver(
         u,
         approximation,
         dt=1,
         internal_variables=m,
-        solver_parameters=solver_parameters,
-        solver_parameters_extra=solver_parameters_extra,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "HOST"},
     )
 
-    assert stokes_solver.solver_parameters == expected_value
+    assert gia_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_GPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_GIA_GPU
+    ],
+    ids=TEST_CASES + TEST_CASES_GIA,
+    indirect=True,
+)
+def test_gia_solver_parameters_gpu(test_case_config, gia_mesh_and_fields):
+    mesh, u, m, density = gia_mesh_and_fields
+
+    mesh.cartesian = test_case_config["cartesian"]
+
+    approximation = MaxwellApproximation(
+        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+    )
+
+    gia_solver = InternalVariableSolver(
+        u,
+        approximation,
+        dt=1,
+        internal_variables=m,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "CUDA"},
+    )
+
+    assert gia_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_GPU_PARAMS_TELESCOPE, 2)
+        for i in ITERATIVE_TEST_CASES + TEST_CASES_GIA_GPU_TELESCOPE
+    ],
+    ids=ITERATIVE_TEST_CASES + TEST_CASES_GIA_GPU_TELESCOPE,
+    indirect=True,
+)
+def test_gia_solver_parameters_gpu_telescope(test_case_config, gia_mesh_and_fields):
+    mesh, u, m, density = gia_mesh_and_fields
+
+    mesh.cartesian = test_case_config["cartesian"]
+
+    approximation = MaxwellApproximation(
+        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+    )
+
+    gia_solver = InternalVariableSolver(
+        u,
+        approximation,
+        dt=1,
+        internal_variables=m,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "CUDA", "telescope_factor": 2},
+    )
+
+    assert gia_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_CPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_GIA_COUPLED
+    ],
+    ids=TEST_CASES + TEST_CASES_GIA_COUPLED,
+    indirect=True,
+)
+def test_gia_coupled_solver_parameters_cpu(
+    test_case_config, coupled_gia_mesh_and_fields
+):
+    mesh, z, density = coupled_gia_mesh_and_fields
+
+    mesh.cartesian = test_case_config["cartesian"]
+
+    approximation = CompressibleInternalVariableApproximation(
+        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+    )
+
+    coupled_solver = CoupledInternalVariableSolver(
+        z,
+        approximation,
+        dt=0.1,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "HOST"},
+    )
+
+    assert coupled_solver.solver_parameters == test_case_config["expected"]
+
+
+@pytest.mark.parametrize(
+    "test_case_config",
+    [
+        (i, DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_GPU_PARAMS, 2)
+        for i in TEST_CASES + TEST_CASES_GIA_COUPLED_GPU
+    ],
+    ids=TEST_CASES + TEST_CASES_GIA_COUPLED_GPU,
+    indirect=True,
+)
+def test_gia_coupled_solver_parameters_gpu(
+    test_case_config, coupled_gia_mesh_and_fields
+):
+    mesh, z, density = coupled_gia_mesh_and_fields
+
+    mesh.cartesian = test_case_config["cartesian"]
+
+    approximation = CompressibleInternalVariableApproximation(
+        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+    )
+
+    coupled_solver = CoupledInternalVariableSolver(
+        z,
+        approximation,
+        dt=0.1,
+        solver_parameters=test_case_config["solver_parameters"],
+        solver_parameters_extra=test_case_config["solver_parameters_extra"],
+        gpu_extra_parameters={"device_type": "CUDA"},
+    )
+
+    assert coupled_solver.solver_parameters == test_case_config["expected"]
+
+
+def test_bad_solver_params_input(stokes_mesh_and_fields):
+    _, stokes_function, temperature = stokes_mesh_and_fields
+
+    approximation = BoussinesqApproximation(1)
 
     with pytest.raises(ValueError):
-        InternalVariableSolver(
-            u, approximation, dt=1, internal_variables=m, solver_parameters=""
+        StokesSolver(
+            stokes_function,
+            approximation,
+            temperature,
+            solver_parameters="",
         )

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -1,6 +1,6 @@
 import firedrake as fd
 import pytest
-from unittest.mock import patch
+from unittest.mock import create_autospec, patch
 
 from copy import deepcopy
 
@@ -601,3 +601,27 @@ def test_debugging_config(test_type, mesh_and_fields, test_params, device, gpu_e
             device,
             gpu_extra_parameters
         )
+
+
+@pytest.mark.parametrize("mesh_and_fields", [("stokes",)], ids=idfn, indirect=True)
+def test_solver_reset(mesh_and_fields):
+    _, stokes_function, temperature = mesh_and_fields
+
+    approximation = BoussinesqApproximation(1)
+
+    # Mock the set_solver function and replace the real set_solver with the mocked
+    # function. set_solver should be called twice, once on creation of the solver
+    # object, and again when reset_solver_config is called.
+    mock_obj = create_autospec(StokesSolver.set_solver)
+    StokesSolver.set_solver = mock_obj
+    solver = StokesSolver(
+        stokes_function,
+        approximation,
+        temperature,
+        gpu_extra_parameters={"device_type": "HOST"},
+    )
+
+    assert solver.solver_parameters == BASE_LINEAR_PARAMS_WITH_LOG | direct_stokes_solver_parameters
+    solver.reset_solver_config(BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CPU_PARAMS)
+    assert solver.solver_parameters == BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CPU_PARAMS
+    assert solver.set_solver.call_count == 2

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -1,5 +1,4 @@
 import firedrake as fd
-import numpy as np
 import pytest
 
 from copy import deepcopy
@@ -16,7 +15,6 @@ from gadopt.stokes_integrators import (
     gia_iterative_cpu_assembled_parameters,
 )
 from gadopt.solver_options_manager import DeleteParam
-from gadopt.utility import initialise_background_field
 
 test_cases = [
     "unspecified",
@@ -134,8 +132,6 @@ def test_gia_solver_parameters_argument(test_case):
     u = fd.Function(V, name="displacement")  # field to hold our displacement solution
     m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
 
-    X = fd.SpatialCoordinate(mesh)
-
     base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
     example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
 
@@ -190,47 +186,13 @@ def test_gia_solver_parameters_argument(test_case):
             expected_value["ksp_rtol"] = 1e-4
             expected_value["ksp_converged_reason"] = None
 
-    domain_depth = 2891e3
-    density_scale = 4500
-    shear_modulus_scale = 1e11
-    viscosity_scale = 1e21
-    gravity_scale = 9.81
-    B_mu = fd.Constant(density_scale * domain_depth * gravity_scale / shear_modulus_scale)
-
-    radius_values_nondim = np.array([6371e3, 6301e3, 5951e3, 5701e3, 3480e3])/domain_depth
-    density_values_nondim = np.array([3037, 3438, 3871, 4978])/density_scale
-    shear_modulus_values_nondim = np.array([0.50605e11, 0.70363e11, 1.05490e11, 2.28340e11])/shear_modulus_scale
-    viscosity_values_nondim = np.array([1e40, 1e21, 1e21, 2e21])/viscosity_scale
-    bulk_shear_ratio = 2
-    bulk_modulus_values_nondim = shear_modulus_values_nondim
-
-    density = fd.Function(DQ0, name="density")
-    initialise_background_field(
-        density, density_values_nondim, X, radius_values_nondim,
-        shift=radius_values_nondim[-1])
-
-    shear_modulus = fd.Function(DQ0, name="shear modulus")
-    initialise_background_field(
-        shear_modulus, shear_modulus_values_nondim, X, radius_values_nondim,
-        shift=radius_values_nondim[-1])
-
-    bulk_modulus = fd.Function(DQ0, name="bulk modulus")
-    initialise_background_field(
-        bulk_modulus, bulk_modulus_values_nondim, X, radius_values_nondim,
-        shift=radius_values_nondim[-1])
-
-    viscosity = fd.Function(DQ0, name="viscosity")
-    initialise_background_field(
-        viscosity, viscosity_values_nondim, X, radius_values_nondim,
-        shift=radius_values_nondim[-1])
-
+    density = fd.Function(DQ0).assign(1)
     approximation = MaxwellApproximation(
-        bulk_modulus=bulk_modulus,
-        density=density,
-        shear_modulus=shear_modulus,
-        viscosity=viscosity,
-        B_mu=B_mu,
-        bulk_shear_ratio=bulk_shear_ratio)
+        bulk_modulus=1,
+        viscosity=1,
+        shear_modulus=1,
+        B_mu=1.27,
+        density=density)
 
     stokes_solver = InternalVariableSolver(
         u,

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -1,16 +1,22 @@
 import firedrake as fd
+import numpy as np
 import pytest
 
 from copy import deepcopy
 
-from gadopt.approximations import BoussinesqApproximation
+from gadopt.approximations import BoussinesqApproximation, MaxwellApproximation
 from gadopt.stokes_integrators import (
     StokesSolver,
+    InternalVariableSolver,
     direct_stokes_solver_parameters,
-    iterative_stokes_solver_parameters,
+    iterative_outer_stokes_solver_parameters,
+    iterative_fieldsplit_0_cpu_params,
     newton_stokes_solver_parameters,
+    gia_outer_solver_parameters,
+    gia_iterative_cpu_assembled_parameters,
 )
 from gadopt.solver_options_manager import DeleteParam
+from gadopt.utility import initialise_background_field
 
 test_cases = [
     "unspecified",
@@ -18,14 +24,15 @@ test_cases = [
     "iterative",
     "dictionary",
     "cartesian_false",
-    "linear_false",
     "add_parameter",
     "delete_parameter",
     "change_tolerance",
 ]
 
+test_cases_mantle = ["linear_false"]
 
-@pytest.mark.parametrize("test_case", test_cases)
+
+@pytest.mark.parametrize("test_case", test_cases + test_cases_mantle)
 def test_solver_parameters_argument(test_case):
     mesh = fd.UnitSquareMesh(10, 10)
 
@@ -45,7 +52,8 @@ def test_solver_parameters_argument(test_case):
 
     # Create copies of the solver parameters
     direct_params = deepcopy(direct_stokes_solver_parameters)
-    iterative_params = deepcopy(iterative_stokes_solver_parameters)
+    iterative_params = deepcopy(iterative_outer_stokes_solver_parameters)
+    iterative_params["fieldsplit_0"] = deepcopy(iterative_fieldsplit_0_cpu_params)["fieldsplit_0"]
     newton_params = deepcopy(newton_stokes_solver_parameters)
 
     match test_case:
@@ -114,3 +122,128 @@ def test_solver_parameters_argument(test_case):
 
     with pytest.raises(ValueError):
         StokesSolver(stokes_function, approximation, temperature, solver_parameters="")
+
+
+@pytest.mark.parametrize("test_case", test_cases)
+def test_gia_solver_parameters_argument(test_case):
+    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
+
+    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
+    S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
+    DQ0 = fd.FunctionSpace(mesh, "DQ", 0)  # Density/viscosity/shear modulus function space
+    u = fd.Function(V, name="displacement")  # field to hold our displacement solution
+    m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
+
+    X = fd.SpatialCoordinate(mesh)
+
+    base_linear_params_with_log = {"snes_type": "ksponly", "snes_monitor": None}
+    example_solver_params = {"mat_type": "aij", "ksp_type": "cg", "pc_type": "sor"}
+
+    mesh.cartesian = True
+
+    # Create copies of the solver parameters
+    direct_params = deepcopy(direct_stokes_solver_parameters)
+    iterative_params = deepcopy(gia_outer_solver_parameters) | deepcopy(
+        gia_iterative_cpu_assembled_parameters
+    )
+
+    match test_case:
+        case "unspecified":
+            solver_parameters = None
+            solver_parameters_extra = None
+            expected_value = base_linear_params_with_log | direct_params
+        case "direct":
+            solver_parameters = "direct"
+            solver_parameters_extra = None
+            expected_value = base_linear_params_with_log | direct_params
+        case "iterative":
+            solver_parameters = "iterative"
+            solver_parameters_extra = None
+            expected_value = base_linear_params_with_log | iterative_params
+            expected_value["ksp_converged_reason"] = None
+        case "dictionary":
+            solver_parameters = example_solver_params
+            solver_parameters_extra = None
+            expected_value = example_solver_params
+        case "cartesian_false":
+            mesh.cartesian = False
+            solver_parameters = None
+            solver_parameters_extra = None
+            expected_value = (
+                base_linear_params_with_log | direct_stokes_solver_parameters
+            )
+        case "add_parameter":
+            solver_parameters = None
+            solver_parameters_extra = {"ksp_converged_reason": None}
+            expected_value = (
+                {"ksp_converged_reason": None} | base_linear_params_with_log | direct_params
+            )
+        case "delete_parameter":
+            solver_parameters = None
+            solver_parameters_extra = {"snes_monitor": DeleteParam}
+            expected_value = base_linear_params_with_log | direct_params
+            del expected_value["snes_monitor"]
+        case "change_tolerance":
+            solver_parameters = "iterative"
+            solver_parameters_extra = {"ksp_rtol": 1e-4}
+            expected_value = base_linear_params_with_log | iterative_params
+            expected_value["ksp_rtol"] = 1e-4
+            expected_value["ksp_converged_reason"] = None
+
+    domain_depth = 2891e3
+    density_scale = 4500
+    shear_modulus_scale = 1e11
+    viscosity_scale = 1e21
+    gravity_scale = 9.81
+    B_mu = fd.Constant(density_scale * domain_depth * gravity_scale / shear_modulus_scale)
+
+    radius_values_nondim = np.array([6371e3, 6301e3, 5951e3, 5701e3, 3480e3])/domain_depth
+    density_values_nondim = np.array([3037, 3438, 3871, 4978])/density_scale
+    shear_modulus_values_nondim = np.array([0.50605e11, 0.70363e11, 1.05490e11, 2.28340e11])/shear_modulus_scale
+    viscosity_values_nondim = np.array([1e40, 1e21, 1e21, 2e21])/viscosity_scale
+    bulk_shear_ratio = 2
+    bulk_modulus_values_nondim = shear_modulus_values_nondim
+
+    density = fd.Function(DQ0, name="density")
+    initialise_background_field(
+        density, density_values_nondim, X, radius_values_nondim,
+        shift=radius_values_nondim[-1])
+
+    shear_modulus = fd.Function(DQ0, name="shear modulus")
+    initialise_background_field(
+        shear_modulus, shear_modulus_values_nondim, X, radius_values_nondim,
+        shift=radius_values_nondim[-1])
+
+    bulk_modulus = fd.Function(DQ0, name="bulk modulus")
+    initialise_background_field(
+        bulk_modulus, bulk_modulus_values_nondim, X, radius_values_nondim,
+        shift=radius_values_nondim[-1])
+
+    viscosity = fd.Function(DQ0, name="viscosity")
+    initialise_background_field(
+        viscosity, viscosity_values_nondim, X, radius_values_nondim,
+        shift=radius_values_nondim[-1])
+
+    approximation = MaxwellApproximation(
+        bulk_modulus=bulk_modulus,
+        density=density,
+        shear_modulus=shear_modulus,
+        viscosity=viscosity,
+        B_mu=B_mu,
+        bulk_shear_ratio=bulk_shear_ratio)
+
+    stokes_solver = InternalVariableSolver(
+        u,
+        approximation,
+        dt=1,
+        internal_variables=m,
+        solver_parameters=solver_parameters,
+        solver_parameters_extra=solver_parameters_extra,
+    )
+
+    assert stokes_solver.solver_parameters == expected_value
+
+    with pytest.raises(ValueError):
+        InternalVariableSolver(
+            u, approximation, dt=1, internal_variables=m, solver_parameters=""
+        )

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -1,5 +1,6 @@
 import firedrake as fd
 import pytest
+from unittest.mock import patch
 
 from copy import deepcopy
 
@@ -17,41 +18,32 @@ from gadopt.stokes_integrators import (
     newton_stokes_solver_parameters,
     gia_outer_solver_parameters,
     coupled_gia_solver_parameters,
+    iterative_cuda_ksp_workarounds_inner
 )
 from gadopt.solver_options_manager import DeleteParam
-
-# Section 1 - Test cases
-#
-# Different solver settings need different test cases, group those here
-ITERATIVE_TEST_CASES = ["iterative"]
 
 TEST_CASES = [
     "unspecified",
     "direct",
+    "iterative",
     "dictionary",
     "cartesian_false",
     "add_parameter",
     "delete_parameter",
-] + ITERATIVE_TEST_CASES
+    "change_tolerance",
+    "linear_false"
+]
 
-TEST_CASES_STOKES = ["linear_false", "change_tolerance_fs"]
-TEST_CASES_STOKES_GPU = ["linear_false", "change_tolerance_fs_gpu"]
-TEST_CASES_STOKES_GPU_TELESCOPE = ["change_tolerance_fs_gpu_telescope"]
-TEST_CASES_GIA = ["change_tolerance"]
-TEST_CASES_GIA_GPU = ["change_tolerance_gpu"]
-TEST_CASES_GIA_GPU_TELESCOPE = ["change_tolerance_gpu_telescope"]
-TEST_CASES_GIA_COUPLED = ["change_tolerance_fs"]
-TEST_CASES_GIA_COUPLED_GPU = ["change_tolerance_fs_gpu"]
 
-BASE_LINEAR_PARAMS_WITH_LOG = {"snes_type": "ksponly", "snes_monitor": None}
-
-# Section 2 - Pre-defined expected solver settings
+# Section 1 - Pre-defined expected solver settings
 #
 # These are constructed manually here to avoid dependence on the solver options
 # construction process being tested. Any entries to this section can use existing
 # solver MappingProxyObjects from stokes_integrators.py but any modifications to
 # those must be performed in this section and not by any of the machinery in
 # StokesSolver.set_solver_options().
+BASE_LINEAR_PARAMS_WITH_LOG = {"snes_type": "ksponly", "snes_monitor": None}
+
 ITERATIVE_FIELDSPLIT_0_CPU = {
     "fieldsplit_0": {
         "ksp_type": "cg",
@@ -79,6 +71,16 @@ ITERATIVE_STOKES_CPU_PARAMS = (
     | deepcopy(ITERATIVE_FIELDSPLIT_0_CPU)
 )
 
+ITERATIVE_STOKES_CPU_DEBUG_PARAMS = deepcopy(ITERATIVE_STOKES_CPU_PARAMS)
+ITERATIVE_STOKES_CPU_DEBUG_PARAMS["fieldsplit_0"]["ksp_converged_reason"] = None
+ITERATIVE_STOKES_CPU_DEBUG_PARAMS["fieldsplit_1"]["ksp_monitor"] = None
+
+ITERATIVE_FREE_SURFACE_CPU_PARAMS = deepcopy(ITERATIVE_STOKES_CPU_PARAMS) | {
+    "pc_fieldsplit_0_fields": "0",
+    "pc_fieldsplit_1_fields": "1,2",
+} | BASE_LINEAR_PARAMS_WITH_LOG
+ITERATIVE_FREE_SURFACE_CPU_PARAMS["fieldsplit_1"]["pc_python_type"] = "gadopt.FreeSurfaceMassInvPC"
+
 ITERATIVE_FIELDSPLIT_0_GPU = {
     "fieldsplit_0": {
         "ksp_type": "preonly",
@@ -102,16 +104,13 @@ ITERATIVE_FIELDSPLIT_0_GPU = {
                     "pc_gamg_square_graph": 100,
                     "pc_gamg_coarse_eq_limit": 1000,
                     "pc_gamg_mis_k_minimum_degree_ordering": True,
-                    "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
-                    "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
-                    "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
                 },
             },
         },
     }
 }
 
-ITERATIVE_STOKES_GPU_PARAMS = (
+ITERATIVE_STOKES_HIP_PARAMS = (
     deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
     | iterative_outer_stokes_solver_parameters
     | {
@@ -120,6 +119,14 @@ ITERATIVE_STOKES_GPU_PARAMS = (
     }
     | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU)
 )
+
+ITERATIVE_STOKES_CUDA_PARAMS = deepcopy(ITERATIVE_STOKES_HIP_PARAMS)
+ITERATIVE_STOKES_CUDA_PARAMS["fieldsplit_0"]["assembled"]["offload"]["ksp"] |= iterative_cuda_ksp_workarounds_inner
+
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS = deepcopy(ITERATIVE_STOKES_CUDA_PARAMS)
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS["fieldsplit_0"]["assembled"]["offload"]["ksp"]["ksp_converged_reason"] = None
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS["fieldsplit_1"]["ksp_monitor"] = None
+
 
 ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE = {
     "fieldsplit_0": {
@@ -148,9 +155,6 @@ ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE = {
                         "pc_gamg_square_graph": 100,
                         "pc_gamg_coarse_eq_limit": 1000,
                         "pc_gamg_mis_k_minimum_degree_ordering": True,
-                        "pc_gamg_square_0_mat_product_algorithm_backend_cpu": True,
-                        "pc_gamg_square_1_mat_product_algorithm_backend_cpu": True,
-                        "pc_gamg_square_2_mat_product_algorithm_backend_cpu": True,
                     },
                 },
             },
@@ -158,7 +162,7 @@ ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE = {
     }
 }
 
-ITERATIVE_STOKES_GPU_PARAMS_TELESCOPE = (
+ITERATIVE_STOKES_HIP_PARAMS_TELESCOPE = (
     deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
     | iterative_outer_stokes_solver_parameters
     | {
@@ -167,27 +171,38 @@ ITERATIVE_STOKES_GPU_PARAMS_TELESCOPE = (
     }
     | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE)
 )
+ITERATIVE_STOKES_CUDA_PARAMS_TELESCOPE = deepcopy(ITERATIVE_STOKES_HIP_PARAMS_TELESCOPE)
+ITERATIVE_STOKES_CUDA_PARAMS_TELESCOPE["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"] |= iterative_cuda_ksp_workarounds_inner
 
-ITERATIVE_GIA_CPU_PARAMS = (
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE = deepcopy(ITERATIVE_STOKES_CUDA_PARAMS_TELESCOPE)
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"]["ksp_converged_reason"] = None
+ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE["fieldsplit_1"]["ksp_monitor"] = None
+
+ITERATIVE_GIA_BASE = (
     deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
     | gia_outer_solver_parameters
-    | {"ksp_converged_reason": None}
-    | deepcopy(ITERATIVE_FIELDSPLIT_0_CPU["fieldsplit_0"])
 )
 
-ITERATIVE_GIA_GPU_PARAMS = (
-    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
-    | gia_outer_solver_parameters
-    | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU["fieldsplit_0"])
+ITERATIVE_GIA_CPU_PARAMS = ITERATIVE_GIA_BASE | deepcopy(
+    ITERATIVE_FIELDSPLIT_0_CPU["fieldsplit_0"] | {"ksp_converged_reason": None}
 )
-ITERATIVE_GIA_GPU_PARAMS["assembled"]["offload"]["ksp"]["ksp_converged_reason"] = None
 
-ITERATIVE_GIA_GPU_PARAMS_TELESCOPE = (
-    deepcopy(BASE_LINEAR_PARAMS_WITH_LOG)
-    | gia_outer_solver_parameters
+ITERATIVE_GIA_HIP_PARAMS = ITERATIVE_GIA_BASE | deepcopy(
+    ITERATIVE_FIELDSPLIT_0_GPU["fieldsplit_0"]
+)
+ITERATIVE_GIA_HIP_PARAMS["assembled"]["offload"]["ksp"]["ksp_converged_reason"] = None
+
+ITERATIVE_GIA_CUDA_PARAMS = deepcopy(ITERATIVE_GIA_HIP_PARAMS)
+ITERATIVE_GIA_CUDA_PARAMS["assembled"]["offload"]["ksp"] |= iterative_cuda_ksp_workarounds_inner
+
+ITERATIVE_GIA_HIP_PARAMS_TELESCOPE = (
+    deepcopy(ITERATIVE_GIA_BASE)
     | deepcopy(ITERATIVE_FIELDSPLIT_0_GPU_TELESCOPE["fieldsplit_0"])
 )
-ITERATIVE_GIA_GPU_PARAMS_TELESCOPE["assembled"]["offload"]["telescope"]["ksp"]["ksp_converged_reason"] = None
+ITERATIVE_GIA_HIP_PARAMS_TELESCOPE["assembled"]["offload"]["telescope"]["ksp"]["ksp_converged_reason"] = None
+
+ITERATIVE_GIA_CUDA_PARAMS_TELESCOPE = deepcopy(ITERATIVE_GIA_HIP_PARAMS_TELESCOPE)
+ITERATIVE_GIA_CUDA_PARAMS_TELESCOPE["assembled"]["offload"]["telescope"]["ksp"] |= iterative_cuda_ksp_workarounds_inner
 
 ITERATIVE_GIA_COUPLED_CPU_PARAMS = (
     {"snes_monitor": None}
@@ -200,7 +215,7 @@ ITERATIVE_GIA_COUPLED_CPU_PARAMS = (
     | newton_stokes_solver_parameters
 )
 
-ITERATIVE_GIA_COUPLED_GPU_PARAMS = (
+ITERATIVE_GIA_COUPLED_HIP_PARAMS = (
     {"snes_monitor": None}
     | coupled_gia_solver_parameters
     | {
@@ -211,86 +226,88 @@ ITERATIVE_GIA_COUPLED_GPU_PARAMS = (
     | newton_stokes_solver_parameters
 )
 
+ITERATIVE_GIA_COUPLED_CUDA_PARAMS = deepcopy(ITERATIVE_GIA_COUPLED_HIP_PARAMS)
+ITERATIVE_GIA_COUPLED_CUDA_PARAMS["fieldsplit_0"]["assembled"]["offload"]["ksp"] |= iterative_cuda_ksp_workarounds_inner
+
 DIRECT_GIA_COUPLED_CPU_PARAMS = (
     newton_stokes_solver_parameters | direct_stokes_solver_parameters
 )
 
-
-# Section 3 - Mesh and Fields Fixtures
+# Section 2 - Test variants
 #
-# Define fixtures for mesh and fields for Stokes 2D, Stokes 3D, GIA and Coupled GIA.
+# Construct tuples that will be used to build parameter sets for fixtures in the
+# sections. Tuples are expected to have 5 elements and contain a test type, expected
+# direct and iterative solver settings, the device type passed to the solver and any
+# additional GPU options.
+
+TEST_VARIANTS = [
+    ("stokes", direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, "HOST", {}),
+    ("stokes_hip", direct_stokes_solver_parameters, ITERATIVE_STOKES_HIP_PARAMS, "HIP", {}),
+    ("stokes_cuda", direct_stokes_solver_parameters, ITERATIVE_STOKES_CUDA_PARAMS, "CUDA", {}),
+    ("stokes_cuda_telescope", direct_stokes_solver_parameters, ITERATIVE_STOKES_CUDA_PARAMS_TELESCOPE, "CUDA", {"telescope_factor": 2}),
+    ("gia", direct_stokes_solver_parameters, ITERATIVE_GIA_CPU_PARAMS, "HOST", {}),
+    ("gia_hip", direct_stokes_solver_parameters, ITERATIVE_GIA_HIP_PARAMS, "HIP", {}),
+    ("gia_cuda", direct_stokes_solver_parameters, ITERATIVE_GIA_CUDA_PARAMS, "CUDA", {}),
+    ("gia_cuda_telescope", direct_stokes_solver_parameters, ITERATIVE_GIA_CUDA_PARAMS_TELESCOPE, "CUDA", {"telescope_factor": 2}),
+    ("coupled_gia", DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_CPU_PARAMS, "HOST", {}),
+    ("coupled_gia_gpu", DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_CUDA_PARAMS, "CUDA", {}),
+]
+
+TEST_VARIANTS_3D = [
+    ("stokes_3d", direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, "HOST", {}),
+]
+
+
+# Section 3 - Fixtures
+#
+# Define fixtures for mesh and fields and the test configurations. Differences in
+# mesh/function configuration are determined by the test type. Since the fixture
+# is evaluated before the test, raise the ValueError for invalid test type in
+# mesh_and_fields.
 @pytest.fixture
-def stokes_mesh_and_fields():
-    mesh = fd.UnitSquareMesh(10, 10)
+def mesh_and_fields(request):
+
+    test_type = request.param[0]
+
+    if test_type == "stokes_3d":
+        mesh = fd.UnitCubeMesh(4, 4, 4)
+    else:
+        mesh = fd.UnitSquareMesh(10, 10, quadrilateral="gia" in test_type)
     mesh.cartesian = True
 
-    func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
-    func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
-    func_space_stokes = fd.MixedFunctionSpace([func_space_vel, func_space_pres])
-    stokes_function = fd.Function(func_space_stokes)
+    if test_type.startswith("stokes"):
+        func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
+        func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
+        func_space_stokes = fd.MixedFunctionSpace([func_space_vel, func_space_pres])
+        stokes_function = fd.Function(func_space_stokes)
 
-    func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
-    temperature = fd.Function(func_space_temp, name="Temperature")
+        func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
+        temperature = fd.Function(func_space_temp, name="Temperature")
 
-    return mesh, stokes_function, temperature
+        return mesh, stokes_function, temperature
 
-
-@pytest.fixture
-def stokes_mesh_and_fields_3d():
-    mesh = fd.UnitCubeMesh(2, 2, 2)
-    mesh.cartesian = True
-
-    func_space_vel = fd.VectorFunctionSpace(mesh, "CG", 2)
-    func_space_pres = fd.FunctionSpace(mesh, "CG", 1)
-    func_space_stokes = fd.MixedFunctionSpace([func_space_vel, func_space_pres])
-    stokes_function = fd.Function(func_space_stokes)
-
-    func_space_temp = fd.FunctionSpace(mesh, "CG", 2)
-    temperature = fd.Function(func_space_temp, name="Temperature")
-
-    return mesh, stokes_function, temperature
-
-
-@pytest.fixture
-def gia_mesh_and_fields():
-    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
-    mesh.cartesian = True
-
+    # left with GIA tests after here
     V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
     S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
     DQ0 = fd.FunctionSpace(mesh, "DQ", 0)  # Density/viscosity/shear modulus function space
-    u = fd.Function(V, name="displacement")  # field to hold our displacement solution
-    m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
     density = fd.Function(DQ0).assign(1)
 
-    return mesh, u, m, density
+    if test_type.startswith("gia"):
+        u = fd.Function(V, name="displacement")  # field to hold our displacement solution
+        m = fd.Function(S, name="Internal variable")  # Lagged internal variable at previous timestep
+
+        return mesh, u, m, density
+    elif test_type.startswith("coupled_gia"):
+        Z = fd.MixedFunctionSpace([V, S])
+        z = fd.Function(Z)
+
+        return mesh, z, density
+    else:
+        raise ValueError(f"Invalid test type: {test_type}")
 
 
 @pytest.fixture
-def coupled_gia_mesh_and_fields():
-    mesh = fd.UnitSquareMesh(10, 10, quadrilateral=True)
-    mesh.cartesian = True
-
-    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Displacement function space
-    S = fd.TensorFunctionSpace(mesh, "DQ", 1)  # Stress tensor function space
-    DQ0 = fd.FunctionSpace(mesh, "DQ", 0)      # Density/viscosity/shear modulus function space
-
-    Z = fd.MixedFunctionSpace([V, S])
-    z = fd.Function(Z)
-    density = fd.Function(DQ0).assign(1)
-
-    return mesh, z, density
-
-
-# Section 4 - Test definitions
-#
-# Constructs a dictionary with the test names as keys and a dict containing
-# 'solver_parameters', 'solver_parameters_extra', 'expected', 'mu' and
-# 'cartesian' keys. The argument to the fixture defines the configuration to be
-# tested, expected parameters and the dimensionality of the problem. The configs
-# dict is constructed in-place as much as possible.
-@pytest.fixture
-def test_case_config(request):
+def case_configurations(request):
 
     cfg, direct_base, iterative_base, dim = request.param
 
@@ -301,10 +318,15 @@ def test_case_config(request):
             # Indicates 'telescope_factor' has been specified
             if "telescope" in iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]:
                 iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
+                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}},
+                            "fieldsplit_1": {"ksp_rtol": 1e-3}}
             else:
                 iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
+                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}},
+                            "fieldsplit_1": {"ksp_rtol": 1e-3}}
         else:
             iterative_different_tolerance["fieldsplit_0"]["ksp_rtol"] = 1e-4
+            tol_dict = {"fieldsplit_0": {"ksp_rtol": 1e-4}, "fieldsplit_1": {"ksp_rtol": 1e-3}}
         iterative_different_tolerance["fieldsplit_1"]["ksp_rtol"] = 1e-3
     else:
         # Indicates GPU solve
@@ -312,10 +334,13 @@ def test_case_config(request):
             # Indicates 'telescope_factor' has been specified
             if "telescope" in iterative_different_tolerance["assembled"]["offload"]:
                 iterative_different_tolerance["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
+                tol_dict = {"assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}}
             else:
                 iterative_different_tolerance["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
+                tol_dict = {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}}
         else:
             iterative_different_tolerance["ksp_rtol"] = 1e-4
+            tol_dict = {"ksp_rtol": 1e-4}
     configs = {
         "unspecified": {
             "solver_parameters": None,
@@ -367,59 +392,9 @@ def test_case_config(request):
             "mu": 1,
             "cartesian": True,
         },
-        "change_tolerance_fs": {
-            "solver_parameters": "iterative",
-            "solver_parameters_extra": {
-                "fieldsplit_0": {"ksp_rtol": 1e-4},
-                "fieldsplit_1": {"ksp_rtol": 1e-3},
-            },
-            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
-            "mu": 1,
-            "cartesian": True,
-        },
-        "change_tolerance_fs_gpu": {
-            "solver_parameters": "iterative",
-            "solver_parameters_extra": {
-                "fieldsplit_0": {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}},
-                "fieldsplit_1": {"ksp_rtol": 1e-3},
-            },
-            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
-            "mu": 1,
-            "cartesian": True,
-        },
-        "change_tolerance_fs_gpu_telescope": {
-            "solver_parameters": "iterative",
-            "solver_parameters_extra": {
-                "fieldsplit_0": {
-                    "assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}
-                },
-                "fieldsplit_1": {"ksp_rtol": 1e-3},
-            },
-            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
-            "mu": 1,
-            "cartesian": True,
-        },
         "change_tolerance": {
             "solver_parameters": "iterative",
-            "solver_parameters_extra": {"ksp_rtol": 1e-4},
-            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
-            "mu": 1,
-            "cartesian": True,
-        },
-        "change_tolerance_gpu": {
-            "solver_parameters": "iterative",
-            "solver_parameters_extra": {
-                "assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}
-            },
-            "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
-            "mu": 1,
-            "cartesian": True,
-        },
-        "change_tolerance_gpu_telescope": {
-            "solver_parameters": "iterative",
-            "solver_parameters_extra": {
-                "assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}
-            },
+            "solver_parameters_extra": tol_dict,
             "expected": BASE_LINEAR_PARAMS_WITH_LOG | iterative_different_tolerance,
             "mu": 1,
             "cartesian": True,
@@ -438,306 +413,125 @@ def test_case_config(request):
     return configs[cfg]
 
 
+# Section 4 - Test parameters
+#
+# Construct test parameter tuples. Note that the 2nd and 3rd elements of this tuple
+# are passed as arguments to their respective fixtures (test_case_config and
+# mesh_and_fields), whereas the remainder are used directly. The GIA solver is in
+# control of whether to use (non)-linear parameters, hence exclude the combination
+# of "gia" and "linear_false"
+all_tests = []
+for test_type, direct_params, iter_params, device_type, gpu_param in TEST_VARIANTS:
+    for case in TEST_CASES:
+        # GIA tests do not have a linear/non-linear option
+        if "gia" in test_type and case == "linear_false":
+            continue
+        all_tests.append(
+            (
+                test_type,
+                (case, direct_params, iter_params, 2),
+                (test_type,),
+                device_type,
+                gpu_param,
+            )
+        )
+for test_type, direct_params, iter_params, device_type, gpu_param in TEST_VARIANTS_3D:
+    for case in TEST_CASES:
+        # GIA tests do not have a linear/non-linear option
+        if "gia" in test_type and case == "linear_false":
+            continue
+        all_tests.append(
+            (
+                test_type,
+                (case, direct_params, iter_params, 3),
+                (test_type,),
+                device_type,
+                gpu_param,
+            )
+        )
+
+
+def idfn(fixture_value):
+    if isinstance(fixture_value, str):
+        return fixture_value
+    elif isinstance(fixture_value, tuple):
+        return fixture_value[0]
+    else:
+        return ""
+
+
 # Section 5 - Tests
 #
-# Selects the relevant tests and expected results for a given solver setup. Different
-# solver setups have different relevant tests.
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_STOKES
-    ],
-    ids=TEST_CASES + TEST_CASES_STOKES,
-    indirect=True,
-)
-def test_stokes_solver_parameters_cpu(test_case_config, stokes_mesh_and_fields):
-    mesh, stokes_function, temperature = stokes_mesh_and_fields
+# Selects the relevant tests and expected results for a given solver setup.
+@pytest.mark.parametrize("test_type, case_configurations, mesh_and_fields, device_type, gpu_param", all_tests, ids=idfn, indirect=["case_configurations", "mesh_and_fields"])
+def test_solver_parameters(test_type, case_configurations, mesh_and_fields, device_type, gpu_param):
 
+    approximation = None
+    solver = None
+
+    mesh_and_field_out = mesh_and_fields
+
+    mesh = mesh_and_field_out[0]
     # Apply cartesian flag override per test case
-    mesh.cartesian = test_case_config["cartesian"]
+    mesh.cartesian = case_configurations["cartesian"]
+    gpu_extra_parameters = {"device_type": device_type} | gpu_param
 
-    # Handle non-standard viscosity definition
-    mu = test_case_config["mu"]
-    if mu == "sym_grad":
-        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
+    if test_type.startswith("stokes"):
+        _, stokes_function, temperature = mesh_and_field_out
+        # Handle non-standard viscosity definition
+        mu = case_configurations["mu"]
+        if mu == "sym_grad":
+            mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
 
-    approximation = BoussinesqApproximation(1, mu=mu)
+        approximation = BoussinesqApproximation(1, mu=mu)
 
-    stokes_solver = StokesSolver(
-        stokes_function,
-        approximation,
-        temperature,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "HOST"},
-    )
+        solver = StokesSolver(
+            stokes_function,
+            approximation,
+            temperature,
+            solver_parameters=case_configurations["solver_parameters"],
+            solver_parameters_extra=case_configurations["solver_parameters_extra"],
+            gpu_extra_parameters=gpu_extra_parameters,
+        )
+    elif test_type.startswith("gia"):
+        _, u, m, density = mesh_and_field_out
+
+        approximation = MaxwellApproximation(
+            bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+        )
+
+        solver = InternalVariableSolver(
+            u,
+            approximation,
+            dt=1,
+            internal_variables=m,
+            solver_parameters=case_configurations["solver_parameters"],
+            solver_parameters_extra=case_configurations["solver_parameters_extra"],
+            gpu_extra_parameters=gpu_extra_parameters,
+        )
+    elif test_type.startswith("coupled_gia"):
+        _, z, density = mesh_and_field_out
+
+        approximation = CompressibleInternalVariableApproximation(
+            bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
+        )
+
+        solver = CoupledInternalVariableSolver(
+            z,
+            approximation,
+            dt=0.1,
+            solver_parameters=case_configurations["solver_parameters"],
+            solver_parameters_extra=case_configurations["solver_parameters_extra"],
+            gpu_extra_parameters=gpu_extra_parameters,
+        )
 
     # Verify solver parameters match expected configuration
-    assert stokes_solver.solver_parameters == test_case_config["expected"]
+    assert solver.solver_parameters == case_configurations["expected"]
 
 
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_CPU_PARAMS, 3)
-        for i in TEST_CASES + TEST_CASES_STOKES
-    ],
-    ids=TEST_CASES + TEST_CASES_STOKES,
-    indirect=True,
-)
-def test_stokes_solver_parameters_cpu_3d(test_case_config, stokes_mesh_and_fields_3d):
-    mesh, stokes_function, temperature = stokes_mesh_and_fields_3d
-
-    # Apply cartesian flag override per test case
-    mesh.cartesian = test_case_config["cartesian"]
-
-    # Handle non-standard viscosity definition
-    mu = test_case_config["mu"]
-    if mu == "sym_grad":
-        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
-
-    approximation = BoussinesqApproximation(1, mu=mu)
-
-    stokes_solver = StokesSolver(
-        stokes_function,
-        approximation,
-        temperature,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "HOST"},
-    )
-
-    # Verify solver parameters match expected configuration
-    assert stokes_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_GPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_STOKES_GPU
-    ],
-    ids=TEST_CASES + TEST_CASES_STOKES_GPU,
-    indirect=True,
-)
-def test_stokes_solver_parameters_gpu(test_case_config, stokes_mesh_and_fields):
-    mesh, stokes_function, temperature = stokes_mesh_and_fields
-
-    # Apply cartesian flag override per test case
-    mesh.cartesian = test_case_config["cartesian"]
-
-    # Handle non-standard viscosity definition
-    mu = test_case_config["mu"]
-    if mu == "sym_grad":
-        mu = fd.sym(fd.grad(fd.split(stokes_function)[0]))
-
-    approximation = BoussinesqApproximation(1, mu=mu)
-
-    stokes_solver = StokesSolver(
-        stokes_function,
-        approximation,
-        temperature,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "CUDA"},
-    )
-
-    # Verify solver parameters match expected configuration
-    assert stokes_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_STOKES_GPU_PARAMS_TELESCOPE, 2)
-        for i in ITERATIVE_TEST_CASES + TEST_CASES_STOKES_GPU_TELESCOPE
-    ],
-    ids=ITERATIVE_TEST_CASES + TEST_CASES_STOKES_GPU_TELESCOPE,
-    indirect=True,
-)
-def test_stokes_solver_parameters_gpu_telescope(
-    test_case_config, stokes_mesh_and_fields
-):
-    mesh, stokes_function, temperature = stokes_mesh_and_fields
-
-    # Apply cartesian flag override per test case
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = BoussinesqApproximation(1)
-
-    stokes_solver = StokesSolver(
-        stokes_function,
-        approximation,
-        temperature,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "CUDA", "telescope_factor": 2},
-    )
-
-    # Verify solver parameters match expected configuration
-    assert stokes_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_CPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_GIA
-    ],
-    ids=TEST_CASES + TEST_CASES_GIA,
-    indirect=True,
-)
-def test_gia_solver_parameters_cpu(test_case_config, gia_mesh_and_fields):
-    mesh, u, m, density = gia_mesh_and_fields
-
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = MaxwellApproximation(
-        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
-    )
-
-    gia_solver = InternalVariableSolver(
-        u,
-        approximation,
-        dt=1,
-        internal_variables=m,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "HOST"},
-    )
-
-    assert gia_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_GPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_GIA_GPU
-    ],
-    ids=TEST_CASES + TEST_CASES_GIA,
-    indirect=True,
-)
-def test_gia_solver_parameters_gpu(test_case_config, gia_mesh_and_fields):
-    mesh, u, m, density = gia_mesh_and_fields
-
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = MaxwellApproximation(
-        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
-    )
-
-    gia_solver = InternalVariableSolver(
-        u,
-        approximation,
-        dt=1,
-        internal_variables=m,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "CUDA"},
-    )
-
-    assert gia_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, direct_stokes_solver_parameters, ITERATIVE_GIA_GPU_PARAMS_TELESCOPE, 2)
-        for i in ITERATIVE_TEST_CASES + TEST_CASES_GIA_GPU_TELESCOPE
-    ],
-    ids=ITERATIVE_TEST_CASES + TEST_CASES_GIA_GPU_TELESCOPE,
-    indirect=True,
-)
-def test_gia_solver_parameters_gpu_telescope(test_case_config, gia_mesh_and_fields):
-    mesh, u, m, density = gia_mesh_and_fields
-
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = MaxwellApproximation(
-        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
-    )
-
-    gia_solver = InternalVariableSolver(
-        u,
-        approximation,
-        dt=1,
-        internal_variables=m,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "CUDA", "telescope_factor": 2},
-    )
-
-    assert gia_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_CPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_GIA_COUPLED
-    ],
-    ids=TEST_CASES + TEST_CASES_GIA_COUPLED,
-    indirect=True,
-)
-def test_gia_coupled_solver_parameters_cpu(
-    test_case_config, coupled_gia_mesh_and_fields
-):
-    mesh, z, density = coupled_gia_mesh_and_fields
-
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = CompressibleInternalVariableApproximation(
-        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
-    )
-
-    coupled_solver = CoupledInternalVariableSolver(
-        z,
-        approximation,
-        dt=0.1,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "HOST"},
-    )
-
-    assert coupled_solver.solver_parameters == test_case_config["expected"]
-
-
-@pytest.mark.parametrize(
-    "test_case_config",
-    [
-        (i, DIRECT_GIA_COUPLED_CPU_PARAMS, ITERATIVE_GIA_COUPLED_GPU_PARAMS, 2)
-        for i in TEST_CASES + TEST_CASES_GIA_COUPLED_GPU
-    ],
-    ids=TEST_CASES + TEST_CASES_GIA_COUPLED_GPU,
-    indirect=True,
-)
-def test_gia_coupled_solver_parameters_gpu(
-    test_case_config, coupled_gia_mesh_and_fields
-):
-    mesh, z, density = coupled_gia_mesh_and_fields
-
-    mesh.cartesian = test_case_config["cartesian"]
-
-    approximation = CompressibleInternalVariableApproximation(
-        bulk_modulus=1, viscosity=1, shear_modulus=1, B_mu=1.27, density=density
-    )
-
-    coupled_solver = CoupledInternalVariableSolver(
-        z,
-        approximation,
-        dt=0.1,
-        solver_parameters=test_case_config["solver_parameters"],
-        solver_parameters_extra=test_case_config["solver_parameters_extra"],
-        gpu_extra_parameters={"device_type": "CUDA"},
-    )
-
-    assert coupled_solver.solver_parameters == test_case_config["expected"]
-
-
-def test_bad_solver_params_input(stokes_mesh_and_fields):
-    _, stokes_function, temperature = stokes_mesh_and_fields
+@pytest.mark.parametrize("mesh_and_fields", [("stokes",)], ids=idfn, indirect=True)
+def test_bad_solver_params_input(mesh_and_fields):
+    _, stokes_function, temperature = mesh_and_fields
 
     approximation = BoussinesqApproximation(1)
 
@@ -747,4 +541,64 @@ def test_bad_solver_params_input(stokes_mesh_and_fields):
             approximation,
             temperature,
             solver_parameters="",
+        )
+
+
+def test_free_surface_params():
+    mesh = fd.UnitCubeMesh(4, 4, 4)
+    mesh.cartesian = True
+    V = fd.VectorFunctionSpace(mesh, "CG", 2)  # Velocity function space (vector)
+    W = fd.FunctionSpace(mesh, "CG", 1)  # Pressure and free surface function space (scalar)
+    Q = fd.FunctionSpace(mesh, "CG", 2)  # Temperature function space (scalar)
+    Z = fd.MixedFunctionSpace([V, W, W])  # Mixed function space for velocity, pressure and eta.
+
+    z = fd.Function(Z)  # A field over the mixed function space Z.
+    T = fd.Function(Q)
+
+    stokes_bcs = {
+        3: {"uy": 0},
+        4: {"free_surface": {"RaFS": 10.0}},
+        1: {"ux": 0},
+        2: {"ux": 0},
+    }
+    approximation = BoussinesqApproximation(1)
+    solver = StokesSolver(
+        z,
+        approximation,
+        T,
+        dt=fd.Constant(1e-6),
+        bcs=stokes_bcs,
+        gpu_extra_parameters={"device_type": "HOST"},
+    )
+
+    assert solver.solver_parameters == ITERATIVE_FREE_SURFACE_CPU_PARAMS
+
+
+debugging_tests = [
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CPU_DEBUG_PARAMS), "HOST", {}),
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS), "CUDA", {}),
+    ("stokes", ("stokes",), ("iterative", None, BASE_LINEAR_PARAMS_WITH_LOG | ITERATIVE_STOKES_CUDA_DEBUG_PARAMS_TELESCOPE), "CUDA", {"telescope_factor": 2}),
+    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CPU_PARAMS | {"ksp_monitor": None}), "HOST", {}),
+    ("gia", ("gia",), ("iterative", None, ITERATIVE_GIA_CUDA_PARAMS | {"ksp_monitor": None}), "CUDA", {})
+]
+
+
+@pytest.mark.parametrize("test_type, mesh_and_fields, test_params, device, gpu_extra_parameters", debugging_tests, ids=idfn, indirect=["mesh_and_fields"])
+def test_debugging_config(test_type, mesh_and_fields, test_params, device, gpu_extra_parameters):
+
+    solver_parameters, solver_parameters_extra, expected = test_params
+    # Patch the version of log_level imported by stokes_integrators
+    with patch("gadopt.stokes_integrators.log_level", 10):
+        test_solver_parameters(
+            test_type,
+            {
+                "solver_parameters": solver_parameters,
+                "solver_parameters_extra": solver_parameters_extra,
+                "expected": expected,
+                "mu": 1,
+                "cartesian": True,
+            },
+            mesh_and_fields,
+            device,
+            gpu_extra_parameters
         )

--- a/tests/unit/test_stokes_solver_configuration.py
+++ b/tests/unit/test_stokes_solver_configuration.py
@@ -312,35 +312,34 @@ def case_configurations(request):
     cfg, direct_base, iterative_base, dim = request.param
 
     iterative_different_tolerance = deepcopy(iterative_base)
+    tol_dict = {"ksp_rtol": 1e-4}
     if iterative_base["pc_type"] == "fieldsplit":
         # Indicates GPU solve
         if iterative_base["fieldsplit_0"]["ksp_type"] == "preonly":
             # Indicates 'telescope_factor' has been specified
             if "telescope" in iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]:
-                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
-                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}},
-                            "fieldsplit_1": {"ksp_rtol": 1e-3}}
+                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["telescope"]["ksp"] |= tol_dict
+                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"telescope": {"ksp": tol_dict}}}}}
             else:
-                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
-                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}},
-                            "fieldsplit_1": {"ksp_rtol": 1e-3}}
+                iterative_different_tolerance["fieldsplit_0"]["assembled"]["offload"]["ksp"] |= tol_dict
+                tol_dict = {"fieldsplit_0": {"assembled": {"offload": {"ksp": tol_dict}}}}
         else:
-            iterative_different_tolerance["fieldsplit_0"]["ksp_rtol"] = 1e-4
-            tol_dict = {"fieldsplit_0": {"ksp_rtol": 1e-4}, "fieldsplit_1": {"ksp_rtol": 1e-3}}
+            iterative_different_tolerance["fieldsplit_0"] |= tol_dict
+            tol_dict = {"fieldsplit_0": tol_dict}
+        tol_dict["fieldsplit_1"] = {"ksp_rtol": 1e-3}
         iterative_different_tolerance["fieldsplit_1"]["ksp_rtol"] = 1e-3
     else:
         # Indicates GPU solve
         if iterative_base["ksp_type"] == "preonly":
             # Indicates 'telescope_factor' has been specified
             if "telescope" in iterative_different_tolerance["assembled"]["offload"]:
-                iterative_different_tolerance["assembled"]["offload"]["telescope"]["ksp"]["ksp_rtol"] = 1e-4
-                tol_dict = {"assembled": {"offload": {"telescope": {"ksp": {"ksp_rtol": 1e-4}}}}}
+                iterative_different_tolerance["assembled"]["offload"]["telescope"]["ksp"] |= tol_dict
+                tol_dict = {"assembled": {"offload": {"telescope": {"ksp": tol_dict}}}}
             else:
-                iterative_different_tolerance["assembled"]["offload"]["ksp"]["ksp_rtol"] = 1e-4
-                tol_dict = {"assembled": {"offload": {"ksp": {"ksp_rtol": 1e-4}}}}
+                iterative_different_tolerance["assembled"]["offload"]["ksp"] |= tol_dict
+                tol_dict = {"assembled": {"offload": {"ksp": tol_dict}}}
         else:
-            iterative_different_tolerance["ksp_rtol"] = 1e-4
-            tol_dict = {"ksp_rtol": 1e-4}
+            iterative_different_tolerance |= tol_dict
     configs = {
         "unspecified": {
             "solver_parameters": None,


### PR DESCRIPTION
Reorganise solver options to enable use of GPUs in Stokes/GIA solvers if a GPU is detected on the system. Adding GPU offload requires a significant reorganisation of solver options, solver options dicts have been reorganised into "inner" and "outer" sections, where the "inner" section contains the GPU-specific options. GIA iterative solver options have also been moved into `stokes_integrators.py` and given a GPU configuration as well. `set_solver_options` has been refactored to take a default direct and iterative solver configuration and has been split into three main functions, `_use_iterative_solve`, `_handle_gpu_settings` and `_set_monitoring_config`.

~~Currently blocked by~~ https://github.com/firedrakeproject/firedrake/pull/5164 is now merged! 🎉.