### PR TITLE
Use FGMRES with fixed Richardson GAMG smoothing

### DIFF
--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -47,6 +47,7 @@ iterative_stokes_solver_parameters = {
         "ksp_type": "fgmres",
         "ksp_rtol": 1e-5,
         "ksp_max_it": 1000,
+        "ksp_norm_type": "unpreconditioned",
         "pc_type": "python",
         "pc_python_type": "gadopt.SPDAssembledPC",
         "assembled_pc_type": "gamg",

--- a/gadopt/stokes_integrators.py
+++ b/gadopt/stokes_integrators.py
@@ -44,12 +44,15 @@ iterative_stokes_solver_parameters = {
     "pc_fieldsplit_type": "schur",
     "pc_fieldsplit_schur_type": "full",
     "fieldsplit_0": {
-        "ksp_type": "cg",
+        "ksp_type": "fgmres",
         "ksp_rtol": 1e-5,
         "ksp_max_it": 1000,
         "pc_type": "python",
         "pc_python_type": "gadopt.SPDAssembledPC",
         "assembled_pc_type": "gamg",
+        "assembled_mg_levels_ksp_type": "richardson",
+        "assembled_mg_levels_ksp_max_it": 2,
+        "assembled_mg_levels_ksp_norm_type": "none",
         "assembled_mg_levels_pc_type": "sor",
         "assembled_pc_gamg_threshold": 0.01,
         "assembled_pc_gamg_square_graph": 100,
@@ -76,8 +79,10 @@ preconditioners for mixed problems that allows a user to apply different precond
 to different blocks of the system.
 
 The `fieldsplit_0` entries configure solver options for the velocity block. The linear
-systems associated with this matrix are solved using a combination of the Conjugate
-Gradient (`cg`) method and an algebraic multigrid preconditioner (`gamg`).
+systems associated with this matrix are solved using a combination of the Flexible
+Generalized Minimal Residual (`fgmres`) method and an algebraic multigrid preconditioner
+(`gamg`). Each non-coarse multigrid level applies two fixed Richardson iterations with
+successive over-relaxation (`sor`) as the preconditioner.
 
 The `fieldsplit_1` entries contain solver options for the Schur complement solve itself.
 For preconditioning, we approximate the Schur complement matrix with a mass matrix


### PR DESCRIPTION
## Summary

- change the default iterative Stokes velocity solver from CG to FGMRES
- use exactly two fixed Richardson iterations with SOR on each non-coarse GAMG level
- update the solver-parameter documentation to match

All existing velocity and pressure tolerances, GAMG construction options, nonlinear settings, physical models, demos, and reference data are unchanged.

## Motivation

We have observed speedups from this FGMRES plus Richardson-2 profile in a number of cases with complex rheologies. Those results are promising, but they are still case-specific.

The purpose of this draft is to determine whether the profile is a more general improvement by exposing it to G-ADOPT's broad CI suite as a starting point. Passing CI would establish compatibility across the existing test matrix; it would not by itself establish a universal performance improvement or justify merging without reviewing the numerical and performance evidence.

## Local verification

- `make lint`
- `python -m pytest tests/unit/test_stokes_solver_configuration.py -q` (9 passed)
- serial linear iterative Stokes smoke solve (converged)
- two-rank MPI linear iterative Stokes smoke solve (converged)
- nonlinear viscosity-dependent iterative Stokes smoke solve (converged in two SNES iterations)

The analytical-comparison runner was not used locally because its optional `assess` dependency is not installed in this Firedrake environment; CI provides the full regression coverage.
