### PR TITLE
Relax the free-surface slab-tip tolerance

### DIFF
--- a/demos/test_all.py
+++ b/demos/test_all.py
@@ -33,7 +33,9 @@ cases = {
         "extra_checks": ["nu_top", "T_min", "T_max", "entrainment"]
     },
     f"{mm_path}/compositional_buoyancy": {"extra_checks": ["entrainment"]},
-    f"{mm_path}/free_surface": {"extra_checks": ["slab_tip_depth"]},
+    f"{mm_path}/free_surface": {
+        "extra_checks": [("slab_tip_depth", {"rtol": 1e-4})]
+    },
     f"{mm_path}/thermochemical_buoyancy": {"extra_checks": ["entrainment"]},
     f"{gia_path}/base_case": {"extra_checks": ["uv_min"]},
     f"{gia_path}/2d_cylindrical": {"extra_checks": ["uv_min"]},


### PR DESCRIPTION
The slab-tip-depth check has been failing on unrelated branches because its value varies more than the generic tolerance allows. This relaxes only that value to `rtol=1e-4`. We can replace it later with a stricter, more focused test.

Closes #546.
